### PR TITLE
feat: add central structured logger (slog) with dependency injection

### DIFF
--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -6,6 +6,8 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -109,7 +111,7 @@ func setupTestServer(t *testing.T, principalName string) *httptest.Server {
 	introspectionRepo := repository.NewIntrospectionRepo(metaDB)
 
 	cat := service.NewAuthorizationService(principalRepo, groupRepo, grantRepo, rowFilterRepo, columnMaskRepo, introspectionRepo)
-	eng := engine.NewSecureEngine(duckDB, cat)
+	eng := engine.NewSecureEngine(duckDB, cat, slog.New(slog.NewTextHandler(io.Discard, nil)))
 
 	lineageRepo := repository.NewLineageRepo(metaDB)
 	querySvc := service.NewQueryService(eng, auditRepo, lineageRepo)
@@ -120,7 +122,7 @@ func setupTestServer(t *testing.T, principalName string) *httptest.Server {
 	columnMaskSvc := service.NewColumnMaskService(columnMaskRepo, auditRepo)
 	auditSvc := service.NewAuditService(auditRepo)
 
-	catalogRepo := repository.NewCatalogRepo(metaDB, duckDB)
+	catalogRepo := repository.NewCatalogRepo(metaDB, duckDB, slog.New(slog.NewTextHandler(io.Discard, nil)))
 	tagRepo := repository.NewTagRepo(metaDB)
 	catalogSvc := service.NewCatalogService(catalogRepo, cat, auditRepo, tagRepo, nil)
 
@@ -358,7 +360,7 @@ func setupCatalogTestServer(t *testing.T, principalName string, mockRepo *mockCa
 	introspectionRepo := repository.NewIntrospectionRepo(metaDB)
 
 	cat := service.NewAuthorizationService(principalRepo, groupRepo, grantRepo, rowFilterRepo, columnMaskRepo, introspectionRepo)
-	eng := engine.NewSecureEngine(duckDB, cat)
+	eng := engine.NewSecureEngine(duckDB, cat, slog.New(slog.NewTextHandler(io.Discard, nil)))
 
 	lineageRepo2 := repository.NewLineageRepo(metaDB)
 	querySvc := service.NewQueryService(eng, auditRepo, lineageRepo2)

--- a/internal/app/seed.go
+++ b/internal/app/seed.go
@@ -184,6 +184,5 @@ func seedCatalog(ctx context.Context, cat *service.AuthorizationService, q *dbst
 		return fmt.Errorf("bind Name mask for researchers: %w", err)
 	}
 
-	fmt.Println("Catalog seeded with demo principals, groups, grants, row filters, and column masks.")
 	return nil
 }

--- a/internal/engine/ducklake_test.go
+++ b/internal/engine/ducklake_test.go
@@ -3,6 +3,8 @@ package engine_test
 import (
 	"context"
 	"database/sql"
+	"io"
+	"log/slog"
 	"os"
 	"testing"
 
@@ -206,7 +208,7 @@ func TestDuckLakeRBACIntegration(t *testing.T) {
 		RowFilterID: filter.ID, PrincipalID: analystsGroup.ID, PrincipalType: "group",
 	})
 
-	eng := engine.NewSecureEngine(db, cat)
+	eng := engine.NewSecureEngine(db, cat, slog.New(slog.NewTextHandler(io.Discard, nil)))
 
 	t.Run("AdminAccess", func(t *testing.T) {
 		rows, err := eng.Query(ctx, "admin", "SELECT * FROM titanic LIMIT 10")

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -3,6 +3,8 @@ package engine_test
 import (
 	"context"
 	"database/sql"
+	"io"
+	"log/slog"
 	"os"
 	"strings"
 	"testing"
@@ -151,7 +153,7 @@ func setupEngine(t *testing.T) *engine.SecureEngine {
 	}
 
 	cat := setupTestCatalog(t)
-	return engine.NewSecureEngine(db, cat)
+	return engine.NewSecureEngine(db, cat, slog.New(slog.NewTextHandler(io.Discard, nil)))
 }
 
 func TestAdminSeesAllRows(t *testing.T) {

--- a/test/integration/catalog_test.go
+++ b/test/integration/catalog_test.go
@@ -5,6 +5,8 @@ package integration
 import (
 	"context"
 	"errors"
+	"io"
+	"log/slog"
 	"testing"
 
 	"duck-demo/internal/db/repository"
@@ -17,7 +19,7 @@ import (
 
 func TestCatalog_SchemaCRUD(t *testing.T) {
 	env := requireCatalogEnv(t)
-	repo := repository.NewCatalogRepo(env.MetaDB, env.DuckDB)
+	repo := repository.NewCatalogRepo(env.MetaDB, env.DuckDB, slog.New(slog.NewTextHandler(io.Discard, nil)))
 	ctx := context.Background()
 
 	type step struct {
@@ -140,7 +142,7 @@ func TestCatalog_SchemaCRUD(t *testing.T) {
 
 func TestCatalog_TableCRUD(t *testing.T) {
 	env := requireCatalogEnv(t)
-	repo := repository.NewCatalogRepo(env.MetaDB, env.DuckDB)
+	repo := repository.NewCatalogRepo(env.MetaDB, env.DuckDB, slog.New(slog.NewTextHandler(io.Discard, nil)))
 	ctx := context.Background()
 
 	type step struct {
@@ -302,7 +304,7 @@ func TestCatalog_TableCRUD(t *testing.T) {
 
 func TestCatalog_SchemaConflict(t *testing.T) {
 	env := requireCatalogEnv(t)
-	repo := repository.NewCatalogRepo(env.MetaDB, env.DuckDB)
+	repo := repository.NewCatalogRepo(env.MetaDB, env.DuckDB, slog.New(slog.NewTextHandler(io.Discard, nil)))
 	ctx := context.Background()
 
 	// Pre-create a schema for duplicate tests (unique prefix to avoid collisions)
@@ -407,7 +409,7 @@ func TestCatalog_SchemaConflict(t *testing.T) {
 
 func TestCatalog_CascadeDelete(t *testing.T) {
 	env := requireCatalogEnv(t)
-	repo := repository.NewCatalogRepo(env.MetaDB, env.DuckDB)
+	repo := repository.NewCatalogRepo(env.MetaDB, env.DuckDB, slog.New(slog.NewTextHandler(io.Discard, nil)))
 	ctx := context.Background()
 
 	type step struct {
@@ -478,7 +480,7 @@ func TestCatalog_CascadeDelete(t *testing.T) {
 
 func TestCatalog_MetastoreSummary(t *testing.T) {
 	env := requireCatalogEnv(t)
-	repo := repository.NewCatalogRepo(env.MetaDB, env.DuckDB)
+	repo := repository.NewCatalogRepo(env.MetaDB, env.DuckDB, slog.New(slog.NewTextHandler(io.Discard, nil)))
 	ctx := context.Background()
 
 	type step struct {
@@ -551,7 +553,7 @@ func TestCatalog_MetastoreSummary(t *testing.T) {
 
 func TestCatalog_Pagination(t *testing.T) {
 	env := requireCatalogEnv(t)
-	repo := repository.NewCatalogRepo(env.MetaDB, env.DuckDB)
+	repo := repository.NewCatalogRepo(env.MetaDB, env.DuckDB, slog.New(slog.NewTextHandler(io.Discard, nil)))
 	ctx := context.Background()
 
 	// Create 5 schemas with unique prefix (DuckLake auto-creates "main")

--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -576,7 +577,7 @@ func setupIntegrationServer(t *testing.T) *testEnv {
 	lineageSvc := service.NewLineageService(lineageRepo)
 	searchSvc := service.NewSearchService(searchRepo)
 	queryHistorySvc := service.NewQueryHistoryService(queryHistoryRepo)
-	catalogRepo := repository.NewCatalogRepo(metaDB, nil)
+	catalogRepo := repository.NewCatalogRepo(metaDB, nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
 	viewSvc := service.NewViewService(viewRepo, catalogRepo, authSvc, auditRepo)
 
 	handler := api.NewHandler(
@@ -910,7 +911,7 @@ func setupHTTPServer(t *testing.T, opts httpTestOpts) *httpTestEnv {
 	querySvc := service.NewQueryService(nil, auditRepo, nil)
 
 	// catalogRepo with duckDB=nil is safe — GetSchema only reads ducklake_schema from metaDB
-	catalogRepo := repository.NewCatalogRepo(metaDB, nil)
+	catalogRepo := repository.NewCatalogRepo(metaDB, nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
 	viewSvc := service.NewViewService(viewRepo, catalogRepo, authSvc, auditRepo)
 
 	var duckDB *sql.DB
@@ -963,7 +964,7 @@ func setupHTTPServer(t *testing.T, opts httpTestOpts) *httpTestEnv {
 		searchSvc = service.NewSearchService(searchRepo)
 		queryHistorySvc = service.NewQueryHistoryService(queryHistoryRepo)
 
-		catalogRepo = repository.NewCatalogRepo(metaDB, duckDB)
+		catalogRepo = repository.NewCatalogRepo(metaDB, duckDB, slog.New(slog.NewTextHandler(io.Discard, nil)))
 		viewSvc = service.NewViewService(viewRepo, catalogRepo, authSvc, auditRepo)
 		tableStatsRepo = repository.NewTableStatisticsRepo(metaDB)
 		catalogSvc = service.NewCatalogService(catalogRepo, authSvc, auditRepo, tagRepo, tableStatsRepo)
@@ -997,7 +998,7 @@ func setupHTTPServer(t *testing.T, opts httpTestOpts) *httpTestEnv {
 		}
 		extLocationSvc = service.NewExternalLocationService(
 			extLocationRepo, storageCredRepo, authSvc, auditRepo,
-			extDuckDB, "",
+			extDuckDB, "", slog.New(slog.NewTextHandler(io.Discard, nil)),
 		)
 	}
 


### PR DESCRIPTION
## Summary

- Replace all 45+ stdlib `log` calls across 5 files with Go's `log/slog` structured logger
- Inject `*slog.Logger` via constructors into `CatalogRepo`, `SecureEngine`, and `ExternalLocationService`
- Add `LOG_LEVEL` env var support (debug/info/warn/error, default: info) with JSON output to stderr

## Changes

**Production files:**
- `internal/config/config.go` — Add `LogLevel`, `Warnings` fields and `SlogLevel()` method; config warnings are now deferred and logged after logger init
- `internal/db/repository/catalog.go` — Logger injected into constructor; 17 cascade cleanup warnings use structured `r.logger.Warn(...)` 
- `internal/engine/engine.go` — Logger injected into constructor; audit log uses structured `e.logger.Info(...)`
- `internal/service/external_location.go` — Logger injected into constructor; 4 log calls replaced with structured equivalents
- `cmd/server/main.go` — Creates JSON slog logger from config; wires into constructors with `.With("component", ...)`; replaces all `log.Fatalf` with `logger.Error` + `os.Exit(1)`

**Test files:** Updated constructor call sites in 6 test files to pass a discard logger

## Design decisions

- **`*slog.Logger` directly** — no wrapper interface; slog is stdlib, abstraction adds complexity with no benefit
- **Only injected where needed** — 3 constructors that currently log, not all 40+; adding later is mechanical
- **Child loggers** — `logger.With("component", "catalog_repo")` at injection point gives free structured context for filtering
- **Config warnings** — returned as `[]string` from `LoadFromEnv` since they're generated before the logger exists

## Verification

```bash
task build   # compiles cleanly
task test    # all unit tests pass
rg '"log"$' -g '*.go' -g '!*_test.go'  # zero remaining stdlib log imports
```