### PR TITLE
fix: use github-script for proper JSON escaping in webhook

### DIFF
--- a/.github/workflows/notify-rune.yml
+++ b/.github/workflows/notify-rune.yml
@@ -15,35 +15,45 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Notify Rune
-        run: |
-          EVENT='${{ github.event_name }}'
-          ACTION='${{ github.event.action }}'
-          
-          if [ "$EVENT" = "pull_request" ]; then
-            TITLE='${{ github.event.pull_request.title }}'
-            URL='${{ github.event.pull_request.html_url }}'
-            AUTHOR='${{ github.event.pull_request.user.login }}'
-            NUM='${{ github.event.pull_request.number }}'
-            MSG="GitHub PR #${NUM} ${ACTION} by ${AUTHOR}: \"${TITLE}\" — ${URL}. Review the changes, run tests if needed, and comment on the PR."
-          elif [ "$EVENT" = "issues" ]; then
-            TITLE='${{ github.event.issue.title }}'
-            URL='${{ github.event.issue.html_url }}'
-            AUTHOR='${{ github.event.issue.user.login }}'
-            NUM='${{ github.event.issue.number }}'
-            MSG="GitHub Issue #${NUM} opened by ${AUTHOR}: \"${TITLE}\" — ${URL}. Review and comment if you can help."
-          elif [ "$EVENT" = "issue_comment" ]; then
-            URL='${{ github.event.comment.html_url }}'
-            AUTHOR='${{ github.event.comment.user.login }}'
-            BODY='${{ github.event.comment.body }}'
-            MSG="New comment by ${AUTHOR} on ${URL}: ${BODY}"
-          elif [ "$EVENT" = "pull_request_review" ]; then
-            URL='${{ github.event.review.html_url }}'
-            AUTHOR='${{ github.event.review.user.login }}'
-            STATE='${{ github.event.review.state }}'
-            MSG="PR review (${STATE}) by ${AUTHOR}: ${URL}"
-          fi
-          
-          curl -s -X POST "${{ secrets.RUNE_WEBHOOK_URL }}/hooks/agent" \
-            -H "Authorization: Bearer ${{ secrets.RUNE_WEBHOOK_TOKEN }}" \
-            -H "Content-Type: application/json" \
-            -d "{\"message\": \"${MSG}\", \"name\": \"GitHub\", \"deliver\": true, \"channel\": \"telegram\", \"to\": \"8599265092\"}"
+        uses: actions/github-script@v7
+        env:
+          RUNE_WEBHOOK_URL: ${{ secrets.RUNE_WEBHOOK_URL }}
+          RUNE_WEBHOOK_TOKEN: ${{ secrets.RUNE_WEBHOOK_TOKEN }}
+        with:
+          script: |
+            const event = context.eventName;
+            const action = context.payload.action;
+            let msg = '';
+
+            if (event === 'pull_request') {
+              const pr = context.payload.pull_request;
+              msg = `GitHub PR #${pr.number} ${action} by ${pr.user.login}: "${pr.title}" — ${pr.html_url}. Review the changes, run tests if needed, and comment on the PR.`;
+            } else if (event === 'issues') {
+              const issue = context.payload.issue;
+              msg = `GitHub Issue #${issue.number} opened by ${issue.user.login}: "${issue.title}" — ${issue.html_url}. Review and comment if you can help.`;
+            } else if (event === 'issue_comment') {
+              const comment = context.payload.comment;
+              const issueNum = context.payload.issue.number;
+              msg = `New comment by ${comment.user.login} on #${issueNum} (${comment.html_url}): ${comment.body.substring(0, 500)}`;
+            } else if (event === 'pull_request_review') {
+              const review = context.payload.review;
+              const prNum = context.payload.pull_request.number;
+              msg = `PR #${prNum} review (${review.state}) by ${review.user.login}: ${review.html_url}`;
+            }
+
+            const resp = await fetch(`${process.env.RUNE_WEBHOOK_URL}/hooks/agent`, {
+              method: 'POST',
+              headers: {
+                'Authorization': `Bearer ${process.env.RUNE_WEBHOOK_TOKEN}`,
+                'Content-Type': 'application/json'
+              },
+              body: JSON.stringify({
+                message: msg,
+                name: 'GitHub',
+                deliver: true,
+                channel: 'telegram',
+                to: '8599265092'
+              })
+            });
+            const body = await resp.text();
+            console.log(`Webhook response (${resp.status}): ${body}`);


### PR DESCRIPTION
The shell-based workflow broke on special characters in titles/bodies. Switched to actions/github-script for proper JSON handling.