### PR TITLE
ci: restrict webhook notifications to repo owner only

### DIFF
--- a/.github/workflows/notify-rune.yml
+++ b/.github/workflows/notify-rune.yml
@@ -3,16 +3,20 @@ name: Notify Rune
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+  pull_request_review:
+    types: [submitted]
   issues:
     types: [opened]
   issue_comment:
     types: [created]
-  pull_request_review:
-    types: [submitted]
 
 jobs:
   notify:
     runs-on: ubuntu-latest
+    # Only notify for repo owner's actions — public repo, don't let strangers trigger the bot
+    if: >-
+      github.actor == 'Yacobolo'
+      || (github.event_name == 'issue_comment' && github.event.comment.user.login == 'Yacobolo')
     steps:
       - name: Notify Rune
         uses: actions/github-script@v7
@@ -34,11 +38,18 @@ jobs:
             } else if (event === 'issue_comment') {
               const comment = context.payload.comment;
               const issueNum = context.payload.issue.number;
-              msg = `New comment by ${comment.user.login} on #${issueNum} (${comment.html_url}): ${comment.body.substring(0, 500)}`;
+              const isPR = !!context.payload.issue.pull_request;
+              const kind = isPR ? 'PR' : 'Issue';
+              msg = `New comment by ${comment.user.login} on ${kind} #${issueNum} (${comment.html_url}): ${comment.body.substring(0, 500)}`;
             } else if (event === 'pull_request_review') {
               const review = context.payload.review;
               const prNum = context.payload.pull_request.number;
               msg = `PR #${prNum} review (${review.state}) by ${review.user.login}: ${review.html_url}`;
+            }
+
+            if (!msg) {
+              console.log('No message to send, skipping.');
+              return;
             }
 
             const resp = await fetch(`${process.env.RUNE_WEBHOOK_URL}/hooks/agent`, {
@@ -57,3 +68,6 @@ jobs:
             });
             const body = await resp.text();
             console.log(`Webhook response (${resp.status}): ${body}`);
+            if (!resp.ok) {
+              core.warning(`Webhook returned ${resp.status}: ${body}`);
+            }


### PR DESCRIPTION
## What
Restricts the notify-rune webhook to only fire for Jacob's actions.

## Why
The repo is public — anyone can open an issue or comment. Without this filter, any random person's comment would wake up Rune and burn tokens/API calls.

## How
- Added `if: github.actor == 'Yacobolo'` to the job
- Extra check for issue_comment events (actor can differ from commenter)
- Also added: empty message guard, error logging, PR/Issue distinction in comments

## Checklist
- [x] No code changes — CI workflow only
- [x] Backwards compatible