### PR TITLE
feat: dbt-like transformation models (Issue #92)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -138,6 +138,8 @@ func run() error {
 		svc.SessionManager,
 		svc.GitService,
 		svc.Pipeline,
+		svc.Model,
+		svc.Macro,
 	)
 
 	// Create strict handler wrapper

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -28,6 +28,8 @@ type APIHandler struct {
 	sessions            sessionService
 	gitRepos            gitRepoService
 	pipelines           pipelineService
+	models              modelService
+	macros              macroService
 }
 
 // NewHandler creates a new APIHandler with all required service dependencies.
@@ -57,6 +59,8 @@ func NewHandler(
 	sessions sessionService,
 	gitRepos gitRepoService,
 	pipelines pipelineService,
+	models modelService,
+	macros macroService,
 ) *APIHandler {
 	return &APIHandler{
 		query:               query,
@@ -84,6 +88,8 @@ func NewHandler(
 		sessions:            sessions,
 		gitRepos:            gitRepos,
 		pipelines:           pipelines,
+		models:              models,
+		macros:              macros,
 	}
 }
 

--- a/internal/api/handler_macros.go
+++ b/internal/api/handler_macros.go
@@ -1,0 +1,164 @@
+package api
+
+import (
+	"context"
+	"errors"
+
+	"duck-demo/internal/domain"
+)
+
+// macroService defines the macro operations used by the API handler.
+type macroService interface {
+	Create(ctx context.Context, principal string, req domain.CreateMacroRequest) (*domain.Macro, error)
+	Get(ctx context.Context, name string) (*domain.Macro, error)
+	List(ctx context.Context, page domain.PageRequest) ([]domain.Macro, int64, error)
+	Update(ctx context.Context, principal, name string, req domain.UpdateMacroRequest) (*domain.Macro, error)
+	Delete(ctx context.Context, principal, name string) error
+}
+
+// === Macros ===
+
+// ListMacros implements the endpoint for listing SQL macros.
+func (h *APIHandler) ListMacros(ctx context.Context, req ListMacrosRequestObject) (ListMacrosResponseObject, error) {
+	page := pageFromParams(req.Params.MaxResults, req.Params.PageToken)
+	macros, total, err := h.macros.List(ctx, page)
+	if err != nil {
+		return nil, err
+	}
+
+	data := make([]Macro, len(macros))
+	for i, m := range macros {
+		data[i] = macroToAPI(m)
+	}
+	nextToken := domain.NextPageToken(page.Offset(), page.Limit(), total)
+	return ListMacros200JSONResponse{
+		Body:    PaginatedMacros{Data: &data, NextPageToken: optStr(nextToken)},
+		Headers: ListMacros200ResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset},
+	}, nil
+}
+
+// CreateMacro implements the endpoint for creating a new SQL macro.
+func (h *APIHandler) CreateMacro(ctx context.Context, req CreateMacroRequestObject) (CreateMacroResponseObject, error) {
+	domReq := domain.CreateMacroRequest{
+		Name: req.Body.Name,
+		Body: req.Body.Body,
+	}
+	if req.Body.MacroType != nil {
+		domReq.MacroType = string(*req.Body.MacroType)
+	}
+	if req.Body.Description != nil {
+		domReq.Description = *req.Body.Description
+	}
+	if req.Body.Parameters != nil {
+		domReq.Parameters = *req.Body.Parameters
+	}
+
+	cp, _ := domain.PrincipalFromContext(ctx)
+	principal := cp.Name
+	result, err := h.macros.Create(ctx, principal, domReq)
+	if err != nil {
+		switch {
+		case errors.As(err, new(*domain.AccessDeniedError)):
+			return CreateMacro403JSONResponse{ForbiddenJSONResponse{Body: Error{Code: 403, Message: err.Error()}, Headers: ForbiddenResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		case errors.As(err, new(*domain.ValidationError)):
+			return CreateMacro400JSONResponse{BadRequestJSONResponse{Body: Error{Code: 400, Message: err.Error()}, Headers: BadRequestResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		case errors.As(err, new(*domain.ConflictError)):
+			return CreateMacro409JSONResponse{ConflictJSONResponse{Body: Error{Code: 409, Message: err.Error()}, Headers: ConflictResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		default:
+			return CreateMacro400JSONResponse{BadRequestJSONResponse{Body: Error{Code: 400, Message: err.Error()}, Headers: BadRequestResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		}
+	}
+	return CreateMacro201JSONResponse{
+		Body:    macroToAPI(*result),
+		Headers: CreateMacro201ResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset},
+	}, nil
+}
+
+// GetMacro implements the endpoint for retrieving a macro by name.
+func (h *APIHandler) GetMacro(ctx context.Context, req GetMacroRequestObject) (GetMacroResponseObject, error) {
+	result, err := h.macros.Get(ctx, req.MacroName)
+	if err != nil {
+		switch {
+		case errors.As(err, new(*domain.NotFoundError)):
+			return GetMacro404JSONResponse{NotFoundJSONResponse{Body: Error{Code: 404, Message: err.Error()}, Headers: NotFoundResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		default:
+			return nil, err
+		}
+	}
+	return GetMacro200JSONResponse{
+		Body:    macroToAPI(*result),
+		Headers: GetMacro200ResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset},
+	}, nil
+}
+
+// UpdateMacro implements the endpoint for updating a SQL macro.
+func (h *APIHandler) UpdateMacro(ctx context.Context, req UpdateMacroRequestObject) (UpdateMacroResponseObject, error) {
+	domReq := domain.UpdateMacroRequest{
+		Body:        req.Body.Body,
+		Description: req.Body.Description,
+	}
+	if req.Body.Parameters != nil {
+		domReq.Parameters = *req.Body.Parameters
+	}
+
+	cp, _ := domain.PrincipalFromContext(ctx)
+	principal := cp.Name
+	result, err := h.macros.Update(ctx, principal, req.MacroName, domReq)
+	if err != nil {
+		switch {
+		case errors.As(err, new(*domain.AccessDeniedError)):
+			return UpdateMacro403JSONResponse{ForbiddenJSONResponse{Body: Error{Code: 403, Message: err.Error()}, Headers: ForbiddenResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		case errors.As(err, new(*domain.NotFoundError)):
+			return UpdateMacro404JSONResponse{NotFoundJSONResponse{Body: Error{Code: 404, Message: err.Error()}, Headers: NotFoundResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		case errors.As(err, new(*domain.ValidationError)):
+			return UpdateMacro400JSONResponse{BadRequestJSONResponse{Body: Error{Code: 400, Message: err.Error()}, Headers: BadRequestResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		default:
+			return nil, err
+		}
+	}
+	return UpdateMacro200JSONResponse{
+		Body:    macroToAPI(*result),
+		Headers: UpdateMacro200ResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset},
+	}, nil
+}
+
+// DeleteMacro implements the endpoint for deleting a SQL macro.
+func (h *APIHandler) DeleteMacro(ctx context.Context, req DeleteMacroRequestObject) (DeleteMacroResponseObject, error) {
+	cp, _ := domain.PrincipalFromContext(ctx)
+	principal := cp.Name
+	if err := h.macros.Delete(ctx, principal, req.MacroName); err != nil {
+		switch {
+		case errors.As(err, new(*domain.AccessDeniedError)):
+			return DeleteMacro403JSONResponse{ForbiddenJSONResponse{Body: Error{Code: 403, Message: err.Error()}, Headers: ForbiddenResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		case errors.As(err, new(*domain.NotFoundError)):
+			return DeleteMacro404JSONResponse{NotFoundJSONResponse{Body: Error{Code: 404, Message: err.Error()}, Headers: NotFoundResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		default:
+			return nil, err
+		}
+	}
+	return DeleteMacro204Response{
+		Headers: DeleteMacro204ResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset},
+	}, nil
+}
+
+// === Macro Mappers ===
+
+func macroToAPI(m domain.Macro) Macro {
+	ct := m.CreatedAt
+	ut := m.UpdatedAt
+	mt := MacroMacroType(m.MacroType)
+	resp := Macro{
+		Id:          &m.ID,
+		Name:        &m.Name,
+		MacroType:   &mt,
+		Body:        &m.Body,
+		Description: &m.Description,
+		CreatedBy:   &m.CreatedBy,
+		CreatedAt:   &ct,
+		UpdatedAt:   &ut,
+	}
+	if len(m.Parameters) > 0 {
+		resp.Parameters = &m.Parameters
+	}
+	return resp
+}

--- a/internal/api/handler_models.go
+++ b/internal/api/handler_models.go
@@ -1,0 +1,687 @@
+package api
+
+import (
+	"context"
+	"errors"
+
+	"duck-demo/internal/domain"
+	"duck-demo/internal/service/model"
+)
+
+// modelService defines the model operations used by the API handler.
+type modelService interface {
+	CreateModel(ctx context.Context, principal string, req domain.CreateModelRequest) (*domain.Model, error)
+	GetModel(ctx context.Context, projectName, name string) (*domain.Model, error)
+	ListModels(ctx context.Context, projectName *string, page domain.PageRequest) ([]domain.Model, int64, error)
+	UpdateModel(ctx context.Context, principal, projectName, name string, req domain.UpdateModelRequest) (*domain.Model, error)
+	DeleteModel(ctx context.Context, principal, projectName, name string) error
+	GetDAG(ctx context.Context, projectName *string) ([][]model.DAGNode, error)
+	TriggerRun(ctx context.Context, principal string, req domain.TriggerModelRunRequest) (*domain.ModelRun, error)
+	GetRun(ctx context.Context, runID string) (*domain.ModelRun, error)
+	ListRuns(ctx context.Context, filter domain.ModelRunFilter) ([]domain.ModelRun, int64, error)
+	ListRunSteps(ctx context.Context, runID string) ([]domain.ModelRunStep, error)
+	CancelRun(ctx context.Context, principal, runID string) error
+	CreateTest(ctx context.Context, principal, projectName, modelName string, req domain.CreateModelTestRequest) (*domain.ModelTest, error)
+	ListTests(ctx context.Context, projectName, modelName string) ([]domain.ModelTest, error)
+	DeleteTest(ctx context.Context, principal, projectName, modelName, testID string) error
+	ListTestResults(ctx context.Context, runID, stepID string) ([]domain.ModelTestResult, error)
+	CheckFreshness(ctx context.Context, projectName, modelName string) (*domain.FreshnessStatus, error)
+	PromoteNotebook(ctx context.Context, principal string, req domain.PromoteNotebookRequest) (*domain.Model, error)
+}
+
+// === Models ===
+
+// ListModels implements the endpoint for listing transformation models.
+func (h *APIHandler) ListModels(ctx context.Context, req ListModelsRequestObject) (ListModelsResponseObject, error) {
+	page := pageFromParams(req.Params.MaxResults, req.Params.PageToken)
+	models, total, err := h.models.ListModels(ctx, req.Params.ProjectName, page)
+	if err != nil {
+		return nil, err
+	}
+
+	data := make([]Model, len(models))
+	for i, m := range models {
+		data[i] = modelToAPI(m)
+	}
+	nextToken := domain.NextPageToken(page.Offset(), page.Limit(), total)
+	return ListModels200JSONResponse{
+		Body:    PaginatedModels{Data: &data, NextPageToken: optStr(nextToken)},
+		Headers: ListModels200ResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset},
+	}, nil
+}
+
+// CreateModel implements the endpoint for creating a new transformation model.
+func (h *APIHandler) CreateModel(ctx context.Context, req CreateModelRequestObject) (CreateModelResponseObject, error) {
+	domReq := domain.CreateModelRequest{
+		ProjectName: req.Body.ProjectName,
+		Name:        req.Body.Name,
+		SQL:         req.Body.Sql,
+	}
+	if req.Body.Materialization != nil {
+		domReq.Materialization = string(*req.Body.Materialization)
+	}
+	if req.Body.Description != nil {
+		domReq.Description = *req.Body.Description
+	}
+	if req.Body.Tags != nil {
+		domReq.Tags = *req.Body.Tags
+	}
+	if req.Body.Config != nil {
+		domReq.Config = domainModelConfig(*req.Body.Config)
+	}
+
+	cp, _ := domain.PrincipalFromContext(ctx)
+	principal := cp.Name
+	result, err := h.models.CreateModel(ctx, principal, domReq)
+	if err != nil {
+		switch {
+		case errors.As(err, new(*domain.AccessDeniedError)):
+			return CreateModel403JSONResponse{ForbiddenJSONResponse{Body: Error{Code: 403, Message: err.Error()}, Headers: ForbiddenResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		case errors.As(err, new(*domain.ValidationError)):
+			return CreateModel400JSONResponse{BadRequestJSONResponse{Body: Error{Code: 400, Message: err.Error()}, Headers: BadRequestResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		case errors.As(err, new(*domain.ConflictError)):
+			return CreateModel409JSONResponse{ConflictJSONResponse{Body: Error{Code: 409, Message: err.Error()}, Headers: ConflictResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		default:
+			return CreateModel400JSONResponse{BadRequestJSONResponse{Body: Error{Code: 400, Message: err.Error()}, Headers: BadRequestResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		}
+	}
+	return CreateModel201JSONResponse{
+		Body:    modelToAPI(*result),
+		Headers: CreateModel201ResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset},
+	}, nil
+}
+
+// GetModel implements the endpoint for retrieving a model by project and name.
+func (h *APIHandler) GetModel(ctx context.Context, req GetModelRequestObject) (GetModelResponseObject, error) {
+	result, err := h.models.GetModel(ctx, req.ProjectName, req.ModelName)
+	if err != nil {
+		switch {
+		case errors.As(err, new(*domain.NotFoundError)):
+			return GetModel404JSONResponse{NotFoundJSONResponse{Body: Error{Code: 404, Message: err.Error()}, Headers: NotFoundResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		default:
+			return nil, err
+		}
+	}
+	return GetModel200JSONResponse{
+		Body:    modelToAPI(*result),
+		Headers: GetModel200ResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset},
+	}, nil
+}
+
+// UpdateModel implements the endpoint for updating a transformation model.
+func (h *APIHandler) UpdateModel(ctx context.Context, req UpdateModelRequestObject) (UpdateModelResponseObject, error) {
+	domReq := domain.UpdateModelRequest{
+		SQL:         req.Body.Sql,
+		Description: req.Body.Description,
+	}
+	if req.Body.Materialization != nil {
+		s := string(*req.Body.Materialization)
+		domReq.Materialization = &s
+	}
+	if req.Body.Tags != nil {
+		domReq.Tags = *req.Body.Tags
+	}
+	if req.Body.Config != nil {
+		cfg := domainModelConfig(*req.Body.Config)
+		domReq.Config = &cfg
+	}
+
+	cp, _ := domain.PrincipalFromContext(ctx)
+	principal := cp.Name
+	result, err := h.models.UpdateModel(ctx, principal, req.ProjectName, req.ModelName, domReq)
+	if err != nil {
+		switch {
+		case errors.As(err, new(*domain.AccessDeniedError)):
+			return UpdateModel403JSONResponse{ForbiddenJSONResponse{Body: Error{Code: 403, Message: err.Error()}, Headers: ForbiddenResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		case errors.As(err, new(*domain.NotFoundError)):
+			return UpdateModel404JSONResponse{NotFoundJSONResponse{Body: Error{Code: 404, Message: err.Error()}, Headers: NotFoundResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		case errors.As(err, new(*domain.ValidationError)):
+			return UpdateModel400JSONResponse{BadRequestJSONResponse{Body: Error{Code: 400, Message: err.Error()}, Headers: BadRequestResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		default:
+			return nil, err
+		}
+	}
+	return UpdateModel200JSONResponse{
+		Body:    modelToAPI(*result),
+		Headers: UpdateModel200ResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset},
+	}, nil
+}
+
+// DeleteModel implements the endpoint for deleting a transformation model.
+func (h *APIHandler) DeleteModel(ctx context.Context, req DeleteModelRequestObject) (DeleteModelResponseObject, error) {
+	cp, _ := domain.PrincipalFromContext(ctx)
+	principal := cp.Name
+	if err := h.models.DeleteModel(ctx, principal, req.ProjectName, req.ModelName); err != nil {
+		switch {
+		case errors.As(err, new(*domain.AccessDeniedError)):
+			return DeleteModel403JSONResponse{ForbiddenJSONResponse{Body: Error{Code: 403, Message: err.Error()}, Headers: ForbiddenResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		case errors.As(err, new(*domain.NotFoundError)):
+			return DeleteModel404JSONResponse{NotFoundJSONResponse{Body: Error{Code: 404, Message: err.Error()}, Headers: NotFoundResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		default:
+			return nil, err
+		}
+	}
+	return DeleteModel204Response{
+		Headers: DeleteModel204ResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset},
+	}, nil
+}
+
+// GetModelDAG implements the endpoint for retrieving the model dependency DAG.
+func (h *APIHandler) GetModelDAG(ctx context.Context, req GetModelDAGRequestObject) (GetModelDAGResponseObject, error) {
+	tiers, err := h.models.GetDAG(ctx, req.Params.ProjectName)
+	if err != nil {
+		switch {
+		case errors.As(err, new(*domain.ValidationError)):
+			return GetModelDAG400JSONResponse{BadRequestJSONResponse{Body: Error{Code: 400, Message: err.Error()}, Headers: BadRequestResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		default:
+			return nil, err
+		}
+	}
+	return GetModelDAG200JSONResponse{
+		Body:    dagToAPI(tiers),
+		Headers: GetModelDAG200ResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset},
+	}, nil
+}
+
+// === Model Runs ===
+
+// TriggerModelRun implements the endpoint for triggering a model run.
+func (h *APIHandler) TriggerModelRun(ctx context.Context, req TriggerModelRunRequestObject) (TriggerModelRunResponseObject, error) {
+	domReq := domain.TriggerModelRunRequest{
+		TargetCatalog: "memory",
+		TargetSchema:  req.Body.ProjectName,
+		TriggerType:   domain.ModelTriggerTypeManual,
+	}
+	if req.Body.ModelNames != nil && len(*req.Body.ModelNames) > 0 {
+		domReq.Selector = (*req.Body.ModelNames)[0]
+	}
+
+	cp, _ := domain.PrincipalFromContext(ctx)
+	principal := cp.Name
+	result, err := h.models.TriggerRun(ctx, principal, domReq)
+	if err != nil {
+		switch {
+		case errors.As(err, new(*domain.AccessDeniedError)):
+			return TriggerModelRun403JSONResponse{ForbiddenJSONResponse{Body: Error{Code: 403, Message: err.Error()}, Headers: ForbiddenResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		case errors.As(err, new(*domain.ValidationError)):
+			return TriggerModelRun400JSONResponse{BadRequestJSONResponse{Body: Error{Code: 400, Message: err.Error()}, Headers: BadRequestResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		case errors.As(err, new(*domain.ConflictError)):
+			return TriggerModelRun409JSONResponse{ConflictJSONResponse{Body: Error{Code: 409, Message: err.Error()}, Headers: ConflictResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		default:
+			return TriggerModelRun400JSONResponse{BadRequestJSONResponse{Body: Error{Code: 400, Message: err.Error()}, Headers: BadRequestResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		}
+	}
+	return TriggerModelRun201JSONResponse{
+		Body:    modelRunToAPI(*result),
+		Headers: TriggerModelRun201ResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset},
+	}, nil
+}
+
+// ListModelRuns implements the endpoint for listing model runs.
+func (h *APIHandler) ListModelRuns(ctx context.Context, req ListModelRunsRequestObject) (ListModelRunsResponseObject, error) {
+	page := pageFromParams(req.Params.MaxResults, req.Params.PageToken)
+	filter := domain.ModelRunFilter{
+		Page: page,
+	}
+	if req.Params.Status != nil {
+		s := string(*req.Params.Status)
+		filter.Status = &s
+	}
+
+	runs, total, err := h.models.ListRuns(ctx, filter)
+	if err != nil {
+		return nil, err
+	}
+
+	data := make([]ModelRun, len(runs))
+	for i, r := range runs {
+		data[i] = modelRunToAPI(r)
+	}
+	nextToken := domain.NextPageToken(page.Offset(), page.Limit(), total)
+	return ListModelRuns200JSONResponse{
+		Body:    PaginatedModelRuns{Data: &data, NextPageToken: optStr(nextToken)},
+		Headers: ListModelRuns200ResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset},
+	}, nil
+}
+
+// GetModelRun implements the endpoint for retrieving a model run.
+func (h *APIHandler) GetModelRun(ctx context.Context, req GetModelRunRequestObject) (GetModelRunResponseObject, error) {
+	result, err := h.models.GetRun(ctx, req.RunId)
+	if err != nil {
+		switch {
+		case errors.As(err, new(*domain.NotFoundError)):
+			return GetModelRun404JSONResponse{NotFoundJSONResponse{Body: Error{Code: 404, Message: err.Error()}, Headers: NotFoundResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		default:
+			return nil, err
+		}
+	}
+	return GetModelRun200JSONResponse{
+		Body:    modelRunToAPI(*result),
+		Headers: GetModelRun200ResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset},
+	}, nil
+}
+
+// ListModelRunSteps implements the endpoint for listing model run steps.
+func (h *APIHandler) ListModelRunSteps(ctx context.Context, req ListModelRunStepsRequestObject) (ListModelRunStepsResponseObject, error) {
+	steps, err := h.models.ListRunSteps(ctx, req.RunId)
+	if err != nil {
+		switch {
+		case errors.As(err, new(*domain.NotFoundError)):
+			return ListModelRunSteps404JSONResponse{NotFoundJSONResponse{Body: Error{Code: 404, Message: err.Error()}, Headers: NotFoundResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		default:
+			return nil, err
+		}
+	}
+
+	data := make([]ModelRunStep, len(steps))
+	for i, s := range steps {
+		data[i] = modelRunStepToAPI(s)
+	}
+	return ListModelRunSteps200JSONResponse{
+		Body:    ModelRunStepList{Data: &data},
+		Headers: ListModelRunSteps200ResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset},
+	}, nil
+}
+
+// CancelModelRun implements the endpoint for cancelling a model run.
+func (h *APIHandler) CancelModelRun(ctx context.Context, req CancelModelRunRequestObject) (CancelModelRunResponseObject, error) {
+	cp, _ := domain.PrincipalFromContext(ctx)
+	principal := cp.Name
+	if err := h.models.CancelRun(ctx, principal, req.RunId); err != nil {
+		switch {
+		case errors.As(err, new(*domain.AccessDeniedError)):
+			return CancelModelRun403JSONResponse{ForbiddenJSONResponse{Body: Error{Code: 403, Message: err.Error()}, Headers: ForbiddenResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		case errors.As(err, new(*domain.ValidationError)):
+			return CancelModelRun400JSONResponse{BadRequestJSONResponse{Body: Error{Code: 400, Message: err.Error()}, Headers: BadRequestResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		case errors.As(err, new(*domain.NotFoundError)):
+			return CancelModelRun404JSONResponse{NotFoundJSONResponse{Body: Error{Code: 404, Message: err.Error()}, Headers: NotFoundResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		case errors.As(err, new(*domain.ConflictError)):
+			return CancelModelRun409JSONResponse{ConflictJSONResponse{Body: Error{Code: 409, Message: err.Error()}, Headers: ConflictResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		default:
+			return nil, err
+		}
+	}
+
+	// Re-fetch the run to return updated state.
+	result, err := h.models.GetRun(ctx, req.RunId)
+	if err != nil {
+		return nil, err
+	}
+	return CancelModelRun200JSONResponse{
+		Body:    modelRunToAPI(*result),
+		Headers: CancelModelRun200ResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset},
+	}, nil
+}
+
+// === Model Mappers ===
+
+func modelToAPI(m domain.Model) Model {
+	ct := m.CreatedAt
+	ut := m.UpdatedAt
+	mat := ModelMaterialization(m.Materialization)
+	resp := Model{
+		Id:              &m.ID,
+		ProjectName:     &m.ProjectName,
+		Name:            &m.Name,
+		Sql:             &m.SQL,
+		Materialization: &mat,
+		Description:     &m.Description,
+		Owner:           &m.Owner,
+		CreatedBy:       &m.CreatedBy,
+		CreatedAt:       &ct,
+		UpdatedAt:       &ut,
+	}
+	if len(m.DependsOn) > 0 {
+		resp.DependsOn = &m.DependsOn
+	}
+	if len(m.Tags) > 0 {
+		resp.Tags = &m.Tags
+	}
+	if m.Config.UniqueKey != nil || m.Config.IncrementalStrategy != "" {
+		cfg := apiModelConfig(m.Config)
+		resp.Config = &cfg
+	}
+	return resp
+}
+
+func modelRunToAPI(r domain.ModelRun) ModelRun {
+	ct := r.CreatedAt
+	status := ModelRunStatus(r.Status)
+	triggerType := ModelRunTriggerType(r.TriggerType)
+	resp := ModelRun{
+		Id:          &r.ID,
+		Status:      &status,
+		TriggerType: &triggerType,
+		TriggeredBy: &r.TriggeredBy,
+		CreatedAt:   &ct,
+	}
+	if r.StartedAt != nil {
+		resp.StartedAt = r.StartedAt
+	}
+	if r.FinishedAt != nil {
+		resp.FinishedAt = r.FinishedAt
+	}
+	if r.ErrorMessage != nil {
+		resp.ErrorMessage = r.ErrorMessage
+	}
+	return resp
+}
+
+func modelRunStepToAPI(s domain.ModelRunStep) ModelRunStep {
+	ct := s.CreatedAt
+	status := ModelRunStepStatus(s.Status)
+	resp := ModelRunStep{
+		Id:        &s.ID,
+		RunId:     &s.RunID,
+		ModelName: &s.ModelName,
+		Status:    &status,
+		CreatedAt: &ct,
+	}
+	if s.RowsAffected != nil {
+		resp.RowsAffected = s.RowsAffected
+	}
+	if s.StartedAt != nil {
+		resp.StartedAt = s.StartedAt
+	}
+	if s.FinishedAt != nil {
+		resp.FinishedAt = s.FinishedAt
+	}
+	if s.ErrorMessage != nil {
+		resp.ErrorMessage = s.ErrorMessage
+	}
+	return resp
+}
+
+func dagToAPI(tiers [][]model.DAGNode) ModelDAG {
+	apiTiers := make([]ModelDAGTier, len(tiers))
+	for i, tier := range tiers {
+		tierNum := int32(i) //nolint:gosec // tier index is small
+		nodes := make([]ModelDAGNode, len(tier))
+		for j, node := range tier {
+			mat := ModelDAGNodeMaterialization(node.Model.Materialization)
+			n := ModelDAGNode{
+				ProjectName:     &node.Model.ProjectName,
+				ModelName:       optStr(node.Model.Name),
+				Materialization: &mat,
+			}
+			if len(node.Model.DependsOn) > 0 {
+				n.DependsOn = &node.Model.DependsOn
+			}
+			nodes[j] = n
+		}
+		apiTiers[i] = ModelDAGTier{
+			Tier:  &tierNum,
+			Nodes: &nodes,
+		}
+	}
+	return ModelDAG{Tiers: &apiTiers}
+}
+
+func apiModelConfig(c domain.ModelConfig) ModelConfig {
+	cfg := ModelConfig{}
+	if len(c.UniqueKey) > 0 {
+		cfg.UniqueKey = &c.UniqueKey
+	}
+	if c.IncrementalStrategy != "" {
+		cfg.IncrementalStrategy = &c.IncrementalStrategy
+	}
+	return cfg
+}
+
+func domainModelConfig(c ModelConfig) domain.ModelConfig {
+	cfg := domain.ModelConfig{}
+	if c.UniqueKey != nil {
+		cfg.UniqueKey = *c.UniqueKey
+	}
+	if c.IncrementalStrategy != nil {
+		cfg.IncrementalStrategy = *c.IncrementalStrategy
+	}
+	return cfg
+}
+
+// === Model Tests ===
+
+// CreateModelTest implements the endpoint for creating a model test.
+func (h *APIHandler) CreateModelTest(ctx context.Context, req CreateModelTestRequestObject) (CreateModelTestResponseObject, error) {
+	domReq := domain.CreateModelTestRequest{
+		Name:     req.Body.Name,
+		TestType: string(req.Body.TestType),
+	}
+	if req.Body.Column != nil {
+		domReq.Column = *req.Body.Column
+	}
+	if req.Body.Config != nil {
+		domReq.Config = domainModelTestConfig(*req.Body.Config)
+	}
+
+	cp, _ := domain.PrincipalFromContext(ctx)
+	principal := cp.Name
+	result, err := h.models.CreateTest(ctx, principal, req.ProjectName, req.ModelName, domReq)
+	if err != nil {
+		switch {
+		case errors.As(err, new(*domain.AccessDeniedError)):
+			return CreateModelTest403JSONResponse{ForbiddenJSONResponse{Body: Error{Code: 403, Message: err.Error()}, Headers: ForbiddenResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		case errors.As(err, new(*domain.NotFoundError)):
+			return CreateModelTest404JSONResponse{NotFoundJSONResponse{Body: Error{Code: 404, Message: err.Error()}, Headers: NotFoundResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		case errors.As(err, new(*domain.ValidationError)):
+			return CreateModelTest400JSONResponse{BadRequestJSONResponse{Body: Error{Code: 400, Message: err.Error()}, Headers: BadRequestResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		case errors.As(err, new(*domain.ConflictError)):
+			return CreateModelTest409JSONResponse{ConflictJSONResponse{Body: Error{Code: 409, Message: err.Error()}, Headers: ConflictResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		default:
+			return CreateModelTest400JSONResponse{BadRequestJSONResponse{Body: Error{Code: 400, Message: err.Error()}, Headers: BadRequestResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		}
+	}
+	return CreateModelTest201JSONResponse{
+		Body:    modelTestToAPI(*result),
+		Headers: CreateModelTest201ResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset},
+	}, nil
+}
+
+// ListModelTests implements the endpoint for listing tests for a model.
+func (h *APIHandler) ListModelTests(ctx context.Context, req ListModelTestsRequestObject) (ListModelTestsResponseObject, error) {
+	tests, err := h.models.ListTests(ctx, req.ProjectName, req.ModelName)
+	if err != nil {
+		switch {
+		case errors.As(err, new(*domain.NotFoundError)):
+			return ListModelTests404JSONResponse{NotFoundJSONResponse{Body: Error{Code: 404, Message: err.Error()}, Headers: NotFoundResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		default:
+			return nil, err
+		}
+	}
+
+	data := make([]ModelTest, len(tests))
+	for i, t := range tests {
+		data[i] = modelTestToAPI(t)
+	}
+	return ListModelTests200JSONResponse{
+		Body:    ModelTestList{Data: &data},
+		Headers: ListModelTests200ResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset},
+	}, nil
+}
+
+// DeleteModelTest implements the endpoint for deleting a model test.
+func (h *APIHandler) DeleteModelTest(ctx context.Context, req DeleteModelTestRequestObject) (DeleteModelTestResponseObject, error) {
+	cp, _ := domain.PrincipalFromContext(ctx)
+	principal := cp.Name
+	if err := h.models.DeleteTest(ctx, principal, req.ProjectName, req.ModelName, req.TestId); err != nil {
+		switch {
+		case errors.As(err, new(*domain.AccessDeniedError)):
+			return DeleteModelTest403JSONResponse{ForbiddenJSONResponse{Body: Error{Code: 403, Message: err.Error()}, Headers: ForbiddenResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		case errors.As(err, new(*domain.NotFoundError)):
+			return DeleteModelTest404JSONResponse{NotFoundJSONResponse{Body: Error{Code: 404, Message: err.Error()}, Headers: NotFoundResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		default:
+			return nil, err
+		}
+	}
+	return DeleteModelTest204Response{
+		Headers: DeleteModelTest204ResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset},
+	}, nil
+}
+
+// ListModelTestResults implements the endpoint for listing test results for a run step.
+func (h *APIHandler) ListModelTestResults(ctx context.Context, req ListModelTestResultsRequestObject) (ListModelTestResultsResponseObject, error) {
+	results, err := h.models.ListTestResults(ctx, req.RunId, req.StepId)
+	if err != nil {
+		switch {
+		case errors.As(err, new(*domain.NotFoundError)):
+			return ListModelTestResults404JSONResponse{NotFoundJSONResponse{Body: Error{Code: 404, Message: err.Error()}, Headers: NotFoundResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		default:
+			return nil, err
+		}
+	}
+
+	data := make([]ModelTestResult, len(results))
+	for i, r := range results {
+		data[i] = modelTestResultToAPI(r)
+	}
+	return ListModelTestResults200JSONResponse{
+		Body:    ModelTestResultList{Data: &data},
+		Headers: ListModelTestResults200ResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset},
+	}, nil
+}
+
+// === Model Test Mappers ===
+
+func modelTestToAPI(t domain.ModelTest) ModelTest {
+	ct := t.CreatedAt
+	tt := ModelTestTestType(t.TestType)
+	resp := ModelTest{
+		Id:        &t.ID,
+		ModelId:   &t.ModelID,
+		Name:      &t.Name,
+		TestType:  &tt,
+		CreatedAt: &ct,
+	}
+	if t.Column != "" {
+		resp.Column = &t.Column
+	}
+	if t.Config.SQL != "" || t.Config.ToModel != "" || len(t.Config.Values) > 0 {
+		cfg := apiModelTestConfig(t.Config)
+		resp.Config = &cfg
+	}
+	return resp
+}
+
+func modelTestResultToAPI(r domain.ModelTestResult) ModelTestResult {
+	ct := r.CreatedAt
+	status := ModelTestResultStatus(r.Status)
+	resp := ModelTestResult{
+		Id:        &r.ID,
+		RunStepId: &r.RunStepID,
+		TestId:    &r.TestID,
+		TestName:  &r.TestName,
+		Status:    &status,
+		CreatedAt: &ct,
+	}
+	if r.RowsReturned != nil {
+		resp.RowsReturned = r.RowsReturned
+	}
+	if r.ErrorMessage != nil {
+		resp.ErrorMessage = r.ErrorMessage
+	}
+	return resp
+}
+
+func apiModelTestConfig(c domain.ModelTestConfig) ModelTestConfig {
+	cfg := ModelTestConfig{}
+	if len(c.Values) > 0 {
+		cfg.Values = &c.Values
+	}
+	if c.ToModel != "" {
+		cfg.ToModel = &c.ToModel
+	}
+	if c.ToColumn != "" {
+		cfg.ToColumn = &c.ToColumn
+	}
+	if c.SQL != "" {
+		cfg.Sql = &c.SQL
+	}
+	return cfg
+}
+
+func domainModelTestConfig(c ModelTestConfig) domain.ModelTestConfig {
+	cfg := domain.ModelTestConfig{}
+	if c.Values != nil {
+		cfg.Values = *c.Values
+	}
+	if c.ToModel != nil {
+		cfg.ToModel = *c.ToModel
+	}
+	if c.ToColumn != nil {
+		cfg.ToColumn = *c.ToColumn
+	}
+	if c.Sql != nil {
+		cfg.SQL = *c.Sql
+	}
+	return cfg
+}
+
+// === Freshness ===
+
+// CheckModelFreshness implements the endpoint for checking a model's freshness status.
+func (h *APIHandler) CheckModelFreshness(ctx context.Context, req CheckModelFreshnessRequestObject) (CheckModelFreshnessResponseObject, error) {
+	result, err := h.models.CheckFreshness(ctx, req.ProjectName, req.ModelName)
+	if err != nil {
+		switch {
+		case errors.As(err, new(*domain.NotFoundError)):
+			return CheckModelFreshness404JSONResponse{NotFoundJSONResponse{Body: Error{Code: 404, Message: err.Error()}, Headers: NotFoundResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		default:
+			return nil, err
+		}
+	}
+	return CheckModelFreshness200JSONResponse{
+		Body:    freshnessStatusToAPI(*result),
+		Headers: CheckModelFreshness200ResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset},
+	}, nil
+}
+
+func freshnessStatusToAPI(s domain.FreshnessStatus) FreshnessStatus {
+	resp := FreshnessStatus{
+		IsFresh:       &s.IsFresh,
+		MaxLagSeconds: &s.MaxLagSeconds,
+	}
+	if s.LastRunAt != nil {
+		resp.LastRunAt = s.LastRunAt
+	}
+	if s.StaleSince != nil {
+		resp.StaleSince = s.StaleSince
+	}
+	return resp
+}
+
+// === Notebook Promotion ===
+
+// PromoteNotebookToModel implements the endpoint for promoting a notebook cell to a model.
+func (h *APIHandler) PromoteNotebookToModel(ctx context.Context, req PromoteNotebookToModelRequestObject) (PromoteNotebookToModelResponseObject, error) {
+	domReq := domain.PromoteNotebookRequest{
+		NotebookID:  req.Body.NotebookId,
+		CellIndex:   int(req.Body.CellIndex),
+		ProjectName: req.Body.ProjectName,
+		Name:        req.Body.Name,
+	}
+	if req.Body.Materialization != nil {
+		domReq.Materialization = string(*req.Body.Materialization)
+	}
+
+	cp, _ := domain.PrincipalFromContext(ctx)
+	principal := cp.Name
+	result, err := h.models.PromoteNotebook(ctx, principal, domReq)
+	if err != nil {
+		switch {
+		case errors.As(err, new(*domain.AccessDeniedError)):
+			return PromoteNotebookToModel403JSONResponse{ForbiddenJSONResponse{Body: Error{Code: 403, Message: err.Error()}, Headers: ForbiddenResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		case errors.As(err, new(*domain.NotFoundError)):
+			return PromoteNotebookToModel404JSONResponse{NotFoundJSONResponse{Body: Error{Code: 404, Message: err.Error()}, Headers: NotFoundResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		case errors.As(err, new(*domain.ValidationError)):
+			return PromoteNotebookToModel400JSONResponse{BadRequestJSONResponse{Body: Error{Code: 400, Message: err.Error()}, Headers: BadRequestResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		case errors.As(err, new(*domain.ConflictError)):
+			return PromoteNotebookToModel409JSONResponse{ConflictJSONResponse{Body: Error{Code: 409, Message: err.Error()}, Headers: ConflictResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		default:
+			return PromoteNotebookToModel400JSONResponse{BadRequestJSONResponse{Body: Error{Code: 400, Message: err.Error()}, Headers: BadRequestResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		}
+	}
+	return PromoteNotebookToModel201JSONResponse{
+		Body:    modelToAPI(*result),
+		Headers: PromoteNotebookToModel201ResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset},
+	}, nil
+}

--- a/internal/api/handler_notebooks_test.go
+++ b/internal/api/handler_notebooks_test.go
@@ -194,6 +194,8 @@ func setupNotebookTestServer(t *testing.T, nb notebookService, sess sessionServi
 		nil, // apiKeys
 		nb, sess, git,
 		nil, // pipelineSvc
+		nil, // modelSvc
+		nil, // macroSvc
 	)
 	strictHandler := NewStrictHandler(handler, nil)
 

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -152,7 +152,7 @@ func setupTestServer(t *testing.T, principalName string) *httptest.Server {
 	tagSvc := governance.NewTagService(repository.NewTagRepo(metaDB), auditRepo)
 	viewSvc := catalog.NewViewService(repository.NewViewRepo(metaDB), catalogRepoFactory, cat, auditRepo)
 
-	handler := NewHandler(querySvc, principalSvc, groupSvc, grantSvc, rowFilterSvc, columnMaskSvc, auditSvc, nil, catalogSvc, nil, queryHistorySvc, lineageSvc, searchSvc, tagSvc, viewSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	handler := NewHandler(querySvc, principalSvc, groupSvc, grantSvc, rowFilterSvc, columnMaskSvc, auditSvc, nil, catalogSvc, nil, queryHistorySvc, lineageSvc, searchSvc, tagSvc, viewSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	strictHandler := NewStrictHandler(handler, nil)
 
 	// Lookup principal to get admin status for context injection
@@ -434,7 +434,7 @@ func setupCatalogTestServer(t *testing.T, principalName string, mockRepo *mockCa
 	tagSvc := governance.NewTagService(repository.NewTagRepo(metaDB), auditRepo)
 	viewSvc := catalog.NewViewService(repository.NewViewRepo(metaDB), mockFactory, cat, auditRepo)
 
-	handler := NewHandler(querySvc, principalSvc, groupSvc, grantSvc, rowFilterSvc, columnMaskSvc, auditSvc, nil, catalogSvc, nil, queryHistorySvc, lineageSvc, searchSvc, tagSvc, viewSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	handler := NewHandler(querySvc, principalSvc, groupSvc, grantSvc, rowFilterSvc, columnMaskSvc, auditSvc, nil, catalogSvc, nil, queryHistorySvc, lineageSvc, searchSvc, tagSvc, viewSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	strictHandler := NewStrictHandler(handler, nil)
 
 	// Lookup principal to get admin status for context injection
@@ -1264,6 +1264,8 @@ func setupSecurityTestServer(t *testing.T, principalName string, isAdmin bool) *
 		apiKeySvc,
 		nil, nil, nil, // notebook, session, gitRepo services
 		nil, // pipelineSvc
+		nil, // modelSvc
+		nil, // macroSvc
 	)
 	strictHandler := NewStrictHandler(handler, nil)
 

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -39,6 +39,8 @@ tags:
     description: SQL notebooks, sessions, jobs, and Git integration.
   - name: Pipelines
     description: Pipeline workflow scheduling and orchestration.
+  - name: Models
+    description: Transformation model definitions, runs, DAG management, macros, and freshness.
 
 components:
   securitySchemes:
@@ -371,6 +373,56 @@ components:
       $ref: 'schemas/pipeline.yaml#/PaginatedPipelines'
     PaginatedPipelineRuns:
       $ref: 'schemas/pipeline.yaml#/PaginatedPipelineRuns'
+    Model:
+      $ref: 'schemas/models.yaml#/Model'
+    ModelConfig:
+      $ref: 'schemas/models.yaml#/ModelConfig'
+    CreateModelRequest:
+      $ref: 'schemas/models.yaml#/CreateModelRequest'
+    UpdateModelRequest:
+      $ref: 'schemas/models.yaml#/UpdateModelRequest'
+    PaginatedModels:
+      $ref: 'schemas/models.yaml#/PaginatedModels'
+    ModelRun:
+      $ref: 'schemas/models.yaml#/ModelRun'
+    ModelRunStep:
+      $ref: 'schemas/models.yaml#/ModelRunStep'
+    TriggerModelRunRequest:
+      $ref: 'schemas/models.yaml#/TriggerModelRunRequest'
+    PaginatedModelRuns:
+      $ref: 'schemas/models.yaml#/PaginatedModelRuns'
+    ModelRunStepList:
+      $ref: 'schemas/models.yaml#/ModelRunStepList'
+    ModelDAG:
+      $ref: 'schemas/models.yaml#/ModelDAG'
+    ModelDAGTier:
+      $ref: 'schemas/models.yaml#/ModelDAGTier'
+    ModelDAGNode:
+      $ref: 'schemas/models.yaml#/ModelDAGNode'
+    ModelTest:
+      $ref: 'schemas/models.yaml#/ModelTest'
+    ModelTestConfig:
+      $ref: 'schemas/models.yaml#/ModelTestConfig'
+    CreateModelTestRequest:
+      $ref: 'schemas/models.yaml#/CreateModelTestRequest'
+    ModelTestList:
+      $ref: 'schemas/models.yaml#/ModelTestList'
+    ModelTestResult:
+      $ref: 'schemas/models.yaml#/ModelTestResult'
+    ModelTestResultList:
+      $ref: 'schemas/models.yaml#/ModelTestResultList'
+    FreshnessStatus:
+      $ref: 'schemas/models.yaml#/FreshnessStatus'
+    PromoteNotebookRequest:
+      $ref: 'schemas/models.yaml#/PromoteNotebookRequest'
+    Macro:
+      $ref: 'schemas/macros.yaml#/Macro'
+    CreateMacroRequest:
+      $ref: 'schemas/macros.yaml#/CreateMacroRequest'
+    UpdateMacroRequest:
+      $ref: 'schemas/macros.yaml#/UpdateMacroRequest'
+    PaginatedMacros:
+      $ref: 'schemas/macros.yaml#/PaginatedMacros'
 
 paths:
   /query:
@@ -555,3 +607,33 @@ paths:
     $ref: 'paths/pipeline.yaml#/paths/~1pipelines~1runs~1{runId}~1cancel'
   /pipelines/runs/{runId}/jobs:
     $ref: 'paths/pipeline.yaml#/paths/~1pipelines~1runs~1{runId}~1jobs'
+  # === Models ===
+  /models:
+    $ref: 'paths/models.yaml#/paths/~1models'
+  /models/{projectName}/{modelName}:
+    $ref: 'paths/models.yaml#/paths/~1models~1{projectName}~1{modelName}'
+  /models/dag:
+    $ref: 'paths/models.yaml#/paths/~1models~1dag'
+  /model-runs:
+    $ref: 'paths/models.yaml#/paths/~1model-runs'
+  /model-runs/{runId}:
+    $ref: 'paths/models.yaml#/paths/~1model-runs~1{runId}'
+  /model-runs/{runId}/steps:
+    $ref: 'paths/models.yaml#/paths/~1model-runs~1{runId}~1steps'
+  /models/{projectName}/{modelName}/tests:
+    $ref: 'paths/models.yaml#/paths/~1models~1{projectName}~1{modelName}~1tests'
+  /models/{projectName}/{modelName}/tests/{testId}:
+    $ref: 'paths/models.yaml#/paths/~1models~1{projectName}~1{modelName}~1tests~1{testId}'
+  /model-runs/{runId}/steps/{stepId}/test-results:
+    $ref: 'paths/models.yaml#/paths/~1model-runs~1{runId}~1steps~1{stepId}~1test-results'
+  /models/{projectName}/{modelName}/freshness:
+    $ref: 'paths/models.yaml#/paths/~1models~1{projectName}~1{modelName}~1freshness'
+  /models/from-notebook:
+    $ref: 'paths/models.yaml#/paths/~1models~1from-notebook'
+  /model-runs/{runId}/cancel:
+    $ref: 'paths/models.yaml#/paths/~1model-runs~1{runId}~1cancel'
+  # === Macros ===
+  /macros:
+    $ref: 'paths/macros.yaml#/paths/~1macros'
+  /macros/{macroName}:
+    $ref: 'paths/macros.yaml#/paths/~1macros~1{macroName}'

--- a/internal/api/paths/macros.yaml
+++ b/internal/api/paths/macros.yaml
@@ -1,0 +1,299 @@
+paths:
+  /macros:
+    get:
+      operationId: listMacros
+      summary: List SQL macros
+      tags: [Models]
+      description: Returns a paginated list of SQL macros.
+      parameters:
+        - $ref: '../schemas/common.yaml#/parameters/MaxResults'
+        - $ref: '../schemas/common.yaml#/parameters/PageToken'
+      responses:
+        '200':
+          description: Paginated list of macros
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum requests allowed in the current window.
+              schema:
+                type: integer
+                minimum: 1
+                maximum: 1000000
+                format: int32
+            X-RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+                minimum: 0
+                maximum: 1000000
+                format: int32
+            X-RateLimit-Reset:
+              description: UTC epoch seconds when the rate limit resets.
+              schema:
+                type: integer
+                minimum: 0
+                maximum: 4102444800
+                format: int64
+          content:
+            application/json:
+              schema:
+                $ref: '../schemas/macros.yaml#/PaginatedMacros'
+              example:
+                data:
+                  - id: "550e8400-e29b-41d4-a716-446655440200"
+                    name: "cents_to_dollars"
+                    macro_type: "SCALAR"
+                    parameters: ["amount"]
+                    body: "amount / 100.0"
+                    description: "Converts cents to dollars"
+                    created_by: "admin"
+                    created_at: "2025-01-15T09:30:00Z"
+                    updated_at: "2025-01-15T09:30:00Z"
+                next_page_token: "eyJpZCI6MTB9"
+        '400':
+          $ref: '../schemas/responses.yaml#/responses/BadRequest'
+        '401':
+          $ref: '../schemas/responses.yaml#/responses/Unauthorized'
+        '429':
+          $ref: '../schemas/responses.yaml#/responses/RateLimitExceeded'
+        '500':
+          $ref: '../schemas/responses.yaml#/responses/InternalError'
+    post:
+      operationId: createMacro
+      summary: Create a SQL macro
+      tags: [Models]
+      description: Creates a new DuckDB SQL macro definition.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/macros.yaml#/CreateMacroRequest'
+            example:
+              name: "cents_to_dollars"
+              macro_type: "SCALAR"
+              parameters: ["amount"]
+              body: "amount / 100.0"
+              description: "Converts cents to dollars"
+      responses:
+        '201':
+          description: Created macro
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum requests allowed in the current window.
+              schema:
+                type: integer
+                minimum: 1
+                maximum: 1000000
+                format: int32
+            X-RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+                minimum: 0
+                maximum: 1000000
+                format: int32
+            X-RateLimit-Reset:
+              description: UTC epoch seconds when the rate limit resets.
+              schema:
+                type: integer
+                minimum: 0
+                maximum: 4102444800
+                format: int64
+          content:
+            application/json:
+              schema:
+                $ref: '../schemas/macros.yaml#/Macro'
+              example:
+                id: "550e8400-e29b-41d4-a716-446655440200"
+                name: "cents_to_dollars"
+                macro_type: "SCALAR"
+                parameters: ["amount"]
+                body: "amount / 100.0"
+                description: "Converts cents to dollars"
+                created_by: "admin"
+                created_at: "2025-01-15T09:30:00Z"
+                updated_at: "2025-01-15T09:30:00Z"
+        '400':
+          $ref: '../schemas/responses.yaml#/responses/BadRequest'
+        '401':
+          $ref: '../schemas/responses.yaml#/responses/Unauthorized'
+        '403':
+          $ref: '../schemas/responses.yaml#/responses/Forbidden'
+        '409':
+          $ref: '../schemas/responses.yaml#/responses/Conflict'
+        '429':
+          $ref: '../schemas/responses.yaml#/responses/RateLimitExceeded'
+        '500':
+          $ref: '../schemas/responses.yaml#/responses/InternalError'
+
+  /macros/{macroName}:
+    parameters:
+      - name: macroName
+        in: path
+        required: true
+        description: The name of the macro.
+        schema:
+          type: string
+          maxLength: 255
+          pattern: '^\S+$'
+    get:
+      operationId: getMacro
+      summary: Get a SQL macro
+      tags: [Models]
+      description: Retrieves a SQL macro by name.
+      responses:
+        '200':
+          description: Macro detail
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum requests allowed in the current window.
+              schema:
+                type: integer
+                minimum: 1
+                maximum: 1000000
+                format: int32
+            X-RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+                minimum: 0
+                maximum: 1000000
+                format: int32
+            X-RateLimit-Reset:
+              description: UTC epoch seconds when the rate limit resets.
+              schema:
+                type: integer
+                minimum: 0
+                maximum: 4102444800
+                format: int64
+          content:
+            application/json:
+              schema:
+                $ref: '../schemas/macros.yaml#/Macro'
+              example:
+                id: "550e8400-e29b-41d4-a716-446655440200"
+                name: "cents_to_dollars"
+                macro_type: "SCALAR"
+                parameters: ["amount"]
+                body: "amount / 100.0"
+                description: "Converts cents to dollars"
+                created_by: "admin"
+                created_at: "2025-01-15T09:30:00Z"
+                updated_at: "2025-01-15T09:30:00Z"
+        '400':
+          $ref: '../schemas/responses.yaml#/responses/BadRequest'
+        '401':
+          $ref: '../schemas/responses.yaml#/responses/Unauthorized'
+        '404':
+          $ref: '../schemas/responses.yaml#/responses/NotFound'
+        '429':
+          $ref: '../schemas/responses.yaml#/responses/RateLimitExceeded'
+        '500':
+          $ref: '../schemas/responses.yaml#/responses/InternalError'
+    patch:
+      operationId: updateMacro
+      summary: Update a SQL macro
+      tags: [Models]
+      description: Updates an existing SQL macro.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/macros.yaml#/UpdateMacroRequest'
+            example:
+              body: "amount / 100.0"
+              description: "Updated description"
+      responses:
+        '200':
+          description: Updated macro
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum requests allowed in the current window.
+              schema:
+                type: integer
+                minimum: 1
+                maximum: 1000000
+                format: int32
+            X-RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+                minimum: 0
+                maximum: 1000000
+                format: int32
+            X-RateLimit-Reset:
+              description: UTC epoch seconds when the rate limit resets.
+              schema:
+                type: integer
+                minimum: 0
+                maximum: 4102444800
+                format: int64
+          content:
+            application/json:
+              schema:
+                $ref: '../schemas/macros.yaml#/Macro'
+              example:
+                id: "550e8400-e29b-41d4-a716-446655440200"
+                name: "cents_to_dollars"
+                macro_type: "SCALAR"
+                parameters: ["amount"]
+                body: "amount / 100.0"
+                description: "Updated description"
+                created_by: "admin"
+                created_at: "2025-01-15T09:30:00Z"
+                updated_at: "2025-01-15T09:30:00Z"
+        '400':
+          $ref: '../schemas/responses.yaml#/responses/BadRequest'
+        '401':
+          $ref: '../schemas/responses.yaml#/responses/Unauthorized'
+        '403':
+          $ref: '../schemas/responses.yaml#/responses/Forbidden'
+        '404':
+          $ref: '../schemas/responses.yaml#/responses/NotFound'
+        '429':
+          $ref: '../schemas/responses.yaml#/responses/RateLimitExceeded'
+        '500':
+          $ref: '../schemas/responses.yaml#/responses/InternalError'
+    delete:
+      operationId: deleteMacro
+      summary: Delete a SQL macro
+      tags: [Models]
+      description: Deletes a SQL macro.
+      responses:
+        '204':
+          description: Macro deleted
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum requests allowed in the current window.
+              schema:
+                type: integer
+                minimum: 1
+                maximum: 1000000
+                format: int32
+            X-RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+                minimum: 0
+                maximum: 1000000
+                format: int32
+            X-RateLimit-Reset:
+              description: UTC epoch seconds when the rate limit resets.
+              schema:
+                type: integer
+                minimum: 0
+                maximum: 4102444800
+                format: int64
+        '400':
+          $ref: '../schemas/responses.yaml#/responses/BadRequest'
+        '401':
+          $ref: '../schemas/responses.yaml#/responses/Unauthorized'
+        '403':
+          $ref: '../schemas/responses.yaml#/responses/Forbidden'
+        '404':
+          $ref: '../schemas/responses.yaml#/responses/NotFound'
+        '429':
+          $ref: '../schemas/responses.yaml#/responses/RateLimitExceeded'
+        '500':
+          $ref: '../schemas/responses.yaml#/responses/InternalError'

--- a/internal/api/paths/models.yaml
+++ b/internal/api/paths/models.yaml
@@ -1,0 +1,1125 @@
+paths:
+  /models:
+    get:
+      operationId: listModels
+      summary: List transformation models
+      tags: [Models]
+      description: Returns a paginated list of transformation models.
+      parameters:
+        - name: project_name
+          in: query
+          required: false
+          description: Filter models by project name.
+          schema:
+            type: string
+            maxLength: 255
+            pattern: '^\S+$'
+        - $ref: '../schemas/common.yaml#/parameters/MaxResults'
+        - $ref: '../schemas/common.yaml#/parameters/PageToken'
+      responses:
+        '200':
+          description: Paginated list of models
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum requests allowed in the current window.
+              schema:
+                type: integer
+                minimum: 1
+                maximum: 1000000
+                format: int32
+            X-RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+                minimum: 0
+                maximum: 1000000
+                format: int32
+            X-RateLimit-Reset:
+              description: UTC epoch seconds when the rate limit resets.
+              schema:
+                type: integer
+                minimum: 0
+                maximum: 4102444800
+                format: int64
+          content:
+            application/json:
+              schema:
+                $ref: '../schemas/models.yaml#/PaginatedModels'
+              example:
+                data:
+                  - id: "550e8400-e29b-41d4-a716-446655440100"
+                    project_name: "analytics"
+                    name: "stg_orders"
+                    sql: "SELECT * FROM raw.orders WHERE status = 'active'"
+                    materialization: "VIEW"
+                    description: "Staging model for orders"
+                    owner: "admin"
+                    tags: ["staging", "orders"]
+                    depends_on: ["raw_orders"]
+                    created_by: "admin"
+                    created_at: "2025-01-15T09:30:00Z"
+                    updated_at: "2025-01-15T09:30:00Z"
+                next_page_token: "eyJpZCI6MTB9"
+        '400':
+          $ref: '../schemas/responses.yaml#/responses/BadRequest'
+        '401':
+          $ref: '../schemas/responses.yaml#/responses/Unauthorized'
+        '429':
+          $ref: '../schemas/responses.yaml#/responses/RateLimitExceeded'
+        '500':
+          $ref: '../schemas/responses.yaml#/responses/InternalError'
+    post:
+      operationId: createModel
+      summary: Create a transformation model
+      tags: [Models]
+      description: Creates a new transformation model.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/models.yaml#/CreateModelRequest'
+            example:
+              project_name: "analytics"
+              name: "stg_orders"
+              sql: "SELECT * FROM raw.orders WHERE status = 'active'"
+              materialization: "VIEW"
+              description: "Staging model for orders"
+              tags: ["staging", "orders"]
+      responses:
+        '201':
+          description: Created model
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum requests allowed in the current window.
+              schema:
+                type: integer
+                minimum: 1
+                maximum: 1000000
+                format: int32
+            X-RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+                minimum: 0
+                maximum: 1000000
+                format: int32
+            X-RateLimit-Reset:
+              description: UTC epoch seconds when the rate limit resets.
+              schema:
+                type: integer
+                minimum: 0
+                maximum: 4102444800
+                format: int64
+          content:
+            application/json:
+              schema:
+                $ref: '../schemas/models.yaml#/Model'
+              example:
+                id: "550e8400-e29b-41d4-a716-446655440100"
+                project_name: "analytics"
+                name: "stg_orders"
+                sql: "SELECT * FROM raw.orders WHERE status = 'active'"
+                materialization: "VIEW"
+                description: "Staging model for orders"
+                owner: "admin"
+                tags: ["staging", "orders"]
+                depends_on: ["raw_orders"]
+                created_by: "admin"
+                created_at: "2025-01-15T09:30:00Z"
+                updated_at: "2025-01-15T09:30:00Z"
+        '400':
+          $ref: '../schemas/responses.yaml#/responses/BadRequest'
+        '401':
+          $ref: '../schemas/responses.yaml#/responses/Unauthorized'
+        '403':
+          $ref: '../schemas/responses.yaml#/responses/Forbidden'
+        '409':
+          $ref: '../schemas/responses.yaml#/responses/Conflict'
+        '429':
+          $ref: '../schemas/responses.yaml#/responses/RateLimitExceeded'
+        '500':
+          $ref: '../schemas/responses.yaml#/responses/InternalError'
+
+  /models/{projectName}/{modelName}:
+    parameters:
+      - name: projectName
+        in: path
+        required: true
+        description: Name of the project.
+        schema:
+          type: string
+          maxLength: 255
+          pattern: '^\S+$'
+      - name: modelName
+        in: path
+        required: true
+        description: Name of the model.
+        schema:
+          type: string
+          maxLength: 255
+          pattern: '^\S+$'
+    get:
+      operationId: getModel
+      summary: Get a model by project and name
+      tags: [Models]
+      description: Retrieves the details of a specific transformation model.
+      responses:
+        '200':
+          description: Model details
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum requests allowed in the current window.
+              schema:
+                type: integer
+                minimum: 1
+                maximum: 1000000
+                format: int32
+            X-RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+                minimum: 0
+                maximum: 1000000
+                format: int32
+            X-RateLimit-Reset:
+              description: UTC epoch seconds when the rate limit resets.
+              schema:
+                type: integer
+                minimum: 0
+                maximum: 4102444800
+                format: int64
+          content:
+            application/json:
+              schema:
+                $ref: '../schemas/models.yaml#/Model'
+              example:
+                id: "550e8400-e29b-41d4-a716-446655440100"
+                project_name: "analytics"
+                name: "stg_orders"
+                sql: "SELECT * FROM raw.orders WHERE status = 'active'"
+                materialization: "VIEW"
+                description: "Staging model for orders"
+                owner: "admin"
+                tags: ["staging", "orders"]
+                depends_on: ["raw_orders"]
+                created_by: "admin"
+                created_at: "2025-01-15T09:30:00Z"
+                updated_at: "2025-01-15T09:30:00Z"
+        '400':
+          $ref: '../schemas/responses.yaml#/responses/BadRequest'
+        '401':
+          $ref: '../schemas/responses.yaml#/responses/Unauthorized'
+        '404':
+          $ref: '../schemas/responses.yaml#/responses/NotFound'
+        '429':
+          $ref: '../schemas/responses.yaml#/responses/RateLimitExceeded'
+        '500':
+          $ref: '../schemas/responses.yaml#/responses/InternalError'
+    patch:
+      operationId: updateModel
+      summary: Update a transformation model
+      tags: [Models]
+      description: Updates transformation model fields.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/models.yaml#/UpdateModelRequest'
+            example:
+              sql: "SELECT * FROM raw.orders WHERE status = 'completed'"
+              materialization: "TABLE"
+      responses:
+        '200':
+          description: Updated model
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum requests allowed in the current window.
+              schema:
+                type: integer
+                minimum: 1
+                maximum: 1000000
+                format: int32
+            X-RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+                minimum: 0
+                maximum: 1000000
+                format: int32
+            X-RateLimit-Reset:
+              description: UTC epoch seconds when the rate limit resets.
+              schema:
+                type: integer
+                minimum: 0
+                maximum: 4102444800
+                format: int64
+          content:
+            application/json:
+              schema:
+                $ref: '../schemas/models.yaml#/Model'
+              example:
+                id: "550e8400-e29b-41d4-a716-446655440100"
+                project_name: "analytics"
+                name: "stg_orders"
+                sql: "SELECT * FROM raw.orders WHERE status = 'completed'"
+                materialization: "TABLE"
+                description: "Staging model for orders"
+                owner: "admin"
+                tags: ["staging", "orders"]
+                depends_on: ["raw_orders"]
+                created_by: "admin"
+                created_at: "2025-01-15T09:30:00Z"
+                updated_at: "2025-01-16T10:00:00Z"
+        '400':
+          $ref: '../schemas/responses.yaml#/responses/BadRequest'
+        '401':
+          $ref: '../schemas/responses.yaml#/responses/Unauthorized'
+        '403':
+          $ref: '../schemas/responses.yaml#/responses/Forbidden'
+        '404':
+          $ref: '../schemas/responses.yaml#/responses/NotFound'
+        '429':
+          $ref: '../schemas/responses.yaml#/responses/RateLimitExceeded'
+        '500':
+          $ref: '../schemas/responses.yaml#/responses/InternalError'
+    delete:
+      operationId: deleteModel
+      summary: Delete a transformation model
+      tags: [Models]
+      description: Deletes a transformation model.
+      responses:
+        '204':
+          description: Model deleted
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum requests allowed in the current window.
+              schema:
+                type: integer
+                minimum: 1
+                maximum: 1000000
+                format: int32
+            X-RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+                minimum: 0
+                maximum: 1000000
+                format: int32
+            X-RateLimit-Reset:
+              description: UTC epoch seconds when the rate limit resets.
+              schema:
+                type: integer
+                minimum: 0
+                maximum: 4102444800
+                format: int64
+        '400':
+          $ref: '../schemas/responses.yaml#/responses/BadRequest'
+        '401':
+          $ref: '../schemas/responses.yaml#/responses/Unauthorized'
+        '403':
+          $ref: '../schemas/responses.yaml#/responses/Forbidden'
+        '404':
+          $ref: '../schemas/responses.yaml#/responses/NotFound'
+        '429':
+          $ref: '../schemas/responses.yaml#/responses/RateLimitExceeded'
+        '500':
+          $ref: '../schemas/responses.yaml#/responses/InternalError'
+
+  /models/dag:
+    get:
+      operationId: getModelDAG
+      summary: Get the model dependency DAG
+      tags: [Models]
+      description: Returns the directed acyclic graph of model dependencies.
+      parameters:
+        - name: project_name
+          in: query
+          required: false
+          description: Filter DAG by project name.
+          schema:
+            type: string
+            maxLength: 255
+            pattern: '^\S+$'
+      responses:
+        '200':
+          description: Model DAG
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum requests allowed in the current window.
+              schema:
+                type: integer
+                minimum: 1
+                maximum: 1000000
+                format: int32
+            X-RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+                minimum: 0
+                maximum: 1000000
+                format: int32
+            X-RateLimit-Reset:
+              description: UTC epoch seconds when the rate limit resets.
+              schema:
+                type: integer
+                minimum: 0
+                maximum: 4102444800
+                format: int64
+          content:
+            application/json:
+              schema:
+                $ref: '../schemas/models.yaml#/ModelDAG'
+              example:
+                tiers:
+                  - tier: 0
+                    nodes:
+                      - project_name: "analytics"
+                        model_name: "stg_orders"
+                        materialization: "VIEW"
+                        depends_on: []
+                  - tier: 1
+                    nodes:
+                      - project_name: "analytics"
+                        model_name: "fct_orders"
+                        materialization: "TABLE"
+                        depends_on: ["stg_orders"]
+        '400':
+          $ref: '../schemas/responses.yaml#/responses/BadRequest'
+        '401':
+          $ref: '../schemas/responses.yaml#/responses/Unauthorized'
+        '429':
+          $ref: '../schemas/responses.yaml#/responses/RateLimitExceeded'
+        '500':
+          $ref: '../schemas/responses.yaml#/responses/InternalError'
+
+  /model-runs:
+    post:
+      operationId: triggerModelRun
+      summary: Trigger a model run
+      tags: [Models]
+      description: Manually triggers a new model run.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/models.yaml#/TriggerModelRunRequest'
+            example:
+              project_name: "analytics"
+              model_names: ["stg_orders", "fct_orders"]
+              full_refresh: false
+      responses:
+        '201':
+          description: Triggered model run
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum requests allowed in the current window.
+              schema:
+                type: integer
+                minimum: 1
+                maximum: 1000000
+                format: int32
+            X-RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+                minimum: 0
+                maximum: 1000000
+                format: int32
+            X-RateLimit-Reset:
+              description: UTC epoch seconds when the rate limit resets.
+              schema:
+                type: integer
+                minimum: 0
+                maximum: 4102444800
+                format: int64
+          content:
+            application/json:
+              schema:
+                $ref: '../schemas/models.yaml#/ModelRun'
+              example:
+                id: "550e8400-e29b-41d4-a716-446655440200"
+                status: PENDING
+                trigger_type: MANUAL
+                triggered_by: "admin"
+                model_names: ["stg_orders", "fct_orders"]
+                project_name: "analytics"
+                created_at: "2025-01-15T10:00:00Z"
+        '400':
+          $ref: '../schemas/responses.yaml#/responses/BadRequest'
+        '401':
+          $ref: '../schemas/responses.yaml#/responses/Unauthorized'
+        '403':
+          $ref: '../schemas/responses.yaml#/responses/Forbidden'
+        '409':
+          $ref: '../schemas/responses.yaml#/responses/Conflict'
+        '429':
+          $ref: '../schemas/responses.yaml#/responses/RateLimitExceeded'
+        '500':
+          $ref: '../schemas/responses.yaml#/responses/InternalError'
+    get:
+      operationId: listModelRuns
+      summary: List model runs
+      tags: [Models]
+      description: Returns a paginated list of model runs.
+      parameters:
+        - name: status
+          in: query
+          required: false
+          description: Filter runs by status.
+          schema:
+            type: string
+            enum: [PENDING, RUNNING, SUCCESS, FAILED, CANCELLED]
+        - $ref: '../schemas/common.yaml#/parameters/MaxResults'
+        - $ref: '../schemas/common.yaml#/parameters/PageToken'
+      responses:
+        '200':
+          description: Paginated list of model runs
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum requests allowed in the current window.
+              schema:
+                type: integer
+                minimum: 1
+                maximum: 1000000
+                format: int32
+            X-RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+                minimum: 0
+                maximum: 1000000
+                format: int32
+            X-RateLimit-Reset:
+              description: UTC epoch seconds when the rate limit resets.
+              schema:
+                type: integer
+                minimum: 0
+                maximum: 4102444800
+                format: int64
+          content:
+            application/json:
+              schema:
+                $ref: '../schemas/models.yaml#/PaginatedModelRuns'
+              example:
+                data:
+                  - id: "550e8400-e29b-41d4-a716-446655440200"
+                    status: SUCCESS
+                    trigger_type: MANUAL
+                    triggered_by: "admin"
+                    model_names: ["stg_orders", "fct_orders"]
+                    project_name: "analytics"
+                    started_at: "2025-01-15T10:00:00Z"
+                    finished_at: "2025-01-15T10:15:00Z"
+                    created_at: "2025-01-15T10:00:00Z"
+                next_page_token: "eyJpZCI6MTB9"
+        '400':
+          $ref: '../schemas/responses.yaml#/responses/BadRequest'
+        '401':
+          $ref: '../schemas/responses.yaml#/responses/Unauthorized'
+        '429':
+          $ref: '../schemas/responses.yaml#/responses/RateLimitExceeded'
+        '500':
+          $ref: '../schemas/responses.yaml#/responses/InternalError'
+
+  /model-runs/{runId}:
+    parameters:
+      - name: runId
+        in: path
+        required: true
+        description: Unique identifier of the model run.
+        schema:
+          type: string
+          pattern: '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+          maxLength: 36
+    get:
+      operationId: getModelRun
+      summary: Get a model run
+      tags: [Models]
+      description: Retrieves the details of a specific model run.
+      responses:
+        '200':
+          description: Model run details
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum requests allowed in the current window.
+              schema:
+                type: integer
+                minimum: 1
+                maximum: 1000000
+                format: int32
+            X-RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+                minimum: 0
+                maximum: 1000000
+                format: int32
+            X-RateLimit-Reset:
+              description: UTC epoch seconds when the rate limit resets.
+              schema:
+                type: integer
+                minimum: 0
+                maximum: 4102444800
+                format: int64
+          content:
+            application/json:
+              schema:
+                $ref: '../schemas/models.yaml#/ModelRun'
+              example:
+                id: "550e8400-e29b-41d4-a716-446655440200"
+                status: RUNNING
+                trigger_type: MANUAL
+                triggered_by: "admin"
+                model_names: ["stg_orders", "fct_orders"]
+                project_name: "analytics"
+                started_at: "2025-01-15T10:00:00Z"
+                created_at: "2025-01-15T10:00:00Z"
+        '400':
+          $ref: '../schemas/responses.yaml#/responses/BadRequest'
+        '401':
+          $ref: '../schemas/responses.yaml#/responses/Unauthorized'
+        '404':
+          $ref: '../schemas/responses.yaml#/responses/NotFound'
+        '429':
+          $ref: '../schemas/responses.yaml#/responses/RateLimitExceeded'
+        '500':
+          $ref: '../schemas/responses.yaml#/responses/InternalError'
+
+  /model-runs/{runId}/steps:
+    parameters:
+      - name: runId
+        in: path
+        required: true
+        description: Unique identifier of the model run.
+        schema:
+          type: string
+          pattern: '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+          maxLength: 36
+    get:
+      operationId: listModelRunSteps
+      summary: List steps for a model run
+      tags: [Models]
+      description: Returns the list of individual model execution steps within a model run.
+      responses:
+        '200':
+          description: List of model run steps
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum requests allowed in the current window.
+              schema:
+                type: integer
+                minimum: 1
+                maximum: 1000000
+                format: int32
+            X-RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+                minimum: 0
+                maximum: 1000000
+                format: int32
+            X-RateLimit-Reset:
+              description: UTC epoch seconds when the rate limit resets.
+              schema:
+                type: integer
+                minimum: 0
+                maximum: 4102444800
+                format: int64
+          content:
+            application/json:
+              schema:
+                $ref: '../schemas/models.yaml#/ModelRunStepList'
+              example:
+                data:
+                  - id: "550e8400-e29b-41d4-a716-446655440300"
+                    run_id: "550e8400-e29b-41d4-a716-446655440200"
+                    model_name: "stg_orders"
+                    status: SUCCESS
+                    started_at: "2025-01-15T10:00:00Z"
+                    finished_at: "2025-01-15T10:05:00Z"
+                    rows_affected: 1500
+                    created_at: "2025-01-15T10:00:00Z"
+        '400':
+          $ref: '../schemas/responses.yaml#/responses/BadRequest'
+        '401':
+          $ref: '../schemas/responses.yaml#/responses/Unauthorized'
+        '404':
+          $ref: '../schemas/responses.yaml#/responses/NotFound'
+        '429':
+          $ref: '../schemas/responses.yaml#/responses/RateLimitExceeded'
+        '500':
+          $ref: '../schemas/responses.yaml#/responses/InternalError'
+
+  /models/{projectName}/{modelName}/tests:
+    parameters:
+      - name: projectName
+        in: path
+        required: true
+        description: Name of the project.
+        schema:
+          type: string
+          maxLength: 255
+          pattern: '^\S+$'
+      - name: modelName
+        in: path
+        required: true
+        description: Name of the model.
+        schema:
+          type: string
+          maxLength: 255
+          pattern: '^\S+$'
+    post:
+      operationId: createModelTest
+      summary: Create a model test
+      tags: [Models]
+      description: Creates a new test assertion for a model.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/models.yaml#/CreateModelTestRequest'
+            example:
+              name: "not_null_order_id"
+              test_type: "not_null"
+              column: "order_id"
+      responses:
+        '201':
+          description: Created model test
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum requests allowed in the current window.
+              schema:
+                type: integer
+                minimum: 1
+                maximum: 1000000
+                format: int32
+            X-RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+                minimum: 0
+                maximum: 1000000
+                format: int32
+            X-RateLimit-Reset:
+              description: UTC epoch seconds when the rate limit resets.
+              schema:
+                type: integer
+                minimum: 0
+                maximum: 4102444800
+                format: int64
+          content:
+            application/json:
+              schema:
+                $ref: '../schemas/models.yaml#/ModelTest'
+              example:
+                id: "550e8400-e29b-41d4-a716-446655440400"
+                model_id: "550e8400-e29b-41d4-a716-446655440100"
+                name: "not_null_order_id"
+                test_type: "not_null"
+                column: "order_id"
+                created_at: "2025-01-15T09:30:00Z"
+        '400':
+          $ref: '../schemas/responses.yaml#/responses/BadRequest'
+        '401':
+          $ref: '../schemas/responses.yaml#/responses/Unauthorized'
+        '403':
+          $ref: '../schemas/responses.yaml#/responses/Forbidden'
+        '404':
+          $ref: '../schemas/responses.yaml#/responses/NotFound'
+        '409':
+          $ref: '../schemas/responses.yaml#/responses/Conflict'
+        '429':
+          $ref: '../schemas/responses.yaml#/responses/RateLimitExceeded'
+        '500':
+          $ref: '../schemas/responses.yaml#/responses/InternalError'
+    get:
+      operationId: listModelTests
+      summary: List tests for a model
+      tags: [Models]
+      description: Returns all test assertions defined for a model.
+      responses:
+        '200':
+          description: List of model tests
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum requests allowed in the current window.
+              schema:
+                type: integer
+                minimum: 1
+                maximum: 1000000
+                format: int32
+            X-RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+                minimum: 0
+                maximum: 1000000
+                format: int32
+            X-RateLimit-Reset:
+              description: UTC epoch seconds when the rate limit resets.
+              schema:
+                type: integer
+                minimum: 0
+                maximum: 4102444800
+                format: int64
+          content:
+            application/json:
+              schema:
+                $ref: '../schemas/models.yaml#/ModelTestList'
+              example:
+                data: []
+        '400':
+          $ref: '../schemas/responses.yaml#/responses/BadRequest'
+        '401':
+          $ref: '../schemas/responses.yaml#/responses/Unauthorized'
+        '404':
+          $ref: '../schemas/responses.yaml#/responses/NotFound'
+        '429':
+          $ref: '../schemas/responses.yaml#/responses/RateLimitExceeded'
+        '500':
+          $ref: '../schemas/responses.yaml#/responses/InternalError'
+
+  /models/{projectName}/{modelName}/tests/{testId}:
+    parameters:
+      - name: projectName
+        in: path
+        required: true
+        description: Name of the project.
+        schema:
+          type: string
+          maxLength: 255
+          pattern: '^\S+$'
+      - name: modelName
+        in: path
+        required: true
+        description: Name of the model.
+        schema:
+          type: string
+          maxLength: 255
+          pattern: '^\S+$'
+      - name: testId
+        in: path
+        required: true
+        description: Unique identifier of the model test.
+        schema:
+          type: string
+          pattern: '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+          maxLength: 36
+    delete:
+      operationId: deleteModelTest
+      summary: Delete a model test
+      tags: [Models]
+      description: Deletes a test assertion from a model.
+      responses:
+        '204':
+          description: Model test deleted
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum requests allowed in the current window.
+              schema:
+                type: integer
+                minimum: 1
+                maximum: 1000000
+                format: int32
+            X-RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+                minimum: 0
+                maximum: 1000000
+                format: int32
+            X-RateLimit-Reset:
+              description: UTC epoch seconds when the rate limit resets.
+              schema:
+                type: integer
+                minimum: 0
+                maximum: 4102444800
+                format: int64
+        '400':
+          $ref: '../schemas/responses.yaml#/responses/BadRequest'
+        '401':
+          $ref: '../schemas/responses.yaml#/responses/Unauthorized'
+        '403':
+          $ref: '../schemas/responses.yaml#/responses/Forbidden'
+        '404':
+          $ref: '../schemas/responses.yaml#/responses/NotFound'
+        '429':
+          $ref: '../schemas/responses.yaml#/responses/RateLimitExceeded'
+        '500':
+          $ref: '../schemas/responses.yaml#/responses/InternalError'
+
+  /model-runs/{runId}/steps/{stepId}/test-results:
+    parameters:
+      - name: runId
+        in: path
+        required: true
+        description: Unique identifier of the model run.
+        schema:
+          type: string
+          pattern: '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+          maxLength: 36
+      - name: stepId
+        in: path
+        required: true
+        description: Unique identifier of the model run step.
+        schema:
+          type: string
+          pattern: '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+          maxLength: 36
+    get:
+      operationId: listModelTestResults
+      summary: List test results for a run step
+      tags: [Models]
+      description: Returns all test results for a specific model run step.
+      responses:
+        '200':
+          description: List of model test results
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum requests allowed in the current window.
+              schema:
+                type: integer
+                minimum: 1
+                maximum: 1000000
+                format: int32
+            X-RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+                minimum: 0
+                maximum: 1000000
+                format: int32
+            X-RateLimit-Reset:
+              description: UTC epoch seconds when the rate limit resets.
+              schema:
+                type: integer
+                minimum: 0
+                maximum: 4102444800
+                format: int64
+          content:
+            application/json:
+              schema:
+                $ref: '../schemas/models.yaml#/ModelTestResultList'
+              example:
+                data: []
+        '400':
+          $ref: '../schemas/responses.yaml#/responses/BadRequest'
+        '401':
+          $ref: '../schemas/responses.yaml#/responses/Unauthorized'
+        '404':
+          $ref: '../schemas/responses.yaml#/responses/NotFound'
+        '429':
+          $ref: '../schemas/responses.yaml#/responses/RateLimitExceeded'
+        '500':
+          $ref: '../schemas/responses.yaml#/responses/InternalError'
+
+  /models/{projectName}/{modelName}/freshness:
+    parameters:
+      - name: projectName
+        in: path
+        required: true
+        description: Name of the project.
+        schema:
+          type: string
+          maxLength: 255
+          pattern: '^\S+$'
+      - name: modelName
+        in: path
+        required: true
+        description: Name of the model.
+        schema:
+          type: string
+          maxLength: 255
+          pattern: '^\S+$'
+    get:
+      operationId: checkModelFreshness
+      summary: Check model freshness
+      tags: [Models]
+      description: Evaluates whether a model is fresh based on its freshness policy.
+      responses:
+        '200':
+          description: Freshness status
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum requests allowed in the current window.
+              schema:
+                type: integer
+                minimum: 1
+                maximum: 1000000
+                format: int32
+            X-RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+                minimum: 0
+                maximum: 1000000
+                format: int32
+            X-RateLimit-Reset:
+              description: UTC epoch seconds when the rate limit resets.
+              schema:
+                type: integer
+                minimum: 0
+                maximum: 4102444800
+                format: int64
+          content:
+            application/json:
+              schema:
+                $ref: '../schemas/models.yaml#/FreshnessStatus'
+              example:
+                is_fresh: true
+                last_run_at: "2025-01-15T10:00:00Z"
+                max_lag_seconds: 3600
+        '400':
+          $ref: '../schemas/responses.yaml#/responses/BadRequest'
+        '401':
+          $ref: '../schemas/responses.yaml#/responses/Unauthorized'
+        '404':
+          $ref: '../schemas/responses.yaml#/responses/NotFound'
+        '429':
+          $ref: '../schemas/responses.yaml#/responses/RateLimitExceeded'
+        '500':
+          $ref: '../schemas/responses.yaml#/responses/InternalError'
+
+  /models/from-notebook:
+    post:
+      operationId: promoteNotebookToModel
+      summary: Promote a notebook cell to a model
+      tags: [Models]
+      description: Creates a new transformation model from a notebook cell's SQL.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/models.yaml#/PromoteNotebookRequest'
+            example:
+              notebook_id: "550e8400-e29b-41d4-a716-446655440050"
+              cell_index: 0
+              project_name: "analytics"
+              name: "stg_orders"
+              materialization: "TABLE"
+      responses:
+        '201':
+          description: Created model from notebook
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum requests allowed in the current window.
+              schema:
+                type: integer
+                minimum: 1
+                maximum: 1000000
+                format: int32
+            X-RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+                minimum: 0
+                maximum: 1000000
+                format: int32
+            X-RateLimit-Reset:
+              description: UTC epoch seconds when the rate limit resets.
+              schema:
+                type: integer
+                minimum: 0
+                maximum: 4102444800
+                format: int64
+          content:
+            application/json:
+              schema:
+                $ref: '../schemas/models.yaml#/Model'
+              example:
+                id: "550e8400-e29b-41d4-a716-446655440100"
+                project_name: "analytics"
+                name: "stg_orders"
+                sql: "SELECT * FROM raw.orders"
+                materialization: "TABLE"
+                created_by: "admin"
+                created_at: "2025-01-15T09:30:00Z"
+                updated_at: "2025-01-15T09:30:00Z"
+        '400':
+          $ref: '../schemas/responses.yaml#/responses/BadRequest'
+        '401':
+          $ref: '../schemas/responses.yaml#/responses/Unauthorized'
+        '403':
+          $ref: '../schemas/responses.yaml#/responses/Forbidden'
+        '404':
+          $ref: '../schemas/responses.yaml#/responses/NotFound'
+        '409':
+          $ref: '../schemas/responses.yaml#/responses/Conflict'
+        '429':
+          $ref: '../schemas/responses.yaml#/responses/RateLimitExceeded'
+        '500':
+          $ref: '../schemas/responses.yaml#/responses/InternalError'
+
+  /model-runs/{runId}/cancel:
+    parameters:
+      - name: runId
+        in: path
+        required: true
+        description: Unique identifier of the model run.
+        schema:
+          type: string
+          pattern: '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+          maxLength: 36
+    post:
+      operationId: cancelModelRun
+      summary: Cancel a model run
+      tags: [Models]
+      description: Cancels a running or pending model run.
+      responses:
+        '200':
+          description: Cancelled model run
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum requests allowed in the current window.
+              schema:
+                type: integer
+                minimum: 1
+                maximum: 1000000
+                format: int32
+            X-RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+                minimum: 0
+                maximum: 1000000
+                format: int32
+            X-RateLimit-Reset:
+              description: UTC epoch seconds when the rate limit resets.
+              schema:
+                type: integer
+                minimum: 0
+                maximum: 4102444800
+                format: int64
+          content:
+            application/json:
+              schema:
+                $ref: '../schemas/models.yaml#/ModelRun'
+              example:
+                id: "550e8400-e29b-41d4-a716-446655440200"
+                status: CANCELLED
+                trigger_type: MANUAL
+                triggered_by: "admin"
+                model_names: ["stg_orders", "fct_orders"]
+                project_name: "analytics"
+                started_at: "2025-01-15T10:00:00Z"
+                finished_at: "2025-01-15T10:05:00Z"
+                created_at: "2025-01-15T10:00:00Z"
+        '400':
+          $ref: '../schemas/responses.yaml#/responses/BadRequest'
+        '401':
+          $ref: '../schemas/responses.yaml#/responses/Unauthorized'
+        '403':
+          $ref: '../schemas/responses.yaml#/responses/Forbidden'
+        '404':
+          $ref: '../schemas/responses.yaml#/responses/NotFound'
+        '409':
+          $ref: '../schemas/responses.yaml#/responses/Conflict'
+        '429':
+          $ref: '../schemas/responses.yaml#/responses/RateLimitExceeded'
+        '500':
+          $ref: '../schemas/responses.yaml#/responses/InternalError'

--- a/internal/api/schemas/macros.yaml
+++ b/internal/api/schemas/macros.yaml
@@ -1,0 +1,134 @@
+Macro:
+  description: A DuckDB SQL macro definition.
+  type: object
+  properties:
+    id:
+      type: string
+      pattern: '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+      maxLength: 36
+      example: 550e8400-e29b-41d4-a716-446655440200
+    name:
+      type: string
+      maxLength: 255
+      pattern: '^\S+$'
+      example: cents_to_dollars
+    macro_type:
+      type: string
+      enum: [SCALAR, TABLE]
+      example: SCALAR
+    parameters:
+      type: array
+      maxItems: 50
+      items:
+        type: string
+        maxLength: 255
+        pattern: '^\S+$'
+      example: ["amount"]
+    body:
+      type: string
+      maxLength: 65536
+      pattern: '^[\s\S]*$'
+      example: "amount / 100.0"
+    description:
+      type: string
+      maxLength: 4096
+      pattern: '^[\s\S]*$'
+      example: Converts cents to dollars
+    created_by:
+      type: string
+      maxLength: 255
+      pattern: '^\S+$'
+      example: admin
+    created_at:
+      type: string
+      format: date-time
+      maxLength: 64
+      example: "2025-01-15T09:30:00Z"
+    updated_at:
+      type: string
+      format: date-time
+      maxLength: 64
+      example: "2025-01-15T09:30:00Z"
+
+CreateMacroRequest:
+  description: Request payload for creating a new SQL macro.
+  type: object
+  additionalProperties: false
+  required: [name, body]
+  properties:
+    name:
+      type: string
+      maxLength: 255
+      pattern: '^\S+$'
+      example: cents_to_dollars
+    macro_type:
+      type: string
+      enum: [SCALAR, TABLE]
+      example: SCALAR
+    parameters:
+      type: array
+      maxItems: 50
+      items:
+        type: string
+        maxLength: 255
+        pattern: '^\S+$'
+      example: ["amount"]
+    body:
+      type: string
+      maxLength: 65536
+      pattern: '^[\s\S]*$'
+      example: "amount / 100.0"
+    description:
+      type: string
+      maxLength: 4096
+      pattern: '^[\s\S]*$'
+      example: Converts cents to dollars
+
+UpdateMacroRequest:
+  description: Request payload for updating an existing SQL macro.
+  type: object
+  additionalProperties: false
+  properties:
+    body:
+      type: string
+      maxLength: 65536
+      pattern: '^[\s\S]*$'
+      example: "amount / 100.0"
+    description:
+      type: string
+      maxLength: 4096
+      pattern: '^[\s\S]*$'
+      example: Updated description
+    parameters:
+      type: array
+      maxItems: 50
+      items:
+        type: string
+        maxLength: 255
+        pattern: '^\S+$'
+      example: ["amount"]
+
+PaginatedMacros:
+  description: Paginated list of macros.
+  type: object
+  properties:
+    data:
+      type: array
+      maxItems: 10000
+      items:
+        $ref: '#/Macro'
+      example:
+        - id: "550e8400-e29b-41d4-a716-446655440200"
+          name: "cents_to_dollars"
+          macro_type: "SCALAR"
+          parameters: ["amount"]
+          body: "amount / 100.0"
+          description: "Converts cents to dollars"
+          created_by: "admin"
+          created_at: "2025-01-15T09:30:00Z"
+          updated_at: "2025-01-15T09:30:00Z"
+    next_page_token:
+      type: string
+      maxLength: 1024
+      pattern: '^[\S]*$'
+      example: "eyJpZCI6MTB9"

--- a/internal/api/schemas/models.yaml
+++ b/internal/api/schemas/models.yaml
@@ -1,0 +1,637 @@
+Model:
+  description: A transformation model definition.
+  type: object
+  properties:
+    id:
+      type: string
+      pattern: '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+      maxLength: 36
+      example: 550e8400-e29b-41d4-a716-446655440100
+    project_name:
+      type: string
+      maxLength: 255
+      pattern: '^\S+$'
+      example: analytics
+    name:
+      type: string
+      maxLength: 255
+      pattern: '^\S.*$'
+      example: stg_orders
+    sql:
+      type: string
+      maxLength: 65536
+      pattern: '^[\s\S]*$'
+      example: "SELECT * FROM raw.orders WHERE status = 'active'"
+    materialization:
+      type: string
+      enum: [VIEW, TABLE, INCREMENTAL, EPHEMERAL]
+      example: VIEW
+    description:
+      type: string
+      maxLength: 4096
+      pattern: '^[\s\S]*$'
+      example: Staging model for orders
+    owner:
+      type: string
+      maxLength: 255
+      pattern: '^\S+$'
+      example: admin
+    tags:
+      type: array
+      maxItems: 100
+      items:
+        type: string
+        maxLength: 255
+        pattern: '^\S.*$'
+      example: ["staging", "orders"]
+    depends_on:
+      type: array
+      maxItems: 100
+      items:
+        type: string
+        maxLength: 255
+        pattern: '^\S.*$'
+      example: ["raw_orders"]
+    config:
+      $ref: '#/ModelConfig'
+    created_by:
+      type: string
+      maxLength: 255
+      pattern: '^\S+$'
+      example: admin
+    created_at:
+      type: string
+      format: date-time
+      maxLength: 64
+      example: "2025-01-15T09:30:00Z"
+    updated_at:
+      type: string
+      format: date-time
+      maxLength: 64
+      example: "2025-01-15T09:30:00Z"
+
+ModelConfig:
+  description: Configuration options for a transformation model.
+  type: object
+  properties:
+    unique_key:
+      type: array
+      maxItems: 50
+      items:
+        type: string
+        maxLength: 255
+        pattern: '^\S+$'
+      example: ["order_id"]
+    incremental_strategy:
+      type: string
+      maxLength: 255
+      pattern: '^\S.*$'
+      example: merge
+
+CreateModelRequest:
+  description: Request payload for creating a new transformation model.
+  type: object
+  additionalProperties: false
+  required: [project_name, name, sql]
+  properties:
+    project_name:
+      type: string
+      maxLength: 255
+      pattern: '^\S+$'
+      example: analytics
+    name:
+      type: string
+      maxLength: 255
+      pattern: '^\S.*$'
+      example: stg_orders
+    sql:
+      type: string
+      maxLength: 65536
+      pattern: '^[\s\S]*$'
+      example: "SELECT * FROM raw.orders WHERE status = 'active'"
+    materialization:
+      type: string
+      enum: [VIEW, TABLE, INCREMENTAL, EPHEMERAL]
+      default: VIEW
+      example: VIEW
+    description:
+      type: string
+      maxLength: 4096
+      pattern: '^[\s\S]*$'
+      example: Staging model for orders
+    tags:
+      type: array
+      maxItems: 100
+      items:
+        type: string
+        maxLength: 255
+        pattern: '^\S.*$'
+      example: ["staging", "orders"]
+    config:
+      $ref: '#/ModelConfig'
+
+UpdateModelRequest:
+  description: Request payload for updating an existing transformation model.
+  type: object
+  additionalProperties: false
+  properties:
+    sql:
+      type: string
+      maxLength: 65536
+      pattern: '^[\s\S]*$'
+      example: "SELECT * FROM raw.orders WHERE status = 'completed'"
+    materialization:
+      type: string
+      enum: [VIEW, TABLE, INCREMENTAL, EPHEMERAL]
+      example: TABLE
+    description:
+      type: string
+      maxLength: 4096
+      pattern: '^[\s\S]*$'
+      example: Updated staging model for orders
+    tags:
+      type: array
+      maxItems: 100
+      items:
+        type: string
+        maxLength: 255
+        pattern: '^\S.*$'
+      example: ["staging", "orders"]
+    config:
+      $ref: '#/ModelConfig'
+
+PaginatedModels:
+  description: A paginated list of transformation models.
+  type: object
+  properties:
+    data:
+      type: array
+      maxItems: 1000
+      items:
+        $ref: '#/Model'
+      example:
+        - id: "550e8400-e29b-41d4-a716-446655440100"
+          project_name: analytics
+          name: stg_orders
+          sql: "SELECT * FROM raw.orders WHERE status = 'active'"
+          materialization: VIEW
+          description: Staging model for orders
+          owner: admin
+          tags: ["staging", "orders"]
+          depends_on: ["raw_orders"]
+          created_by: admin
+          created_at: "2025-01-15T09:30:00Z"
+          updated_at: "2025-01-15T09:30:00Z"
+    next_page_token:
+      type: string
+      maxLength: 4096
+      pattern: '^\S+$'
+      example: eyJpZCI6MTB9
+
+ModelRun:
+  description: An execution instance of a model run.
+  type: object
+  properties:
+    id:
+      type: string
+      pattern: '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+      maxLength: 36
+      example: 550e8400-e29b-41d4-a716-446655440200
+    status:
+      type: string
+      enum: [PENDING, RUNNING, SUCCESS, FAILED, CANCELLED]
+      example: RUNNING
+    trigger_type:
+      type: string
+      enum: [MANUAL, SCHEDULED]
+      example: MANUAL
+    triggered_by:
+      type: string
+      maxLength: 255
+      pattern: '^\S+$'
+      example: admin
+    model_names:
+      type: array
+      maxItems: 1000
+      items:
+        type: string
+        maxLength: 255
+        pattern: '^\S.*$'
+      example: ["stg_orders", "fct_orders"]
+    project_name:
+      type: string
+      maxLength: 255
+      pattern: '^\S+$'
+      example: analytics
+    started_at:
+      type: string
+      format: date-time
+      maxLength: 64
+      example: "2025-01-15T10:00:00Z"
+    finished_at:
+      type: string
+      format: date-time
+      maxLength: 64
+      example: "2025-01-15T10:15:00Z"
+    error_message:
+      type: string
+      maxLength: 4096
+      pattern: '^[\s\S]*$'
+      example: model stg_orders failed
+    created_at:
+      type: string
+      format: date-time
+      maxLength: 64
+      example: "2025-01-15T10:00:00Z"
+
+ModelRunStep:
+  description: Execution status of a single model within a model run.
+  type: object
+  properties:
+    id:
+      type: string
+      pattern: '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+      maxLength: 36
+      example: 550e8400-e29b-41d4-a716-446655440300
+    run_id:
+      type: string
+      pattern: '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+      maxLength: 36
+      example: 550e8400-e29b-41d4-a716-446655440200
+    model_name:
+      type: string
+      maxLength: 255
+      pattern: '^\S.*$'
+      example: stg_orders
+    status:
+      type: string
+      enum: [PENDING, RUNNING, SUCCESS, FAILED, SKIPPED, CANCELLED]
+      example: SUCCESS
+    started_at:
+      type: string
+      format: date-time
+      maxLength: 64
+      example: "2025-01-15T10:00:00Z"
+    finished_at:
+      type: string
+      format: date-time
+      maxLength: 64
+      example: "2025-01-15T10:05:00Z"
+    error_message:
+      type: string
+      maxLength: 4096
+      pattern: '^[\s\S]*$'
+      example: query execution timed out
+    rows_affected:
+      type: integer
+      format: int64
+      minimum: 0
+      maximum: 9999999999
+      example: 1500
+    created_at:
+      type: string
+      format: date-time
+      maxLength: 64
+      example: "2025-01-15T10:00:00Z"
+
+TriggerModelRunRequest:
+  description: Request payload for triggering a model run.
+  type: object
+  additionalProperties: false
+  required: [project_name]
+  properties:
+    project_name:
+      type: string
+      maxLength: 255
+      pattern: '^\S+$'
+      example: analytics
+    model_names:
+      type: array
+      maxItems: 1000
+      items:
+        type: string
+        maxLength: 255
+        pattern: '^\S.*$'
+      example: ["stg_orders", "fct_orders"]
+    full_refresh:
+      type: boolean
+      default: false
+      example: false
+
+PaginatedModelRuns:
+  description: A paginated list of model runs.
+  type: object
+  properties:
+    data:
+      type: array
+      maxItems: 1000
+      items:
+        $ref: '#/ModelRun'
+      example:
+        - id: "550e8400-e29b-41d4-a716-446655440200"
+          status: SUCCESS
+          trigger_type: MANUAL
+          triggered_by: admin
+          model_names: ["stg_orders", "fct_orders"]
+          project_name: analytics
+          started_at: "2025-01-15T10:00:00Z"
+          finished_at: "2025-01-15T10:15:00Z"
+          created_at: "2025-01-15T10:00:00Z"
+    next_page_token:
+      type: string
+      maxLength: 4096
+      pattern: '^\S+$'
+      example: eyJpZCI6MTB9
+
+ModelRunStepList:
+  description: A list of model run steps.
+  type: object
+  properties:
+    data:
+      type: array
+      maxItems: 1000
+      items:
+        $ref: '#/ModelRunStep'
+      example: []
+    next_page_token:
+      type: string
+      maxLength: 4096
+      pattern: '^\S+$'
+      example: eyJpZCI6MTB9
+
+ModelDAG:
+  description: The directed acyclic graph of model dependencies.
+  type: object
+  properties:
+    tiers:
+      type: array
+      maxItems: 100
+      items:
+        $ref: '#/ModelDAGTier'
+      example:
+        - tier: 0
+          nodes:
+            - project_name: "analytics"
+              model_name: "stg_orders"
+              materialization: "VIEW"
+              depends_on: []
+        - tier: 1
+          nodes:
+            - project_name: "analytics"
+              model_name: "fct_orders"
+              materialization: "TABLE"
+              depends_on: ["stg_orders"]
+
+ModelDAGTier:
+  description: A tier of models in the DAG that can be executed in parallel.
+  type: object
+  properties:
+    tier:
+      type: integer
+      format: int32
+      minimum: 0
+      maximum: 1000
+      example: 0
+    nodes:
+      type: array
+      maxItems: 1000
+      items:
+        $ref: '#/ModelDAGNode'
+
+ModelDAGNode:
+  description: A single model node in the DAG.
+  type: object
+  properties:
+    project_name:
+      type: string
+      maxLength: 255
+      pattern: '^\S+$'
+      example: analytics
+    model_name:
+      type: string
+      maxLength: 255
+      pattern: '^\S.*$'
+      example: stg_orders
+    materialization:
+      type: string
+      enum: [VIEW, TABLE, INCREMENTAL, EPHEMERAL]
+      example: VIEW
+    depends_on:
+      type: array
+      maxItems: 100
+      items:
+        type: string
+        maxLength: 255
+        pattern: '^\S.*$'
+      example: ["raw_orders"]
+
+ModelTest:
+  description: A test assertion for a model's output.
+  type: object
+  properties:
+    id:
+      type: string
+      pattern: '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+      maxLength: 36
+      example: 550e8400-e29b-41d4-a716-446655440400
+    model_id:
+      type: string
+      pattern: '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+      maxLength: 36
+      example: 550e8400-e29b-41d4-a716-446655440100
+    name:
+      type: string
+      maxLength: 255
+      pattern: '^\S.*$'
+      example: not_null_order_id
+    test_type:
+      type: string
+      enum: [not_null, unique, accepted_values, relationships, custom_sql]
+      example: not_null
+    column:
+      type: string
+      maxLength: 255
+      pattern: '^\S.*$'
+      example: order_id
+    config:
+      $ref: '#/ModelTestConfig'
+    created_at:
+      type: string
+      format: date-time
+      maxLength: 64
+      example: "2025-01-15T09:30:00Z"
+
+ModelTestConfig:
+  description: Test-type-specific configuration for a model test.
+  type: object
+  properties:
+    values:
+      type: array
+      maxItems: 1000
+      items:
+        type: string
+        maxLength: 255
+        pattern: '^[\s\S]*$'
+      example: ["active", "pending", "completed"]
+    to_model:
+      type: string
+      maxLength: 255
+      pattern: '^\S.*$'
+      example: stg_customers
+    to_column:
+      type: string
+      maxLength: 255
+      pattern: '^\S.*$'
+      example: customer_id
+    sql:
+      type: string
+      maxLength: 65536
+      pattern: '^[\s\S]*$'
+      example: "SELECT * FROM {{ model }} WHERE amount < 0"
+
+CreateModelTestRequest:
+  description: Request payload for creating a new model test.
+  type: object
+  additionalProperties: false
+  required: [name, test_type]
+  properties:
+    name:
+      type: string
+      maxLength: 255
+      pattern: '^\S.*$'
+      example: not_null_order_id
+    test_type:
+      type: string
+      enum: [not_null, unique, accepted_values, relationships, custom_sql]
+      example: not_null
+    column:
+      type: string
+      maxLength: 255
+      pattern: '^\S.*$'
+      example: order_id
+    config:
+      $ref: '#/ModelTestConfig'
+
+ModelTestList:
+  description: A list of model tests.
+  type: object
+  properties:
+    data:
+      type: array
+      maxItems: 1000
+      items:
+        $ref: '#/ModelTest'
+      example: []
+
+ModelTestResult:
+  description: The result of a model test execution.
+  type: object
+  properties:
+    id:
+      type: string
+      pattern: '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+      maxLength: 36
+      example: 550e8400-e29b-41d4-a716-446655440500
+    run_step_id:
+      type: string
+      pattern: '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+      maxLength: 36
+      example: 550e8400-e29b-41d4-a716-446655440300
+    test_id:
+      type: string
+      pattern: '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+      maxLength: 36
+      example: 550e8400-e29b-41d4-a716-446655440400
+    test_name:
+      type: string
+      maxLength: 255
+      pattern: '^\S.*$'
+      example: not_null_order_id
+    status:
+      type: string
+      enum: [PASS, FAIL, ERROR]
+      example: PASS
+    rows_returned:
+      type: integer
+      format: int64
+      minimum: 0
+      maximum: 9999999999
+      example: 0
+    error_message:
+      type: string
+      maxLength: 4096
+      pattern: '^[\s\S]*$'
+      example: query execution timed out
+    created_at:
+      type: string
+      format: date-time
+      maxLength: 64
+      example: "2025-01-15T10:00:00Z"
+
+ModelTestResultList:
+  description: A list of model test results.
+  type: object
+  properties:
+    data:
+      type: array
+      maxItems: 1000
+      items:
+        $ref: '#/ModelTestResult'
+      example: []
+
+FreshnessStatus:
+  description: The freshness status of a model based on its freshness policy.
+  type: object
+  properties:
+    is_fresh:
+      type: boolean
+      example: true
+    last_run_at:
+      type: string
+      format: date-time
+      maxLength: 64
+      example: "2025-01-15T10:00:00Z"
+    max_lag_seconds:
+      type: integer
+      format: int64
+      minimum: 0
+      maximum: 999999999
+      example: 3600
+    stale_since:
+      type: string
+      format: date-time
+      maxLength: 64
+      example: "2025-01-15T11:00:00Z"
+
+PromoteNotebookRequest:
+  description: Request payload for promoting a notebook cell to a transformation model.
+  type: object
+  additionalProperties: false
+  required: [notebook_id, cell_index, project_name, name]
+  properties:
+    notebook_id:
+      type: string
+      pattern: '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+      maxLength: 36
+      example: 550e8400-e29b-41d4-a716-446655440050
+    cell_index:
+      type: integer
+      format: int32
+      minimum: 0
+      maximum: 10000
+      example: 0
+    project_name:
+      type: string
+      maxLength: 255
+      pattern: '^\S+$'
+      example: analytics
+    name:
+      type: string
+      maxLength: 255
+      pattern: '^\S.*$'
+      example: stg_orders
+    materialization:
+      type: string
+      enum: [VIEW, TABLE, INCREMENTAL, EPHEMERAL]
+      default: TABLE
+      example: TABLE

--- a/internal/db/migrations/034_create_models.sql
+++ b/internal/db/migrations/034_create_models.sql
@@ -1,0 +1,57 @@
+-- +goose Up
+CREATE TABLE models (
+    id TEXT PRIMARY KEY,
+    project_name TEXT NOT NULL,
+    name TEXT NOT NULL,
+    sql_body TEXT NOT NULL,
+    materialization TEXT NOT NULL DEFAULT 'VIEW'
+        CHECK (materialization IN ('VIEW','TABLE','INCREMENTAL','EPHEMERAL')),
+    description TEXT NOT NULL DEFAULT '',
+    owner TEXT NOT NULL DEFAULT '',
+    tags TEXT NOT NULL DEFAULT '[]',
+    depends_on TEXT NOT NULL DEFAULT '[]',
+    config TEXT NOT NULL DEFAULT '{}',
+    created_by TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(project_name, name)
+);
+CREATE INDEX idx_models_project ON models(project_name);
+
+CREATE TABLE model_runs (
+    id TEXT PRIMARY KEY,
+    status TEXT NOT NULL DEFAULT 'PENDING'
+        CHECK (status IN ('PENDING','RUNNING','SUCCESS','FAILED','CANCELLED')),
+    trigger_type TEXT NOT NULL CHECK (trigger_type IN ('MANUAL','SCHEDULED','PIPELINE')),
+    triggered_by TEXT NOT NULL,
+    target_catalog TEXT NOT NULL DEFAULT '',
+    target_schema TEXT NOT NULL DEFAULT '',
+    model_selector TEXT NOT NULL DEFAULT '',
+    variables TEXT NOT NULL DEFAULT '{}',
+    started_at TEXT,
+    finished_at TEXT,
+    error_message TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX idx_model_runs_status ON model_runs(status);
+
+CREATE TABLE model_run_steps (
+    id TEXT PRIMARY KEY,
+    run_id TEXT NOT NULL REFERENCES model_runs(id) ON DELETE CASCADE,
+    model_id TEXT NOT NULL,
+    model_name TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'PENDING'
+        CHECK (status IN ('PENDING','RUNNING','SUCCESS','FAILED','SKIPPED','CANCELLED')),
+    tier INTEGER NOT NULL DEFAULT 0,
+    rows_affected INTEGER,
+    started_at TEXT,
+    finished_at TEXT,
+    error_message TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX idx_model_run_steps_run ON model_run_steps(run_id);
+
+-- +goose Down
+DROP TABLE IF EXISTS model_run_steps;
+DROP TABLE IF EXISTS model_runs;
+DROP TABLE IF EXISTS models;

--- a/internal/db/migrations/035_model_tests.sql
+++ b/internal/db/migrations/035_model_tests.sql
@@ -1,0 +1,31 @@
+-- +goose Up
+CREATE TABLE model_tests (
+    id TEXT PRIMARY KEY,
+    model_id TEXT NOT NULL REFERENCES models(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    test_type TEXT NOT NULL
+        CHECK (test_type IN ('not_null','unique','accepted_values','relationships','custom_sql')),
+    column_name TEXT NOT NULL DEFAULT '',
+    config TEXT NOT NULL DEFAULT '{}',
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(model_id, name)
+);
+CREATE INDEX idx_model_tests_model ON model_tests(model_id);
+
+CREATE TABLE model_test_results (
+    id TEXT PRIMARY KEY,
+    run_step_id TEXT NOT NULL REFERENCES model_run_steps(id) ON DELETE CASCADE,
+    test_id TEXT NOT NULL,
+    test_name TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('PASS','FAIL','ERROR')),
+    rows_returned INTEGER,
+    error_message TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX idx_model_test_results_step ON model_test_results(run_step_id);
+
+ALTER TABLE models ADD COLUMN contract TEXT NOT NULL DEFAULT '{}';
+
+-- +goose Down
+DROP TABLE IF EXISTS model_test_results;
+DROP TABLE IF EXISTS model_tests;

--- a/internal/db/migrations/036_create_macros.sql
+++ b/internal/db/migrations/036_create_macros.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+CREATE TABLE macros (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE,
+    macro_type TEXT NOT NULL CHECK (macro_type IN ('SCALAR','TABLE')),
+    parameters TEXT NOT NULL DEFAULT '[]',
+    body TEXT NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    created_by TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- +goose Down
+DROP TABLE IF EXISTS macros;

--- a/internal/db/migrations/037_model_freshness.sql
+++ b/internal/db/migrations/037_model_freshness.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE models ADD COLUMN freshness_max_lag INTEGER;
+ALTER TABLE models ADD COLUMN freshness_cron TEXT;
+
+-- +goose Down

--- a/internal/db/migrations/038_pipeline_job_type.sql
+++ b/internal/db/migrations/038_pipeline_job_type.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE pipeline_jobs ADD COLUMN job_type TEXT NOT NULL DEFAULT 'NOTEBOOK';
+ALTER TABLE pipeline_jobs ADD COLUMN model_selector TEXT NOT NULL DEFAULT '';
+
+-- +goose Down

--- a/internal/db/queries/macros.sql
+++ b/internal/db/queries/macros.sql
@@ -1,0 +1,27 @@
+-- name: CreateMacro :one
+INSERT INTO macros (id, name, macro_type, parameters, body, description, created_by)
+VALUES (?, ?, ?, ?, ?, ?, ?)
+RETURNING *;
+
+-- name: GetMacroByName :one
+SELECT * FROM macros WHERE name = ?;
+
+-- name: ListMacros :many
+SELECT * FROM macros ORDER BY name LIMIT ? OFFSET ?;
+
+-- name: CountMacros :one
+SELECT COUNT(*) FROM macros;
+
+-- name: ListAllMacros :many
+SELECT * FROM macros ORDER BY name;
+
+-- name: UpdateMacro :exec
+UPDATE macros
+SET body = COALESCE(?, body),
+    description = COALESCE(?, description),
+    parameters = COALESCE(?, parameters),
+    updated_at = datetime('now')
+WHERE name = ?;
+
+-- name: DeleteMacro :exec
+DELETE FROM macros WHERE name = ?;

--- a/internal/db/queries/model_tests.sql
+++ b/internal/db/queries/model_tests.sql
@@ -1,0 +1,21 @@
+-- name: CreateModelTest :one
+INSERT INTO model_tests (id, model_id, name, test_type, column_name, config)
+VALUES (?, ?, ?, ?, ?, ?)
+RETURNING *;
+
+-- name: GetModelTestByID :one
+SELECT * FROM model_tests WHERE id = ?;
+
+-- name: ListModelTestsByModel :many
+SELECT * FROM model_tests WHERE model_id = ? ORDER BY name;
+
+-- name: DeleteModelTest :exec
+DELETE FROM model_tests WHERE id = ?;
+
+-- name: CreateModelTestResult :one
+INSERT INTO model_test_results (id, run_step_id, test_id, test_name, status, rows_returned, error_message)
+VALUES (?, ?, ?, ?, ?, ?, ?)
+RETURNING *;
+
+-- name: ListModelTestResultsByStep :many
+SELECT * FROM model_test_results WHERE run_step_id = ? ORDER BY test_name;

--- a/internal/db/queries/models.sql
+++ b/internal/db/queries/models.sql
@@ -1,0 +1,80 @@
+-- name: CreateModel :one
+INSERT INTO models (id, project_name, name, sql_body, materialization, description, owner, tags, depends_on, config, created_by, contract, freshness_max_lag, freshness_cron)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+RETURNING *;
+
+-- name: GetModelByID :one
+SELECT * FROM models WHERE id = ?;
+
+-- name: GetModelByName :one
+SELECT * FROM models WHERE project_name = ? AND name = ?;
+
+-- name: ListModels :many
+SELECT * FROM models
+WHERE (? = '' OR project_name = ?)
+ORDER BY project_name, name
+LIMIT ? OFFSET ?;
+
+-- name: CountModels :one
+SELECT COUNT(*) FROM models
+WHERE (? = '' OR project_name = ?);
+
+-- name: ListAllModels :many
+SELECT * FROM models ORDER BY project_name, name;
+
+-- name: UpdateModel :exec
+UPDATE models
+SET sql_body = COALESCE(?, sql_body),
+    materialization = COALESCE(?, materialization),
+    description = COALESCE(?, description),
+    tags = COALESCE(?, tags),
+    config = COALESCE(?, config),
+    contract = COALESCE(?, contract),
+    freshness_max_lag = ?,
+    freshness_cron = ?,
+    updated_at = datetime('now')
+WHERE id = ?;
+
+-- name: UpdateModelDependencies :exec
+UPDATE models SET depends_on = ?, updated_at = datetime('now') WHERE id = ?;
+
+-- name: DeleteModel :exec
+DELETE FROM models WHERE id = ?;
+
+-- name: CreateModelRun :one
+INSERT INTO model_runs (id, status, trigger_type, triggered_by, target_catalog, target_schema, model_selector, variables)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+RETURNING *;
+
+-- name: GetModelRunByID :one
+SELECT * FROM model_runs WHERE id = ?;
+
+-- name: ListModelRuns :many
+SELECT * FROM model_runs
+WHERE (? = '' OR status = ?)
+ORDER BY created_at DESC
+LIMIT ? OFFSET ?;
+
+-- name: CountModelRuns :one
+SELECT COUNT(*) FROM model_runs
+WHERE (? = '' OR status = ?);
+
+-- name: UpdateModelRunStarted :exec
+UPDATE model_runs SET status = 'RUNNING', started_at = datetime('now') WHERE id = ?;
+
+-- name: UpdateModelRunFinished :exec
+UPDATE model_runs SET status = ?, finished_at = datetime('now'), error_message = ? WHERE id = ?;
+
+-- name: CreateModelRunStep :one
+INSERT INTO model_run_steps (id, run_id, model_id, model_name, status, tier)
+VALUES (?, ?, ?, ?, ?, ?)
+RETURNING *;
+
+-- name: ListModelRunStepsByRun :many
+SELECT * FROM model_run_steps WHERE run_id = ? ORDER BY tier, model_name;
+
+-- name: UpdateModelRunStepStarted :exec
+UPDATE model_run_steps SET status = 'RUNNING', started_at = datetime('now') WHERE id = ?;
+
+-- name: UpdateModelRunStepFinished :exec
+UPDATE model_run_steps SET status = ?, finished_at = datetime('now'), rows_affected = ?, error_message = ? WHERE id = ?;

--- a/internal/db/queries/pipelines.sql
+++ b/internal/db/queries/pipelines.sql
@@ -31,8 +31,8 @@ DELETE FROM pipelines WHERE id = ?;
 SELECT * FROM pipelines WHERE schedule_cron IS NOT NULL AND is_paused = 0;
 
 -- name: CreatePipelineJob :one
-INSERT INTO pipeline_jobs (id, pipeline_id, name, compute_endpoint_id, depends_on, notebook_id, timeout_seconds, retry_count, job_order)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+INSERT INTO pipeline_jobs (id, pipeline_id, name, compute_endpoint_id, depends_on, notebook_id, timeout_seconds, retry_count, job_order, job_type, model_selector)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 RETURNING *;
 
 -- name: GetPipelineJobByID :one

--- a/internal/db/repository/macro.go
+++ b/internal/db/repository/macro.go
@@ -1,0 +1,166 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"duck-demo/internal/db/dbstore"
+	"duck-demo/internal/domain"
+)
+
+// Compile-time check.
+var _ domain.MacroRepository = (*MacroRepo)(nil)
+
+// MacroRepo implements MacroRepository using SQLite.
+type MacroRepo struct {
+	q  *dbstore.Queries
+	db *sql.DB
+}
+
+// NewMacroRepo creates a new MacroRepo.
+func NewMacroRepo(db *sql.DB) *MacroRepo {
+	return &MacroRepo{q: dbstore.New(db), db: db}
+}
+
+// Create inserts a new SQL macro.
+func (r *MacroRepo) Create(ctx context.Context, m *domain.Macro) (*domain.Macro, error) {
+	paramsJSON, err := json.Marshal(m.Parameters)
+	if err != nil {
+		return nil, fmt.Errorf("marshal parameters: %w", err)
+	}
+
+	row, err := r.q.CreateMacro(ctx, dbstore.CreateMacroParams{
+		ID:          newID(),
+		Name:        m.Name,
+		MacroType:   m.MacroType,
+		Parameters:  string(paramsJSON),
+		Body:        m.Body,
+		Description: m.Description,
+		CreatedBy:   m.CreatedBy,
+	})
+	if err != nil {
+		return nil, mapDBError(err)
+	}
+	return macroFromDB(row), nil
+}
+
+// GetByName returns a macro by name.
+func (r *MacroRepo) GetByName(ctx context.Context, name string) (*domain.Macro, error) {
+	row, err := r.q.GetMacroByName(ctx, name)
+	if err != nil {
+		return nil, mapDBError(err)
+	}
+	return macroFromDB(row), nil
+}
+
+// List returns a paginated list of macros.
+func (r *MacroRepo) List(ctx context.Context, page domain.PageRequest) ([]domain.Macro, int64, error) {
+	total, err := r.q.CountMacros(ctx)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	rows, err := r.q.ListMacros(ctx, dbstore.ListMacrosParams{
+		Limit:  int64(page.Limit()),
+		Offset: int64(page.Offset()),
+	})
+	if err != nil {
+		return nil, 0, err
+	}
+
+	macros := make([]domain.Macro, 0, len(rows))
+	for _, row := range rows {
+		macros = append(macros, *macroFromDB(row))
+	}
+	return macros, total, nil
+}
+
+// Update applies partial updates to a macro using read-modify-write.
+func (r *MacroRepo) Update(ctx context.Context, name string, req domain.UpdateMacroRequest) (*domain.Macro, error) {
+	current, err := r.GetByName(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+
+	body := current.Body
+	if req.Body != nil {
+		body = *req.Body
+	}
+	description := current.Description
+	if req.Description != nil {
+		description = *req.Description
+	}
+	params := current.Parameters
+	if req.Parameters != nil {
+		params = req.Parameters
+	}
+	paramsJSON, err := json.Marshal(params)
+	if err != nil {
+		return nil, fmt.Errorf("marshal parameters: %w", err)
+	}
+
+	err = r.q.UpdateMacro(ctx, dbstore.UpdateMacroParams{
+		Body:        body,
+		Description: description,
+		Parameters:  string(paramsJSON),
+		Name:        name,
+	})
+	if err != nil {
+		return nil, mapDBError(err)
+	}
+	return r.GetByName(ctx, name)
+}
+
+// Delete removes a macro by name.
+func (r *MacroRepo) Delete(ctx context.Context, name string) error {
+	return mapDBError(r.q.DeleteMacro(ctx, name))
+}
+
+// ListAll returns all macros ordered by name.
+func (r *MacroRepo) ListAll(ctx context.Context) ([]domain.Macro, error) {
+	rows, err := r.q.ListAllMacros(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	macros := make([]domain.Macro, 0, len(rows))
+	for _, row := range rows {
+		macros = append(macros, *macroFromDB(row))
+	}
+	return macros, nil
+}
+
+// === Private mappers ===
+
+func macroFromDB(row dbstore.Macro) *domain.Macro {
+	createdAt, err := time.Parse("2006-01-02 15:04:05", row.CreatedAt)
+	if err != nil {
+		slog.Default().Warn("failed to parse macro created_at", "value", row.CreatedAt, "error", err)
+	}
+	updatedAt, err := time.Parse("2006-01-02 15:04:05", row.UpdatedAt)
+	if err != nil {
+		slog.Default().Warn("failed to parse macro updated_at", "value", row.UpdatedAt, "error", err)
+	}
+
+	var params []string
+	_ = json.Unmarshal([]byte(row.Parameters), &params)
+	if params == nil {
+		params = []string{}
+	}
+
+	return &domain.Macro{
+		ID:          row.ID,
+		Name:        row.Name,
+		MacroType:   row.MacroType,
+		Parameters:  params,
+		Body:        row.Body,
+		Description: row.Description,
+		CreatedBy:   row.CreatedBy,
+		CreatedAt:   createdAt,
+		UpdatedAt:   updatedAt,
+	}
+}

--- a/internal/db/repository/model.go
+++ b/internal/db/repository/model.go
@@ -1,0 +1,309 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"duck-demo/internal/db/dbstore"
+	"duck-demo/internal/domain"
+)
+
+// Compile-time check.
+var _ domain.ModelRepository = (*ModelRepo)(nil)
+
+// ModelRepo implements ModelRepository using SQLite.
+type ModelRepo struct {
+	q  *dbstore.Queries
+	db *sql.DB
+}
+
+// NewModelRepo creates a new ModelRepo.
+func NewModelRepo(db *sql.DB) *ModelRepo {
+	return &ModelRepo{q: dbstore.New(db), db: db}
+}
+
+// Create inserts a new transformation model.
+func (r *ModelRepo) Create(ctx context.Context, m *domain.Model) (*domain.Model, error) {
+	tagsJSON, err := json.Marshal(m.Tags)
+	if err != nil {
+		return nil, fmt.Errorf("marshal tags: %w", err)
+	}
+	depsJSON, err := json.Marshal(m.DependsOn)
+	if err != nil {
+		return nil, fmt.Errorf("marshal depends_on: %w", err)
+	}
+	configJSON, err := json.Marshal(m.Config)
+	if err != nil {
+		return nil, fmt.Errorf("marshal config: %w", err)
+	}
+	contractJSON := "{}"
+	if m.Contract != nil {
+		b, err := json.Marshal(m.Contract)
+		if err != nil {
+			return nil, fmt.Errorf("marshal contract: %w", err)
+		}
+		contractJSON = string(b)
+	}
+
+	var freshnessMaxLag sql.NullInt64
+	var freshnessCron sql.NullString
+	if m.Freshness != nil {
+		if m.Freshness.MaxLagSeconds > 0 {
+			freshnessMaxLag = sql.NullInt64{Int64: m.Freshness.MaxLagSeconds, Valid: true}
+		}
+		if m.Freshness.CronSchedule != "" {
+			freshnessCron = sql.NullString{String: m.Freshness.CronSchedule, Valid: true}
+		}
+	}
+
+	row, err := r.q.CreateModel(ctx, dbstore.CreateModelParams{
+		ID:              newID(),
+		ProjectName:     m.ProjectName,
+		Name:            m.Name,
+		SqlBody:         m.SQL,
+		Materialization: m.Materialization,
+		Description:     m.Description,
+		Owner:           m.Owner,
+		Tags:            string(tagsJSON),
+		DependsOn:       string(depsJSON),
+		Config:          string(configJSON),
+		CreatedBy:       m.CreatedBy,
+		Contract:        contractJSON,
+		FreshnessMaxLag: freshnessMaxLag,
+		FreshnessCron:   freshnessCron,
+	})
+	if err != nil {
+		return nil, mapDBError(err)
+	}
+	return modelFromDB(row), nil
+}
+
+// GetByID returns a model by its ID.
+func (r *ModelRepo) GetByID(ctx context.Context, id string) (*domain.Model, error) {
+	row, err := r.q.GetModelByID(ctx, id)
+	if err != nil {
+		return nil, mapDBError(err)
+	}
+	return modelFromDB(row), nil
+}
+
+// GetByName returns a model by project name and model name.
+func (r *ModelRepo) GetByName(ctx context.Context, projectName, name string) (*domain.Model, error) {
+	row, err := r.q.GetModelByName(ctx, dbstore.GetModelByNameParams{
+		ProjectName: projectName,
+		Name:        name,
+	})
+	if err != nil {
+		return nil, mapDBError(err)
+	}
+	return modelFromDB(row), nil
+}
+
+// List returns a paginated list of models, optionally filtered by project.
+func (r *ModelRepo) List(ctx context.Context, projectName *string, page domain.PageRequest) ([]domain.Model, int64, error) {
+	projectFilter := ""
+	if projectName != nil {
+		projectFilter = *projectName
+	}
+
+	total, err := r.q.CountModels(ctx, dbstore.CountModelsParams{
+		Column1:     projectFilter,
+		ProjectName: projectFilter,
+	})
+	if err != nil {
+		return nil, 0, err
+	}
+
+	rows, err := r.q.ListModels(ctx, dbstore.ListModelsParams{
+		Column1:     projectFilter,
+		ProjectName: projectFilter,
+		Limit:       int64(page.Limit()),
+		Offset:      int64(page.Offset()),
+	})
+	if err != nil {
+		return nil, 0, err
+	}
+
+	models := make([]domain.Model, 0, len(rows))
+	for _, row := range rows {
+		models = append(models, *modelFromDB(row))
+	}
+	return models, total, nil
+}
+
+// Update applies partial updates to a model using read-modify-write.
+func (r *ModelRepo) Update(ctx context.Context, id string, req domain.UpdateModelRequest) (*domain.Model, error) {
+	current, err := r.GetByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	sqlBody := current.SQL
+	if req.SQL != nil {
+		sqlBody = *req.SQL
+	}
+	materialization := current.Materialization
+	if req.Materialization != nil {
+		materialization = *req.Materialization
+	}
+	description := current.Description
+	if req.Description != nil {
+		description = *req.Description
+	}
+
+	tags := current.Tags
+	if req.Tags != nil {
+		tags = req.Tags
+	}
+	tagsJSON, err := json.Marshal(tags)
+	if err != nil {
+		return nil, fmt.Errorf("marshal tags: %w", err)
+	}
+
+	config := current.Config
+	if req.Config != nil {
+		config = *req.Config
+	}
+	configJSON, err := json.Marshal(config)
+	if err != nil {
+		return nil, fmt.Errorf("marshal config: %w", err)
+	}
+
+	contract := current.Contract
+	if req.Contract != nil {
+		contract = req.Contract
+	}
+	contractJSON, err := json.Marshal(contract)
+	if err != nil {
+		return nil, fmt.Errorf("marshal contract: %w", err)
+	}
+
+	freshness := current.Freshness
+	if req.Freshness != nil {
+		freshness = req.Freshness
+	}
+	var freshnessMaxLag sql.NullInt64
+	var freshnessCron sql.NullString
+	if freshness != nil {
+		if freshness.MaxLagSeconds > 0 {
+			freshnessMaxLag = sql.NullInt64{Int64: freshness.MaxLagSeconds, Valid: true}
+		}
+		if freshness.CronSchedule != "" {
+			freshnessCron = sql.NullString{String: freshness.CronSchedule, Valid: true}
+		}
+	}
+
+	err = r.q.UpdateModel(ctx, dbstore.UpdateModelParams{
+		SqlBody:         sqlBody,
+		Materialization: materialization,
+		Description:     description,
+		Tags:            string(tagsJSON),
+		Config:          string(configJSON),
+		Contract:        string(contractJSON),
+		FreshnessMaxLag: freshnessMaxLag,
+		FreshnessCron:   freshnessCron,
+		ID:              id,
+	})
+	if err != nil {
+		return nil, mapDBError(err)
+	}
+	return r.GetByID(ctx, id)
+}
+
+// Delete removes a model by ID.
+func (r *ModelRepo) Delete(ctx context.Context, id string) error {
+	return mapDBError(r.q.DeleteModel(ctx, id))
+}
+
+// ListAll returns all models ordered by project and name.
+func (r *ModelRepo) ListAll(ctx context.Context) ([]domain.Model, error) {
+	rows, err := r.q.ListAllModels(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	models := make([]domain.Model, 0, len(rows))
+	for _, row := range rows {
+		models = append(models, *modelFromDB(row))
+	}
+	return models, nil
+}
+
+// UpdateDependencies updates a model's dependency list.
+func (r *ModelRepo) UpdateDependencies(ctx context.Context, id string, deps []string) error {
+	depsJSON, err := json.Marshal(deps)
+	if err != nil {
+		return fmt.Errorf("marshal depends_on: %w", err)
+	}
+	return mapDBError(r.q.UpdateModelDependencies(ctx, dbstore.UpdateModelDependenciesParams{
+		DependsOn: string(depsJSON),
+		ID:        id,
+	}))
+}
+
+// === Private mappers ===
+
+func modelFromDB(row dbstore.Model) *domain.Model {
+	createdAt, err := time.Parse("2006-01-02 15:04:05", row.CreatedAt)
+	if err != nil {
+		slog.Default().Warn("failed to parse model created_at", "value", row.CreatedAt, "error", err)
+	}
+	updatedAt, err := time.Parse("2006-01-02 15:04:05", row.UpdatedAt)
+	if err != nil {
+		slog.Default().Warn("failed to parse model updated_at", "value", row.UpdatedAt, "error", err)
+	}
+
+	var tags []string
+	_ = json.Unmarshal([]byte(row.Tags), &tags)
+	if tags == nil {
+		tags = []string{}
+	}
+
+	var deps []string
+	_ = json.Unmarshal([]byte(row.DependsOn), &deps)
+	if deps == nil {
+		deps = []string{}
+	}
+
+	var config domain.ModelConfig
+	_ = json.Unmarshal([]byte(row.Config), &config)
+
+	var contract *domain.ModelContract
+	if row.Contract != "" && row.Contract != "{}" {
+		contract = &domain.ModelContract{}
+		_ = json.Unmarshal([]byte(row.Contract), contract)
+	}
+
+	var freshness *domain.FreshnessPolicy
+	if row.FreshnessMaxLag.Valid || row.FreshnessCron.Valid {
+		freshness = &domain.FreshnessPolicy{}
+		if row.FreshnessMaxLag.Valid {
+			freshness.MaxLagSeconds = row.FreshnessMaxLag.Int64
+		}
+		if row.FreshnessCron.Valid {
+			freshness.CronSchedule = row.FreshnessCron.String
+		}
+	}
+
+	return &domain.Model{
+		ID:              row.ID,
+		ProjectName:     row.ProjectName,
+		Name:            row.Name,
+		SQL:             row.SqlBody,
+		Materialization: row.Materialization,
+		Description:     row.Description,
+		Owner:           row.Owner,
+		Tags:            tags,
+		DependsOn:       deps,
+		Config:          config,
+		Contract:        contract,
+		Freshness:       freshness,
+		CreatedBy:       row.CreatedBy,
+		CreatedAt:       createdAt,
+		UpdatedAt:       updatedAt,
+	}
+}

--- a/internal/db/repository/model_repo_test.go
+++ b/internal/db/repository/model_repo_test.go
@@ -1,0 +1,298 @@
+package repository
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	_ "github.com/mattn/go-sqlite3"
+
+	internaldb "duck-demo/internal/db"
+	"duck-demo/internal/domain"
+)
+
+func setupModelRepo(t *testing.T) *ModelRepo {
+	t.Helper()
+	writeDB, _ := internaldb.OpenTestSQLite(t)
+	return NewModelRepo(writeDB)
+}
+
+func TestModelRepo_Create(t *testing.T) {
+	repo := setupModelRepo(t)
+	ctx := context.Background()
+
+	m := &domain.Model{
+		ProjectName:     "sales",
+		Name:            "stg_orders",
+		SQL:             "SELECT order_id, customer_id FROM raw_data.orders",
+		Materialization: "TABLE",
+		Description:     "Staged orders",
+		Owner:           "data-team",
+		Tags:            []string{"finance", "staging"},
+		DependsOn:       []string{"sales.raw_orders"},
+		Config:          domain.ModelConfig{},
+		CreatedBy:       "admin",
+	}
+
+	created, err := repo.Create(ctx, m)
+	require.NoError(t, err)
+	require.NotNil(t, created)
+
+	assert.NotEmpty(t, created.ID)
+	assert.Equal(t, "sales", created.ProjectName)
+	assert.Equal(t, "stg_orders", created.Name)
+	assert.Equal(t, "SELECT order_id, customer_id FROM raw_data.orders", created.SQL)
+	assert.Equal(t, "TABLE", created.Materialization)
+	assert.Equal(t, "Staged orders", created.Description)
+	assert.Equal(t, "data-team", created.Owner)
+	assert.Equal(t, []string{"finance", "staging"}, created.Tags)
+	assert.Equal(t, []string{"sales.raw_orders"}, created.DependsOn)
+	assert.Equal(t, "admin", created.CreatedBy)
+	assert.False(t, created.CreatedAt.IsZero())
+	assert.False(t, created.UpdatedAt.IsZero())
+}
+
+func TestModelRepo_GetByName(t *testing.T) {
+	repo := setupModelRepo(t)
+	ctx := context.Background()
+
+	m := &domain.Model{
+		ProjectName:     "sales",
+		Name:            "stg_orders",
+		SQL:             "SELECT 1",
+		Materialization: "VIEW",
+		Tags:            []string{},
+		DependsOn:       []string{},
+		CreatedBy:       "admin",
+	}
+
+	created, err := repo.Create(ctx, m)
+	require.NoError(t, err)
+
+	got, err := repo.GetByName(ctx, "sales", "stg_orders")
+	require.NoError(t, err)
+	assert.Equal(t, created.ID, got.ID)
+	assert.Equal(t, "sales", got.ProjectName)
+	assert.Equal(t, "stg_orders", got.Name)
+	assert.Equal(t, "VIEW", got.Materialization)
+}
+
+func TestModelRepo_GetByName_NotFound(t *testing.T) {
+	repo := setupModelRepo(t)
+	ctx := context.Background()
+
+	_, err := repo.GetByName(ctx, "nonexistent-project", "nonexistent-model")
+	require.Error(t, err)
+	var notFound *domain.NotFoundError
+	assert.ErrorAs(t, err, &notFound)
+}
+
+func TestModelRepo_List(t *testing.T) {
+	repo := setupModelRepo(t)
+	ctx := context.Background()
+
+	models := []struct {
+		project string
+		name    string
+	}{
+		{"sales", "stg_orders"},
+		{"sales", "fct_orders"},
+		{"warehouse", "dim_products"},
+	}
+
+	for _, m := range models {
+		_, err := repo.Create(ctx, &domain.Model{
+			ProjectName:     m.project,
+			Name:            m.name,
+			SQL:             "SELECT 1",
+			Materialization: "VIEW",
+			Tags:            []string{},
+			DependsOn:       []string{},
+			CreatedBy:       "admin",
+		})
+		require.NoError(t, err)
+	}
+
+	t.Run("list_all_projects", func(t *testing.T) {
+		results, total, err := repo.List(ctx, nil, domain.PageRequest{})
+		require.NoError(t, err)
+		assert.Equal(t, int64(3), total)
+		assert.Len(t, results, 3)
+	})
+
+	t.Run("filter_by_project", func(t *testing.T) {
+		project := "sales"
+		results, total, err := repo.List(ctx, &project, domain.PageRequest{})
+		require.NoError(t, err)
+		assert.Equal(t, int64(2), total)
+		assert.Len(t, results, 2)
+		for _, r := range results {
+			assert.Equal(t, "sales", r.ProjectName)
+		}
+	})
+
+	t.Run("pagination", func(t *testing.T) {
+		results, total, err := repo.List(ctx, nil, domain.PageRequest{MaxResults: 2})
+		require.NoError(t, err)
+		assert.Equal(t, int64(3), total)
+		assert.Len(t, results, 2)
+	})
+}
+
+func TestModelRepo_Update(t *testing.T) {
+	repo := setupModelRepo(t)
+	ctx := context.Background()
+
+	created, err := repo.Create(ctx, &domain.Model{
+		ProjectName:     "sales",
+		Name:            "stg_orders",
+		SQL:             "SELECT 1",
+		Materialization: "VIEW",
+		Description:     "original",
+		Tags:            []string{"v1"},
+		DependsOn:       []string{},
+		CreatedBy:       "admin",
+	})
+	require.NoError(t, err)
+
+	t.Run("update_sql_and_materialization", func(t *testing.T) {
+		newSQL := "SELECT 2"
+		newMat := "TABLE"
+		updated, err := repo.Update(ctx, created.ID, domain.UpdateModelRequest{
+			SQL:             &newSQL,
+			Materialization: &newMat,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "SELECT 2", updated.SQL)
+		assert.Equal(t, "TABLE", updated.Materialization)
+		assert.Equal(t, "original", updated.Description) // unchanged
+	})
+
+	t.Run("update_description", func(t *testing.T) {
+		newDesc := "updated description"
+		updated, err := repo.Update(ctx, created.ID, domain.UpdateModelRequest{
+			Description: &newDesc,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "updated description", updated.Description)
+	})
+
+	t.Run("update_tags", func(t *testing.T) {
+		updated, err := repo.Update(ctx, created.ID, domain.UpdateModelRequest{
+			Tags: []string{"v2", "production"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"v2", "production"}, updated.Tags)
+	})
+
+	t.Run("update_nonexistent", func(t *testing.T) {
+		desc := "x"
+		_, err := repo.Update(ctx, "nonexistent-id", domain.UpdateModelRequest{Description: &desc})
+		require.Error(t, err)
+		var notFound *domain.NotFoundError
+		assert.ErrorAs(t, err, &notFound)
+	})
+}
+
+func TestModelRepo_Delete(t *testing.T) {
+	repo := setupModelRepo(t)
+	ctx := context.Background()
+
+	created, err := repo.Create(ctx, &domain.Model{
+		ProjectName:     "sales",
+		Name:            "to_delete",
+		SQL:             "SELECT 1",
+		Materialization: "VIEW",
+		Tags:            []string{},
+		DependsOn:       []string{},
+		CreatedBy:       "admin",
+	})
+	require.NoError(t, err)
+
+	err = repo.Delete(ctx, created.ID)
+	require.NoError(t, err)
+
+	_, err = repo.GetByID(ctx, created.ID)
+	require.Error(t, err)
+	var notFound *domain.NotFoundError
+	assert.ErrorAs(t, err, &notFound)
+}
+
+func TestModelRepo_ListAll(t *testing.T) {
+	repo := setupModelRepo(t)
+	ctx := context.Background()
+
+	for _, name := range []string{"alpha", "beta", "gamma"} {
+		_, err := repo.Create(ctx, &domain.Model{
+			ProjectName:     "analytics",
+			Name:            name,
+			SQL:             "SELECT 1",
+			Materialization: "VIEW",
+			Tags:            []string{},
+			DependsOn:       []string{},
+			CreatedBy:       "admin",
+		})
+		require.NoError(t, err)
+	}
+
+	all, err := repo.ListAll(ctx)
+	require.NoError(t, err)
+	assert.Len(t, all, 3)
+}
+
+func TestModelRepo_UpdateDependencies(t *testing.T) {
+	repo := setupModelRepo(t)
+	ctx := context.Background()
+
+	created, err := repo.Create(ctx, &domain.Model{
+		ProjectName:     "sales",
+		Name:            "fct_orders",
+		SQL:             "SELECT 1",
+		Materialization: "VIEW",
+		Tags:            []string{},
+		DependsOn:       []string{},
+		CreatedBy:       "admin",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, created.DependsOn)
+
+	err = repo.UpdateDependencies(ctx, created.ID, []string{"sales.stg_orders", "sales.stg_customers"})
+	require.NoError(t, err)
+
+	got, err := repo.GetByID(ctx, created.ID)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"sales.stg_orders", "sales.stg_customers"}, got.DependsOn)
+}
+
+func TestModelRepo_DuplicateConflict(t *testing.T) {
+	repo := setupModelRepo(t)
+	ctx := context.Background()
+
+	m := &domain.Model{
+		ProjectName:     "sales",
+		Name:            "stg_orders",
+		SQL:             "SELECT 1",
+		Materialization: "VIEW",
+		Tags:            []string{},
+		DependsOn:       []string{},
+		CreatedBy:       "admin",
+	}
+
+	_, err := repo.Create(ctx, m)
+	require.NoError(t, err)
+
+	_, err = repo.Create(ctx, &domain.Model{
+		ProjectName:     "sales",
+		Name:            "stg_orders",
+		SQL:             "SELECT 2",
+		Materialization: "TABLE",
+		Tags:            []string{},
+		DependsOn:       []string{},
+		CreatedBy:       "other",
+	})
+	require.Error(t, err)
+	var conflict *domain.ConflictError
+	assert.ErrorAs(t, err, &conflict)
+}

--- a/internal/db/repository/model_run.go
+++ b/internal/db/repository/model_run.go
@@ -1,0 +1,238 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"duck-demo/internal/db/dbstore"
+	"duck-demo/internal/domain"
+)
+
+// Compile-time check.
+var _ domain.ModelRunRepository = (*ModelRunRepo)(nil)
+
+// ModelRunRepo implements ModelRunRepository using SQLite.
+type ModelRunRepo struct {
+	q  *dbstore.Queries
+	db *sql.DB
+}
+
+// NewModelRunRepo creates a new ModelRunRepo.
+func NewModelRunRepo(db *sql.DB) *ModelRunRepo {
+	return &ModelRunRepo{q: dbstore.New(db), db: db}
+}
+
+// CreateRun inserts a new model run.
+func (r *ModelRunRepo) CreateRun(ctx context.Context, run *domain.ModelRun) (*domain.ModelRun, error) {
+	varsJSON, err := json.Marshal(run.Variables)
+	if err != nil {
+		return nil, fmt.Errorf("marshal variables: %w", err)
+	}
+
+	row, err := r.q.CreateModelRun(ctx, dbstore.CreateModelRunParams{
+		ID:            newID(),
+		Status:        run.Status,
+		TriggerType:   run.TriggerType,
+		TriggeredBy:   run.TriggeredBy,
+		TargetCatalog: run.TargetCatalog,
+		TargetSchema:  run.TargetSchema,
+		ModelSelector: run.ModelSelector,
+		Variables:     string(varsJSON),
+	})
+	if err != nil {
+		return nil, mapDBError(err)
+	}
+	return modelRunFromDB(row), nil
+}
+
+// GetRunByID returns a model run by its ID.
+func (r *ModelRunRepo) GetRunByID(ctx context.Context, id string) (*domain.ModelRun, error) {
+	row, err := r.q.GetModelRunByID(ctx, id)
+	if err != nil {
+		return nil, mapDBError(err)
+	}
+	return modelRunFromDB(row), nil
+}
+
+// ListRuns returns a filtered, paginated list of model runs.
+func (r *ModelRunRepo) ListRuns(ctx context.Context, filter domain.ModelRunFilter) ([]domain.ModelRun, int64, error) {
+	statusFilter := ""
+	if filter.Status != nil {
+		statusFilter = *filter.Status
+	}
+
+	total, err := r.q.CountModelRuns(ctx, dbstore.CountModelRunsParams{
+		Column1: statusFilter,
+		Status:  statusFilter,
+	})
+	if err != nil {
+		return nil, 0, err
+	}
+
+	rows, err := r.q.ListModelRuns(ctx, dbstore.ListModelRunsParams{
+		Column1: statusFilter,
+		Status:  statusFilter,
+		Limit:   int64(filter.Page.Limit()),
+		Offset:  int64(filter.Page.Offset()),
+	})
+	if err != nil {
+		return nil, 0, err
+	}
+
+	runs := make([]domain.ModelRun, 0, len(rows))
+	for _, row := range rows {
+		runs = append(runs, *modelRunFromDB(row))
+	}
+	return runs, total, nil
+}
+
+// UpdateRunStarted marks a model run as started.
+func (r *ModelRunRepo) UpdateRunStarted(ctx context.Context, id string) error {
+	return mapDBError(r.q.UpdateModelRunStarted(ctx, id))
+}
+
+// UpdateRunFinished marks a model run as finished with a final status.
+func (r *ModelRunRepo) UpdateRunFinished(ctx context.Context, id string, status string, errMsg *string) error {
+	return mapDBError(r.q.UpdateModelRunFinished(ctx, dbstore.UpdateModelRunFinishedParams{
+		Status:       status,
+		ErrorMessage: nullStrFromPtr(errMsg),
+		ID:           id,
+	}))
+}
+
+// CreateStep inserts a new model run step.
+func (r *ModelRunRepo) CreateStep(ctx context.Context, step *domain.ModelRunStep) (*domain.ModelRunStep, error) {
+	row, err := r.q.CreateModelRunStep(ctx, dbstore.CreateModelRunStepParams{
+		ID:        newID(),
+		RunID:     step.RunID,
+		ModelID:   step.ModelID,
+		ModelName: step.ModelName,
+		Status:    step.Status,
+		Tier:      int64(step.Tier),
+	})
+	if err != nil {
+		return nil, mapDBError(err)
+	}
+	return modelRunStepFromDB(row), nil
+}
+
+// ListStepsByRun returns all steps for a model run.
+func (r *ModelRunRepo) ListStepsByRun(ctx context.Context, runID string) ([]domain.ModelRunStep, error) {
+	rows, err := r.q.ListModelRunStepsByRun(ctx, runID)
+	if err != nil {
+		return nil, err
+	}
+
+	steps := make([]domain.ModelRunStep, 0, len(rows))
+	for _, row := range rows {
+		steps = append(steps, *modelRunStepFromDB(row))
+	}
+	return steps, nil
+}
+
+// UpdateStepStarted marks a model run step as started.
+func (r *ModelRunRepo) UpdateStepStarted(ctx context.Context, id string) error {
+	return mapDBError(r.q.UpdateModelRunStepStarted(ctx, id))
+}
+
+// UpdateStepFinished marks a model run step as finished with a final status.
+func (r *ModelRunRepo) UpdateStepFinished(ctx context.Context, id string, status string, rowsAffected *int64, errMsg *string) error {
+	var ra sql.NullInt64
+	if rowsAffected != nil {
+		ra = sql.NullInt64{Int64: *rowsAffected, Valid: true}
+	}
+
+	return mapDBError(r.q.UpdateModelRunStepFinished(ctx, dbstore.UpdateModelRunStepFinishedParams{
+		Status:       status,
+		RowsAffected: ra,
+		ErrorMessage: nullStrFromPtr(errMsg),
+		ID:           id,
+	}))
+}
+
+// === Private mappers ===
+
+func modelRunFromDB(row dbstore.ModelRun) *domain.ModelRun {
+	createdAt, _ := time.Parse("2006-01-02 15:04:05", row.CreatedAt)
+
+	var vars map[string]string
+	_ = json.Unmarshal([]byte(row.Variables), &vars)
+	if vars == nil {
+		vars = map[string]string{}
+	}
+
+	var startedAt *time.Time
+	if row.StartedAt.Valid {
+		t, _ := time.Parse("2006-01-02 15:04:05", row.StartedAt.String)
+		startedAt = &t
+	}
+
+	var finishedAt *time.Time
+	if row.FinishedAt.Valid {
+		t, _ := time.Parse("2006-01-02 15:04:05", row.FinishedAt.String)
+		finishedAt = &t
+	}
+
+	var errMsg *string
+	if row.ErrorMessage.Valid {
+		errMsg = &row.ErrorMessage.String
+	}
+
+	return &domain.ModelRun{
+		ID:            row.ID,
+		Status:        row.Status,
+		TriggerType:   row.TriggerType,
+		TriggeredBy:   row.TriggeredBy,
+		TargetCatalog: row.TargetCatalog,
+		TargetSchema:  row.TargetSchema,
+		ModelSelector: row.ModelSelector,
+		Variables:     vars,
+		StartedAt:     startedAt,
+		FinishedAt:    finishedAt,
+		ErrorMessage:  errMsg,
+		CreatedAt:     createdAt,
+	}
+}
+
+func modelRunStepFromDB(row dbstore.ModelRunStep) *domain.ModelRunStep {
+	createdAt, _ := time.Parse("2006-01-02 15:04:05", row.CreatedAt)
+
+	var startedAt *time.Time
+	if row.StartedAt.Valid {
+		t, _ := time.Parse("2006-01-02 15:04:05", row.StartedAt.String)
+		startedAt = &t
+	}
+
+	var finishedAt *time.Time
+	if row.FinishedAt.Valid {
+		t, _ := time.Parse("2006-01-02 15:04:05", row.FinishedAt.String)
+		finishedAt = &t
+	}
+
+	var errMsg *string
+	if row.ErrorMessage.Valid {
+		errMsg = &row.ErrorMessage.String
+	}
+
+	var rowsAffected *int64
+	if row.RowsAffected.Valid {
+		rowsAffected = &row.RowsAffected.Int64
+	}
+
+	return &domain.ModelRunStep{
+		ID:           row.ID,
+		RunID:        row.RunID,
+		ModelID:      row.ModelID,
+		ModelName:    row.ModelName,
+		Status:       row.Status,
+		Tier:         int(row.Tier),
+		RowsAffected: rowsAffected,
+		StartedAt:    startedAt,
+		FinishedAt:   finishedAt,
+		ErrorMessage: errMsg,
+		CreatedAt:    createdAt,
+	}
+}

--- a/internal/db/repository/model_test_repo.go
+++ b/internal/db/repository/model_test_repo.go
@@ -1,0 +1,175 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"duck-demo/internal/db/dbstore"
+	"duck-demo/internal/domain"
+)
+
+// Compile-time checks.
+var _ domain.ModelTestRepository = (*ModelTestRepo)(nil)
+var _ domain.ModelTestResultRepository = (*ModelTestResultRepo)(nil)
+
+// ModelTestRepo implements ModelTestRepository using SQLite.
+type ModelTestRepo struct {
+	q  *dbstore.Queries
+	db *sql.DB
+}
+
+// NewModelTestRepo creates a new ModelTestRepo.
+func NewModelTestRepo(db *sql.DB) *ModelTestRepo {
+	return &ModelTestRepo{q: dbstore.New(db), db: db}
+}
+
+// Create inserts a new model test.
+func (r *ModelTestRepo) Create(ctx context.Context, test *domain.ModelTest) (*domain.ModelTest, error) {
+	configJSON, err := json.Marshal(test.Config)
+	if err != nil {
+		return nil, fmt.Errorf("marshal config: %w", err)
+	}
+
+	row, err := r.q.CreateModelTest(ctx, dbstore.CreateModelTestParams{
+		ID:         newID(),
+		ModelID:    test.ModelID,
+		Name:       test.Name,
+		TestType:   test.TestType,
+		ColumnName: test.Column,
+		Config:     string(configJSON),
+	})
+	if err != nil {
+		return nil, mapDBError(err)
+	}
+	return modelTestFromDB(row), nil
+}
+
+// GetByID returns a model test by its ID.
+func (r *ModelTestRepo) GetByID(ctx context.Context, id string) (*domain.ModelTest, error) {
+	row, err := r.q.GetModelTestByID(ctx, id)
+	if err != nil {
+		return nil, mapDBError(err)
+	}
+	return modelTestFromDB(row), nil
+}
+
+// ListByModel returns all tests for a model.
+func (r *ModelTestRepo) ListByModel(ctx context.Context, modelID string) ([]domain.ModelTest, error) {
+	rows, err := r.q.ListModelTestsByModel(ctx, modelID)
+	if err != nil {
+		return nil, err
+	}
+
+	tests := make([]domain.ModelTest, 0, len(rows))
+	for _, row := range rows {
+		tests = append(tests, *modelTestFromDB(row))
+	}
+	return tests, nil
+}
+
+// Delete removes a model test by ID.
+func (r *ModelTestRepo) Delete(ctx context.Context, id string) error {
+	return mapDBError(r.q.DeleteModelTest(ctx, id))
+}
+
+// === Private mapper ===
+
+func modelTestFromDB(row dbstore.ModelTest) *domain.ModelTest {
+	createdAt, err := time.Parse("2006-01-02 15:04:05", row.CreatedAt)
+	if err != nil {
+		slog.Default().Warn("failed to parse model_test created_at", "value", row.CreatedAt, "error", err)
+	}
+
+	var config domain.ModelTestConfig
+	_ = json.Unmarshal([]byte(row.Config), &config)
+
+	return &domain.ModelTest{
+		ID:        row.ID,
+		ModelID:   row.ModelID,
+		Name:      row.Name,
+		TestType:  row.TestType,
+		Column:    row.ColumnName,
+		Config:    config,
+		CreatedAt: createdAt,
+	}
+}
+
+// === ModelTestResultRepo ===
+
+// ModelTestResultRepo implements ModelTestResultRepository using SQLite.
+type ModelTestResultRepo struct {
+	q  *dbstore.Queries
+	db *sql.DB
+}
+
+// NewModelTestResultRepo creates a new ModelTestResultRepo.
+func NewModelTestResultRepo(db *sql.DB) *ModelTestResultRepo {
+	return &ModelTestResultRepo{q: dbstore.New(db), db: db}
+}
+
+// Create inserts a new model test result.
+func (r *ModelTestResultRepo) Create(ctx context.Context, result *domain.ModelTestResult) (*domain.ModelTestResult, error) {
+	var rowsReturned sql.NullInt64
+	if result.RowsReturned != nil {
+		rowsReturned = sql.NullInt64{Int64: *result.RowsReturned, Valid: true}
+	}
+
+	row, err := r.q.CreateModelTestResult(ctx, dbstore.CreateModelTestResultParams{
+		ID:           newID(),
+		RunStepID:    result.RunStepID,
+		TestID:       result.TestID,
+		TestName:     result.TestName,
+		Status:       result.Status,
+		RowsReturned: rowsReturned,
+		ErrorMessage: nullStrFromPtr(result.ErrorMessage),
+	})
+	if err != nil {
+		return nil, mapDBError(err)
+	}
+	return modelTestResultFromDB(row), nil
+}
+
+// ListByStep returns all test results for a run step.
+func (r *ModelTestResultRepo) ListByStep(ctx context.Context, runStepID string) ([]domain.ModelTestResult, error) {
+	rows, err := r.q.ListModelTestResultsByStep(ctx, runStepID)
+	if err != nil {
+		return nil, err
+	}
+
+	results := make([]domain.ModelTestResult, 0, len(rows))
+	for _, row := range rows {
+		results = append(results, *modelTestResultFromDB(row))
+	}
+	return results, nil
+}
+
+// === Private mapper ===
+
+func modelTestResultFromDB(row dbstore.ModelTestResult) *domain.ModelTestResult {
+	createdAt, _ := time.Parse("2006-01-02 15:04:05", row.CreatedAt)
+
+	var rowsReturned *int64
+	if row.RowsReturned.Valid {
+		rowsReturned = &row.RowsReturned.Int64
+	}
+
+	var errMsg *string
+	if row.ErrorMessage.Valid {
+		errMsg = &row.ErrorMessage.String
+	}
+
+	return &domain.ModelTestResult{
+		ID:           row.ID,
+		RunStepID:    row.RunStepID,
+		TestID:       row.TestID,
+		TestName:     row.TestName,
+		Status:       row.Status,
+		RowsReturned: rowsReturned,
+		ErrorMessage: errMsg,
+		CreatedAt:    createdAt,
+	}
+}

--- a/internal/db/repository/pipeline.go
+++ b/internal/db/repository/pipeline.go
@@ -146,6 +146,11 @@ func (r *PipelineRepo) CreateJob(ctx context.Context, job *domain.PipelineJob) (
 		return nil, fmt.Errorf("marshal depends_on: %w", err)
 	}
 
+	jobType := job.JobType
+	if jobType == "" {
+		jobType = domain.PipelineJobTypeNotebook
+	}
+
 	row, err := r.q.CreatePipelineJob(ctx, dbstore.CreatePipelineJobParams{
 		ID:                newID(),
 		PipelineID:        job.PipelineID,
@@ -156,6 +161,8 @@ func (r *PipelineRepo) CreateJob(ctx context.Context, job *domain.PipelineJob) (
 		TimeoutSeconds:    nullInt64Ptr(job.TimeoutSeconds),
 		RetryCount:        int64(job.RetryCount),
 		JobOrder:          int64(job.JobOrder),
+		JobType:           jobType,
+		ModelSelector:     job.ModelSelector,
 	})
 	if err != nil {
 		return nil, mapDBError(err)
@@ -258,6 +265,8 @@ func pipelineJobFromDB(row dbstore.PipelineJob) *domain.PipelineJob {
 		TimeoutSeconds:    ts,
 		RetryCount:        int(row.RetryCount),
 		JobOrder:          int(row.JobOrder),
+		JobType:           row.JobType,
+		ModelSelector:     row.ModelSelector,
 		CreatedAt:         createdAt,
 	}
 }

--- a/internal/declarative/exporter.go
+++ b/internal/declarative/exporter.go
@@ -53,6 +53,16 @@ func ExportDirectory(dir string, state *DesiredState, overwrite bool) error {
 		return err
 	}
 
+	// Models.
+	if err := exportModels(dir, state); err != nil {
+		return err
+	}
+
+	// Macros.
+	if err := exportMacros(dir, state); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -390,6 +400,42 @@ func exportPipelines(dir string, state *DesiredState) error {
 			Spec:       pl.Spec,
 		}
 		path := filepath.Join(dir, "pipelines", pl.Name+".yaml")
+		if err := writeYAMLFile(path, doc); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// === Models ===
+
+func exportModels(dir string, state *DesiredState) error {
+	for _, m := range state.Models {
+		doc := ModelDoc{
+			APIVersion: SupportedAPIVersion,
+			Kind:       KindNameModel,
+			Metadata:   ObjectMeta{Name: m.ModelName},
+			Spec:       m.Spec,
+		}
+		path := filepath.Join(dir, "models", m.ProjectName, m.ModelName+".yaml")
+		if err := writeYAMLFile(path, doc); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// === Macros ===
+
+func exportMacros(dir string, state *DesiredState) error {
+	for _, m := range state.Macros {
+		doc := MacroDoc{
+			APIVersion: SupportedAPIVersion,
+			Kind:       KindNameMacro,
+			Metadata:   ObjectMeta{Name: m.Name},
+			Spec:       m.Spec,
+		}
+		path := filepath.Join(dir, "macros", m.Name+".yaml")
 		if err := writeYAMLFile(path, doc); err != nil {
 			return err
 		}

--- a/internal/declarative/kinds.go
+++ b/internal/declarative/kinds.go
@@ -9,6 +9,7 @@ const (
 	KindStorageCredential   ResourceKind = iota // layer 0
 	KindPrincipal                               // layer 0
 	KindTag                                     // layer 0
+	KindMacro                                   // layer 0
 	KindGroup                                   // layer 1
 	KindExternalLocation                        // layer 1
 	KindComputeEndpoint                         // layer 1
@@ -29,6 +30,7 @@ const (
 	KindNotebook                                // layer 6
 	KindPipeline                                // layer 7
 	KindPipelineJob                             // layer 7
+	KindModel                                   // layer 8
 )
 
 // String returns a human-readable kebab-case name for the resource kind.
@@ -40,6 +42,8 @@ func (k ResourceKind) String() string {
 		return "principal"
 	case KindTag:
 		return "tag"
+	case KindMacro:
+		return "macro"
 	case KindGroup:
 		return "group"
 	case KindExternalLocation:
@@ -80,6 +84,8 @@ func (k ResourceKind) String() string {
 		return "pipeline"
 	case KindPipelineJob:
 		return "pipeline-job"
+	case KindModel:
+		return "model"
 	default:
 		return "unknown"
 	}
@@ -89,7 +95,7 @@ func (k ResourceKind) String() string {
 // Layer 0 has no dependencies; higher layers depend on lower ones.
 func (k ResourceKind) Layer() int {
 	switch k {
-	case KindStorageCredential, KindPrincipal, KindTag:
+	case KindStorageCredential, KindPrincipal, KindTag, KindMacro:
 		return 0
 	case KindGroup, KindExternalLocation, KindComputeEndpoint:
 		return 1
@@ -105,13 +111,15 @@ func (k ResourceKind) Layer() int {
 		return 6
 	case KindPipeline, KindPipelineJob:
 		return 7
+	case KindModel:
+		return 8
 	default:
 		return 99
 	}
 }
 
 // MaxLayer is the highest dependency layer.
-const MaxLayer = 7
+const MaxLayer = 8
 
 // Operation represents a planned change type.
 type Operation int
@@ -159,6 +167,8 @@ const (
 	KindNameComputeAssignmentList = "ComputeAssignmentList"
 	KindNameNotebook              = "Notebook"
 	KindNamePipeline              = "Pipeline"
+	KindNameModel                 = "Model"
+	KindNameMacro                 = "Macro"
 )
 
 // SupportedAPIVersion is the current API version for YAML documents.

--- a/internal/declarative/testdata/valid/models-only/models/sales/marts/fct_orders.yaml
+++ b/internal/declarative/testdata/valid/models-only/models/sales/marts/fct_orders.yaml
@@ -1,0 +1,9 @@
+apiVersion: duck/v1
+kind: Model
+metadata:
+  name: fct_orders
+spec:
+  materialization: VIEW
+  description: "Orders fact table"
+  sql: |
+    SELECT * FROM stg_orders

--- a/internal/declarative/testdata/valid/models-only/models/sales/staging/stg_orders.yaml
+++ b/internal/declarative/testdata/valid/models-only/models/sales/staging/stg_orders.yaml
@@ -1,0 +1,11 @@
+apiVersion: duck/v1
+kind: Model
+metadata:
+  name: stg_orders
+spec:
+  materialization: TABLE
+  description: "Staged orders"
+  tags: [finance, staging]
+  sql: |
+    SELECT order_id, customer_id
+    FROM raw_data.orders

--- a/internal/declarative/testdata/valid/models/sales/marts/fct_orders.yaml
+++ b/internal/declarative/testdata/valid/models/sales/marts/fct_orders.yaml
@@ -1,0 +1,9 @@
+apiVersion: duck/v1
+kind: Model
+metadata:
+  name: fct_orders
+spec:
+  materialization: VIEW
+  description: "Orders fact table"
+  sql: |
+    SELECT * FROM stg_orders

--- a/internal/declarative/testdata/valid/models/sales/staging/stg_orders.yaml
+++ b/internal/declarative/testdata/valid/models/sales/staging/stg_orders.yaml
@@ -1,0 +1,11 @@
+apiVersion: duck/v1
+kind: Model
+metadata:
+  name: stg_orders
+spec:
+  materialization: TABLE
+  description: "Staged orders"
+  tags: [finance, staging]
+  sql: |
+    SELECT order_id, customer_id
+    FROM raw_data.orders

--- a/internal/declarative/types.go
+++ b/internal/declarative/types.go
@@ -410,6 +410,8 @@ type DesiredState struct {
 	APIKeys            []APIKeySpec
 	Notebooks          []NotebookResource
 	Pipelines          []PipelineResource
+	Models             []ModelResource
+	Macros             []MacroResource
 }
 
 // CatalogResource is a catalog with positional context from the directory tree.
@@ -478,6 +480,95 @@ type NotebookResource struct {
 type PipelineResource struct {
 	Name string
 	Spec PipelineSpec
+}
+
+// === SQL Macros ===
+
+// MacroDoc declares a SQL macro.
+type MacroDoc struct {
+	APIVersion string     `yaml:"apiVersion"`
+	Kind       string     `yaml:"kind"`
+	Metadata   ObjectMeta `yaml:"metadata"`
+	Spec       MacroSpec  `yaml:"spec"`
+}
+
+// MacroSpec holds the configuration for a SQL macro.
+type MacroSpec struct {
+	MacroType   string   `yaml:"macro_type,omitempty"` // SCALAR or TABLE
+	Parameters  []string `yaml:"parameters,omitempty"`
+	Body        string   `yaml:"body"`
+	Description string   `yaml:"description,omitempty"`
+}
+
+// MacroResource is a macro with its resolved name.
+type MacroResource struct {
+	Name string
+	Spec MacroSpec
+}
+
+// === Transformation Models ===
+
+// ModelDoc declares a transformation model.
+type ModelDoc struct {
+	APIVersion string     `yaml:"apiVersion"`
+	Kind       string     `yaml:"kind"`
+	Metadata   ObjectMeta `yaml:"metadata"`
+	Spec       ModelSpec  `yaml:"spec"`
+}
+
+// ModelSpec holds the configuration for a transformation model.
+type ModelSpec struct {
+	Materialization string             `yaml:"materialization"`
+	Description     string             `yaml:"description,omitempty"`
+	Tags            []string           `yaml:"tags,omitempty"`
+	SQL             string             `yaml:"sql"`
+	Config          *ModelConfigSpec   `yaml:"config,omitempty"`
+	Contract        *ContractSpec      `yaml:"contract,omitempty"`
+	Tests           []TestSpec         `yaml:"tests,omitempty"`
+	Freshness       *FreshnessSpecYAML `yaml:"freshness,omitempty"`
+}
+
+// FreshnessSpecYAML defines freshness policy in YAML.
+type FreshnessSpecYAML struct {
+	MaxLagSeconds int64  `yaml:"max_lag_seconds,omitempty"`
+	CronSchedule  string `yaml:"cron_schedule,omitempty"`
+}
+
+// ContractSpec defines enforced output column types for a model.
+type ContractSpec struct {
+	Enforce bool                 `yaml:"enforce"`
+	Columns []ContractColumnSpec `yaml:"columns,omitempty"`
+}
+
+// ContractColumnSpec defines an expected column in a model contract.
+type ContractColumnSpec struct {
+	Name     string `yaml:"name"`
+	Type     string `yaml:"type"`
+	Nullable bool   `yaml:"nullable"`
+}
+
+// TestSpec describes a test assertion for a model.
+type TestSpec struct {
+	Name     string   `yaml:"name"`
+	Type     string   `yaml:"type"`
+	Column   string   `yaml:"column,omitempty"`
+	Values   []string `yaml:"values,omitempty"`
+	ToModel  string   `yaml:"to_model,omitempty"`
+	ToColumn string   `yaml:"to_column,omitempty"`
+	SQL      string   `yaml:"sql,omitempty"`
+}
+
+// ModelConfigSpec holds optional model configuration options.
+type ModelConfigSpec struct {
+	UniqueKey           []string `yaml:"unique_key,omitempty"`
+	IncrementalStrategy string   `yaml:"incremental_strategy,omitempty"`
+}
+
+// ModelResource is a model with project context from the directory tree.
+type ModelResource struct {
+	ProjectName string
+	ModelName   string
+	Spec        ModelSpec
 }
 
 // ActualState mirrors DesiredState but populated from the server.

--- a/internal/domain/macro.go
+++ b/internal/domain/macro.go
@@ -1,0 +1,91 @@
+package domain
+
+import "time"
+
+// Macro types.
+const (
+	MacroTypeScalar = "SCALAR"
+	MacroTypeTable  = "TABLE"
+)
+
+// Macro represents a DuckDB SQL macro definition.
+type Macro struct {
+	ID          string
+	Name        string
+	MacroType   string // SCALAR or TABLE
+	Parameters  []string
+	Body        string
+	Description string
+	CreatedBy   string
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
+// CreateMacroRequest holds parameters for creating a macro.
+type CreateMacroRequest struct {
+	Name        string
+	MacroType   string
+	Parameters  []string
+	Body        string
+	Description string
+}
+
+// Validate checks that the request is well-formed.
+func (r *CreateMacroRequest) Validate() error {
+	if r.Name == "" {
+		return ErrValidation("name is required")
+	}
+	if r.Body == "" {
+		return ErrValidation("body is required")
+	}
+	if r.MacroType == "" {
+		r.MacroType = MacroTypeScalar
+	}
+	if r.MacroType != MacroTypeScalar && r.MacroType != MacroTypeTable {
+		return ErrValidation("macro_type must be SCALAR or TABLE")
+	}
+	return nil
+}
+
+// UpdateMacroRequest holds partial-update parameters.
+type UpdateMacroRequest struct {
+	Body        *string
+	Description *string
+	Parameters  []string
+}
+
+// PromoteNotebookRequest holds parameters for promoting a notebook cell to a model.
+type PromoteNotebookRequest struct {
+	NotebookID      string
+	CellIndex       int
+	ProjectName     string
+	Name            string
+	Materialization string
+}
+
+// Validate checks that the request is well-formed.
+func (r *PromoteNotebookRequest) Validate() error {
+	if r.NotebookID == "" {
+		return ErrValidation("notebook_id is required")
+	}
+	if r.ProjectName == "" {
+		return ErrValidation("project_name is required")
+	}
+	if r.Name == "" {
+		return ErrValidation("name is required")
+	}
+	if r.CellIndex < 0 {
+		return ErrValidation("cell_index must be non-negative")
+	}
+	if r.Materialization == "" {
+		r.Materialization = MaterializationTable
+	}
+	validMat := map[string]bool{
+		MaterializationView: true, MaterializationTable: true,
+		MaterializationIncremental: true, MaterializationEphemeral: true,
+	}
+	if !validMat[r.Materialization] {
+		return ErrValidation("materialization must be VIEW, TABLE, INCREMENTAL, or EPHEMERAL")
+	}
+	return nil
+}

--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -1,0 +1,286 @@
+package domain
+
+import "time"
+
+// Materialization strategy constants.
+const (
+	MaterializationView        = "VIEW"
+	MaterializationTable       = "TABLE"
+	MaterializationIncremental = "INCREMENTAL"
+	MaterializationEphemeral   = "EPHEMERAL"
+)
+
+// Model run status constants.
+const (
+	ModelRunStatusPending   = "PENDING"
+	ModelRunStatusRunning   = "RUNNING"
+	ModelRunStatusSuccess   = "SUCCESS"
+	ModelRunStatusFailed    = "FAILED"
+	ModelRunStatusCancelled = "CANCELLED"
+	ModelRunStatusSkipped   = "SKIPPED"
+)
+
+// Model trigger type constants.
+const (
+	ModelTriggerTypeManual    = "MANUAL"
+	ModelTriggerTypeScheduled = "SCHEDULED"
+	ModelTriggerTypePipeline  = "PIPELINE"
+)
+
+// FreshnessPolicy defines staleness thresholds for a model.
+type FreshnessPolicy struct {
+	MaxLagSeconds int64  `json:"max_lag_seconds,omitempty"`
+	CronSchedule  string `json:"cron_schedule,omitempty"`
+}
+
+// Model represents a transformation model definition.
+type Model struct {
+	ID              string
+	ProjectName     string // e.g. "sales"
+	Name            string // e.g. "stg_orders" — derived from filename
+	SQL             string // the transformation SQL
+	Materialization string // VIEW, TABLE, INCREMENTAL, EPHEMERAL
+	Description     string
+	Owner           string
+	Tags            []string    // for selector syntax
+	DependsOn       []string    // auto-extracted: ["sales.stg_customers", "warehouse.orders"]
+	Config          ModelConfig // materialization-specific config
+	Contract        *ModelContract
+	Freshness       *FreshnessPolicy
+	CreatedBy       string
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
+}
+
+// ModelConfig holds materialization-specific configuration.
+type ModelConfig struct {
+	// For INCREMENTAL: the unique key columns for MERGE.
+	UniqueKey []string `json:"unique_key,omitempty"`
+	// For INCREMENTAL: the strategy (merge, delete+insert).
+	IncrementalStrategy string `json:"incremental_strategy,omitempty"`
+}
+
+// QualifiedName returns "project.name" for cross-project references.
+func (m *Model) QualifiedName() string {
+	return m.ProjectName + "." + m.Name
+}
+
+// CreateModelRequest holds parameters for creating a model.
+type CreateModelRequest struct {
+	ProjectName     string
+	Name            string
+	SQL             string
+	Materialization string
+	Description     string
+	Tags            []string
+	Config          ModelConfig
+	Contract        *ModelContract
+}
+
+// Validate checks that the request is well-formed.
+func (r *CreateModelRequest) Validate() error {
+	if r.ProjectName == "" {
+		return ErrValidation("project_name is required")
+	}
+	if r.Name == "" {
+		return ErrValidation("name is required")
+	}
+	if r.SQL == "" {
+		return ErrValidation("sql is required")
+	}
+	validMat := map[string]bool{
+		MaterializationView: true, MaterializationTable: true,
+		MaterializationIncremental: true, MaterializationEphemeral: true,
+	}
+	if r.Materialization == "" {
+		r.Materialization = MaterializationView
+	}
+	if !validMat[r.Materialization] {
+		return ErrValidation("materialization must be VIEW, TABLE, INCREMENTAL, or EPHEMERAL")
+	}
+	return nil
+}
+
+// UpdateModelRequest holds partial-update parameters.
+type UpdateModelRequest struct {
+	SQL             *string
+	Materialization *string
+	Description     *string
+	Tags            []string // nil = no change, empty = clear
+	Config          *ModelConfig
+	Contract        *ModelContract
+	Freshness       *FreshnessPolicy
+}
+
+// FreshnessStatus holds the result of a freshness check.
+type FreshnessStatus struct {
+	IsFresh       bool
+	LastRunAt     *time.Time
+	MaxLagSeconds int64
+	StaleSince    *time.Time
+}
+
+// ModelRun represents a single execution of the model DAG.
+type ModelRun struct {
+	ID            string
+	Status        string
+	TriggerType   string // "MANUAL", "SCHEDULED", "PIPELINE"
+	TriggeredBy   string
+	TargetCatalog string
+	TargetSchema  string
+	ModelSelector string // which models: "" = all, "stg_orders+", "tag:finance"
+	Variables     map[string]string
+	StartedAt     *time.Time
+	FinishedAt    *time.Time
+	ErrorMessage  *string
+	CreatedAt     time.Time
+}
+
+// ModelRunStep represents a single model's execution within a run.
+type ModelRunStep struct {
+	ID           string
+	RunID        string
+	ModelID      string
+	ModelName    string // "project.name" qualified
+	Status       string
+	Tier         int // DAG tier (0 = roots)
+	RowsAffected *int64
+	StartedAt    *time.Time
+	FinishedAt   *time.Time
+	ErrorMessage *string
+	CreatedAt    time.Time
+}
+
+// ModelRunFilter holds filter parameters for querying model runs.
+type ModelRunFilter struct {
+	Status *string
+	Page   PageRequest
+}
+
+// TriggerModelRunRequest holds parameters for triggering a model run.
+type TriggerModelRunRequest struct {
+	TargetCatalog string
+	TargetSchema  string
+	Selector      string
+	TriggerType   string
+	Variables     map[string]string
+}
+
+// Validate checks that the request is well-formed.
+func (r *TriggerModelRunRequest) Validate() error {
+	if r.TargetCatalog == "" {
+		return ErrValidation("target_catalog is required")
+	}
+	if r.TargetSchema == "" {
+		return ErrValidation("target_schema is required")
+	}
+	return nil
+}
+
+// ModelTest defines a test assertion for a model's output.
+type ModelTest struct {
+	ID        string
+	ModelID   string
+	Name      string
+	TestType  string // "not_null", "unique", "accepted_values", "relationships", "custom_sql"
+	Column    string // for not_null, unique, accepted_values
+	Config    ModelTestConfig
+	CreatedAt time.Time
+}
+
+// ModelTestConfig holds test-type-specific configuration.
+type ModelTestConfig struct {
+	Values   []string `json:"values,omitempty"`    // For accepted_values
+	ToModel  string   `json:"to_model,omitempty"`  // For relationships
+	ToColumn string   `json:"to_column,omitempty"` // For relationships
+	SQL      string   `json:"sql,omitempty"`       // For custom_sql
+}
+
+// ModelTestResult represents the result of a test execution.
+type ModelTestResult struct {
+	ID           string
+	RunStepID    string
+	TestID       string
+	TestName     string
+	Status       string // "PASS", "FAIL", "ERROR"
+	RowsReturned *int64
+	ErrorMessage *string
+	CreatedAt    time.Time
+}
+
+// Model test result status constants.
+const (
+	TestResultPass  = "PASS"
+	TestResultFail  = "FAIL"
+	TestResultError = "ERROR"
+)
+
+// Valid test type constants.
+const (
+	TestTypeNotNull        = "not_null"
+	TestTypeUnique         = "unique"
+	TestTypeAcceptedValues = "accepted_values"
+	TestTypeRelationships  = "relationships"
+	TestTypeCustomSQL      = "custom_sql"
+)
+
+// CreateModelTestRequest holds parameters for creating a model test.
+type CreateModelTestRequest struct {
+	Name     string
+	TestType string
+	Column   string
+	Config   ModelTestConfig
+}
+
+// Validate checks that the request is well-formed.
+func (r *CreateModelTestRequest) Validate() error {
+	if r.Name == "" {
+		return ErrValidation("name is required")
+	}
+	validTypes := map[string]bool{
+		TestTypeNotNull: true, TestTypeUnique: true,
+		TestTypeAcceptedValues: true, TestTypeRelationships: true,
+		TestTypeCustomSQL: true,
+	}
+	if !validTypes[r.TestType] {
+		return ErrValidation("test_type must be not_null, unique, accepted_values, relationships, or custom_sql")
+	}
+	switch r.TestType {
+	case TestTypeNotNull, TestTypeUnique:
+		if r.Column == "" {
+			return ErrValidation("column is required for %s tests", r.TestType)
+		}
+	case TestTypeAcceptedValues:
+		if r.Column == "" {
+			return ErrValidation("column is required for accepted_values tests")
+		}
+		if len(r.Config.Values) == 0 {
+			return ErrValidation("values are required for accepted_values tests")
+		}
+	case TestTypeRelationships:
+		if r.Column == "" {
+			return ErrValidation("column is required for relationships tests")
+		}
+		if r.Config.ToModel == "" || r.Config.ToColumn == "" {
+			return ErrValidation("to_model and to_column are required for relationships tests")
+		}
+	case TestTypeCustomSQL:
+		if r.Config.SQL == "" {
+			return ErrValidation("sql is required for custom_sql tests")
+		}
+	}
+	return nil
+}
+
+// ModelContract defines enforced output column types.
+type ModelContract struct {
+	Enforce bool                  `json:"enforce"`
+	Columns []ModelContractColumn `json:"columns,omitempty"`
+}
+
+// ModelContractColumn defines an expected column in a model contract.
+type ModelContractColumn struct {
+	Name     string `json:"name"`
+	Type     string `json:"type"`
+	Nullable bool   `json:"nullable"`
+}

--- a/internal/domain/ports.go
+++ b/internal/domain/ports.go
@@ -75,3 +75,8 @@ type MetastoreQuerier interface {
 type NotebookProvider interface {
 	GetSQLBlocks(ctx context.Context, notebookID string) ([]string, error)
 }
+
+// ModelRunner executes a model run synchronously. Used by the pipeline executor.
+type ModelRunner interface {
+	TriggerRunSync(ctx context.Context, principal string, req TriggerModelRunRequest) error
+}

--- a/internal/domain/repository.go
+++ b/internal/domain/repository.go
@@ -315,3 +315,52 @@ type PipelineRunRepository interface {
 	UpdateJobRunStarted(ctx context.Context, id string) error
 	UpdateJobRunFinished(ctx context.Context, id string, status string, errorMsg *string) error
 }
+
+// ModelRepository provides CRUD operations for transformation models.
+type ModelRepository interface {
+	Create(ctx context.Context, m *Model) (*Model, error)
+	GetByID(ctx context.Context, id string) (*Model, error)
+	GetByName(ctx context.Context, projectName, name string) (*Model, error)
+	List(ctx context.Context, projectName *string, page PageRequest) ([]Model, int64, error)
+	Update(ctx context.Context, id string, req UpdateModelRequest) (*Model, error)
+	Delete(ctx context.Context, id string) error
+	ListAll(ctx context.Context) ([]Model, error)
+	UpdateDependencies(ctx context.Context, id string, deps []string) error
+}
+
+// ModelRunRepository provides CRUD operations for model runs and steps.
+type ModelRunRepository interface {
+	CreateRun(ctx context.Context, run *ModelRun) (*ModelRun, error)
+	GetRunByID(ctx context.Context, id string) (*ModelRun, error)
+	ListRuns(ctx context.Context, filter ModelRunFilter) ([]ModelRun, int64, error)
+	UpdateRunStarted(ctx context.Context, id string) error
+	UpdateRunFinished(ctx context.Context, id string, status string, errMsg *string) error
+	CreateStep(ctx context.Context, step *ModelRunStep) (*ModelRunStep, error)
+	ListStepsByRun(ctx context.Context, runID string) ([]ModelRunStep, error)
+	UpdateStepStarted(ctx context.Context, id string) error
+	UpdateStepFinished(ctx context.Context, id string, status string, rowsAffected *int64, errMsg *string) error
+}
+
+// ModelTestRepository provides CRUD operations for model tests.
+type ModelTestRepository interface {
+	Create(ctx context.Context, test *ModelTest) (*ModelTest, error)
+	GetByID(ctx context.Context, id string) (*ModelTest, error)
+	ListByModel(ctx context.Context, modelID string) ([]ModelTest, error)
+	Delete(ctx context.Context, id string) error
+}
+
+// ModelTestResultRepository provides operations for model test results.
+type ModelTestResultRepository interface {
+	Create(ctx context.Context, result *ModelTestResult) (*ModelTestResult, error)
+	ListByStep(ctx context.Context, runStepID string) ([]ModelTestResult, error)
+}
+
+// MacroRepository provides CRUD operations for SQL macros.
+type MacroRepository interface {
+	Create(ctx context.Context, m *Macro) (*Macro, error)
+	GetByName(ctx context.Context, name string) (*Macro, error)
+	List(ctx context.Context, page PageRequest) ([]Macro, int64, error)
+	Update(ctx context.Context, name string, req UpdateMacroRequest) (*Macro, error)
+	Delete(ctx context.Context, name string) error
+	ListAll(ctx context.Context) ([]Macro, error)
+}

--- a/internal/service/macro/service.go
+++ b/internal/service/macro/service.go
@@ -1,0 +1,92 @@
+// Package macro provides business logic for SQL macro management.
+package macro
+
+import (
+	"context"
+
+	"duck-demo/internal/domain"
+)
+
+// Service provides business logic for macro management.
+type Service struct {
+	macros domain.MacroRepository
+	audit  domain.AuditRepository
+}
+
+// NewService creates a new macro Service.
+func NewService(macros domain.MacroRepository, audit domain.AuditRepository) *Service {
+	return &Service{macros: macros, audit: audit}
+}
+
+// Create creates a new SQL macro.
+func (s *Service) Create(ctx context.Context, principal string, req domain.CreateMacroRequest) (*domain.Macro, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+
+	m := &domain.Macro{
+		Name:        req.Name,
+		MacroType:   req.MacroType,
+		Parameters:  req.Parameters,
+		Body:        req.Body,
+		Description: req.Description,
+		CreatedBy:   principal,
+	}
+	if m.Parameters == nil {
+		m.Parameters = []string{}
+	}
+
+	result, err := s.macros.Create(ctx, m)
+	if err != nil {
+		return nil, err
+	}
+
+	_ = s.audit.Insert(ctx, &domain.AuditEntry{
+		PrincipalName: principal,
+		Action:        "create_macro",
+		Status:        "SUCCESS",
+	})
+
+	return result, nil
+}
+
+// Get retrieves a macro by name.
+func (s *Service) Get(ctx context.Context, name string) (*domain.Macro, error) {
+	return s.macros.GetByName(ctx, name)
+}
+
+// List returns a paginated list of macros.
+func (s *Service) List(ctx context.Context, page domain.PageRequest) ([]domain.Macro, int64, error) {
+	return s.macros.List(ctx, page)
+}
+
+// Update updates a macro.
+func (s *Service) Update(ctx context.Context, principal, name string, req domain.UpdateMacroRequest) (*domain.Macro, error) {
+	result, err := s.macros.Update(ctx, name, req)
+	if err != nil {
+		return nil, err
+	}
+
+	_ = s.audit.Insert(ctx, &domain.AuditEntry{
+		PrincipalName: principal,
+		Action:        "update_macro",
+		Status:        "SUCCESS",
+	})
+
+	return result, nil
+}
+
+// Delete deletes a macro.
+func (s *Service) Delete(ctx context.Context, principal, name string) error {
+	if err := s.macros.Delete(ctx, name); err != nil {
+		return err
+	}
+
+	_ = s.audit.Insert(ctx, &domain.AuditEntry{
+		PrincipalName: principal,
+		Action:        "delete_macro",
+		Status:        "SUCCESS",
+	})
+
+	return nil
+}

--- a/internal/service/model/contracts.go
+++ b/internal/service/model/contracts.go
@@ -1,0 +1,72 @@
+package model
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"duck-demo/internal/domain"
+)
+
+// validateContract checks that a materialized model's output matches its contract.
+// Returns nil if no contract is defined or validation passes.
+func (s *Service) validateContract(ctx context.Context, conn *sql.Conn,
+	model *domain.Model, config ExecutionConfig, principal string) error {
+
+	if model.Contract == nil || !model.Contract.Enforce || len(model.Contract.Columns) == 0 {
+		return nil
+	}
+
+	fqn := quoteIdent(config.TargetSchema) + "." + quoteIdent(model.Name)
+
+	// Query information_schema to get actual columns
+	infoSQL := fmt.Sprintf(
+		"SELECT column_name, data_type, is_nullable FROM information_schema.columns WHERE table_schema = '%s' AND table_name = '%s' ORDER BY ordinal_position",
+		strings.ReplaceAll(config.TargetSchema, "'", "''"),
+		strings.ReplaceAll(model.Name, "'", "''"),
+	)
+
+	rows, err := s.engine.QueryOnConn(ctx, conn, principal, infoSQL)
+	if err != nil {
+		return fmt.Errorf("query information_schema for %s: %w", fqn, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	actualCols := make(map[string]struct{ dataType, isNullable string })
+	for rows.Next() {
+		var colName, dataType, isNullable string
+		if err := rows.Scan(&colName, &dataType, &isNullable); err != nil {
+			return fmt.Errorf("scan column info: %w", err)
+		}
+		actualCols[strings.ToLower(colName)] = struct{ dataType, isNullable string }{
+			dataType:   strings.ToUpper(dataType),
+			isNullable: isNullable,
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate columns: %w", err)
+	}
+
+	var violations []string
+	for _, expected := range model.Contract.Columns {
+		actual, ok := actualCols[strings.ToLower(expected.Name)]
+		if !ok {
+			violations = append(violations, fmt.Sprintf("column %q not found in output", expected.Name))
+			continue
+		}
+		if expected.Type != "" && !strings.EqualFold(actual.dataType, expected.Type) {
+			violations = append(violations, fmt.Sprintf("column %q: expected type %s, got %s",
+				expected.Name, expected.Type, actual.dataType))
+		}
+		if !expected.Nullable && strings.EqualFold(actual.isNullable, "YES") {
+			violations = append(violations, fmt.Sprintf("column %q: expected NOT NULL but is nullable",
+				expected.Name))
+		}
+	}
+
+	if len(violations) > 0 {
+		return domain.ErrValidation("contract violation for %s: %s", model.QualifiedName(), strings.Join(violations, "; "))
+	}
+	return nil
+}

--- a/internal/service/model/dag.go
+++ b/internal/service/model/dag.go
@@ -1,0 +1,81 @@
+// Package model provides transformation model management including
+// dependency extraction, DAG resolution, and materialization execution.
+package model
+
+import (
+	"sort"
+
+	"duck-demo/internal/domain"
+)
+
+// DAGNode represents a model in the execution graph.
+type DAGNode struct {
+	Model *domain.Model
+	Tier  int
+}
+
+// ResolveDAG computes execution tiers using Kahn's algorithm.
+func ResolveDAG(models []domain.Model) ([][]DAGNode, error) {
+	if len(models) == 0 {
+		return nil, nil
+	}
+
+	nameToIdx := make(map[string]int, len(models))
+	for i, m := range models {
+		nameToIdx[m.QualifiedName()] = i
+	}
+
+	inDegree := make([]int, len(models))
+	dependents := make(map[int][]int)
+
+	for i, m := range models {
+		for _, dep := range m.DependsOn {
+			depIdx, ok := nameToIdx[dep]
+			if !ok {
+				continue // physical table dep, not a model
+			}
+			if depIdx == i {
+				return nil, domain.ErrValidation("self dependency: %s", m.QualifiedName())
+			}
+			dependents[depIdx] = append(dependents[depIdx], i)
+			inDegree[i]++
+		}
+	}
+
+	var tiers [][]DAGNode
+	var queue []int
+	for i, deg := range inDegree {
+		if deg == 0 {
+			queue = append(queue, i)
+		}
+	}
+
+	processed := 0
+	tierNum := 0
+	for len(queue) > 0 {
+		sort.Ints(queue) // deterministic ordering
+		tier := make([]DAGNode, 0, len(queue))
+		for _, idx := range queue {
+			tier = append(tier, DAGNode{Model: &models[idx], Tier: tierNum})
+		}
+		tiers = append(tiers, tier)
+		processed += len(queue)
+
+		var next []int
+		for _, idx := range queue {
+			for _, dep := range dependents[idx] {
+				inDegree[dep]--
+				if inDegree[dep] == 0 {
+					next = append(next, dep)
+				}
+			}
+		}
+		queue = next
+		tierNum++
+	}
+
+	if processed != len(models) {
+		return nil, domain.ErrValidation("cycle detected in model dependencies")
+	}
+	return tiers, nil
+}

--- a/internal/service/model/dag_test.go
+++ b/internal/service/model/dag_test.go
@@ -1,0 +1,87 @@
+package model
+
+import (
+	"testing"
+
+	"duck-demo/internal/domain"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveDAG(t *testing.T) {
+	tests := []struct {
+		name      string
+		models    []domain.Model
+		wantTiers int
+		wantErr   string
+	}{
+		{
+			name:      "empty",
+			models:    nil,
+			wantTiers: 0,
+		},
+		{
+			name: "single model no deps",
+			models: []domain.Model{
+				{ProjectName: "p", Name: "a"},
+			},
+			wantTiers: 1,
+		},
+		{
+			name: "linear chain",
+			models: []domain.Model{
+				{ProjectName: "p", Name: "a"},
+				{ProjectName: "p", Name: "b", DependsOn: []string{"p.a"}},
+				{ProjectName: "p", Name: "c", DependsOn: []string{"p.b"}},
+			},
+			wantTiers: 3,
+		},
+		{
+			name: "diamond",
+			models: []domain.Model{
+				{ProjectName: "p", Name: "a"},
+				{ProjectName: "p", Name: "b", DependsOn: []string{"p.a"}},
+				{ProjectName: "p", Name: "c", DependsOn: []string{"p.a"}},
+				{ProjectName: "p", Name: "d", DependsOn: []string{"p.b", "p.c"}},
+			},
+			wantTiers: 3,
+		},
+		{
+			name: "cross-project",
+			models: []domain.Model{
+				{ProjectName: "warehouse", Name: "raw"},
+				{ProjectName: "sales", Name: "stg", DependsOn: []string{"warehouse.raw"}},
+			},
+			wantTiers: 2,
+		},
+		{
+			name: "cycle",
+			models: []domain.Model{
+				{ProjectName: "p", Name: "a", DependsOn: []string{"p.b"}},
+				{ProjectName: "p", Name: "b", DependsOn: []string{"p.a"}},
+			},
+			wantErr: "cycle detected",
+		},
+		{
+			name: "self dependency",
+			models: []domain.Model{
+				{ProjectName: "p", Name: "a", DependsOn: []string{"p.a"}},
+			},
+			wantErr: "self dependency",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tiers, err := ResolveDAG(tt.models)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Len(t, tiers, tt.wantTiers)
+		})
+	}
+}

--- a/internal/service/model/deps.go
+++ b/internal/service/model/deps.go
@@ -1,0 +1,78 @@
+package model
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"duck-demo/internal/domain"
+	"duck-demo/internal/duckdbsql"
+)
+
+// ExtractDependencies parses a model's SQL and resolves references to known models.
+// Returns qualified model names: "project.name".
+func ExtractDependencies(sqlText string, thisProject string, allModels []domain.Model) ([]string, error) {
+	stmt, err := duckdbsql.Parse(sqlText)
+	if err != nil {
+		return nil, fmt.Errorf("parse model SQL: %w", err)
+	}
+
+	// Collect all table names from the statement
+	tableRefs := duckdbsql.CollectTableNames(stmt)
+
+	// Build lookup maps
+	byQualified := make(map[string]*domain.Model, len(allModels))
+	byName := make(map[string][]*domain.Model, len(allModels))
+	for i := range allModels {
+		m := &allModels[i]
+		byQualified[m.ProjectName+"."+m.Name] = m
+		byName[m.Name] = append(byName[m.Name], m)
+	}
+
+	seen := make(map[string]bool)
+	var deps []string
+
+	for _, ref := range tableRefs {
+		if strings.HasPrefix(ref, "__func__") {
+			continue
+		}
+
+		parts := strings.SplitN(ref, ".", 2)
+
+		if len(parts) == 2 {
+			qualName := ref
+			if _, ok := byQualified[qualName]; ok {
+				if !seen[qualName] {
+					seen[qualName] = true
+					deps = append(deps, qualName)
+				}
+				continue
+			}
+		}
+
+		unqualName := ref
+		if len(parts) == 2 {
+			unqualName = parts[1]
+		}
+
+		sameProjectQual := thisProject + "." + unqualName
+		if _, ok := byQualified[sameProjectQual]; ok {
+			if !seen[sameProjectQual] {
+				seen[sameProjectQual] = true
+				deps = append(deps, sameProjectQual)
+			}
+			continue
+		}
+
+		if candidates, ok := byName[unqualName]; ok && len(candidates) == 1 {
+			qualName := candidates[0].ProjectName + "." + candidates[0].Name
+			if !seen[qualName] {
+				seen[qualName] = true
+				deps = append(deps, qualName)
+			}
+		}
+	}
+
+	sort.Strings(deps)
+	return deps, nil
+}

--- a/internal/service/model/deps_test.go
+++ b/internal/service/model/deps_test.go
@@ -1,0 +1,86 @@
+package model
+
+import (
+	"testing"
+
+	"duck-demo/internal/domain"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractDependencies(t *testing.T) {
+	allModels := []domain.Model{
+		{ProjectName: "sales", Name: "stg_orders"},
+		{ProjectName: "sales", Name: "stg_customers"},
+		{ProjectName: "warehouse", Name: "raw_events"},
+		{ProjectName: "warehouse", Name: "dim_products"},
+	}
+
+	tests := []struct {
+		name     string
+		sql      string
+		project  string
+		wantDeps []string
+		wantErr  bool
+	}{
+		{
+			name:     "no model deps",
+			sql:      "SELECT * FROM raw_data.orders",
+			project:  "sales",
+			wantDeps: []string{},
+		},
+		{
+			name:     "same-project dep",
+			sql:      "SELECT * FROM stg_customers",
+			project:  "sales",
+			wantDeps: []string{"sales.stg_customers"},
+		},
+		{
+			name:     "cross-project dep",
+			sql:      "SELECT * FROM warehouse.raw_events",
+			project:  "sales",
+			wantDeps: []string{"warehouse.raw_events"},
+		},
+		{
+			name:     "multiple deps",
+			sql:      "SELECT o.*, c.name FROM stg_orders o JOIN stg_customers c ON o.cid = c.id",
+			project:  "sales",
+			wantDeps: []string{"sales.stg_customers", "sales.stg_orders"},
+		},
+		{
+			name:     "no deps for physical table",
+			sql:      "SELECT * FROM some_physical_table",
+			project:  "sales",
+			wantDeps: []string{},
+		},
+		{
+			name:     "CTE does not appear as dep",
+			sql:      "WITH cte AS (SELECT * FROM stg_orders) SELECT * FROM cte",
+			project:  "sales",
+			wantDeps: []string{"sales.stg_orders"},
+		},
+		{
+			name:    "invalid SQL returns error",
+			sql:     "NOT VALID SQL !!@#$",
+			project: "sales",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			deps, err := ExtractDependencies(tt.sql, tt.project, allModels)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			if len(tt.wantDeps) == 0 {
+				assert.Empty(t, deps)
+			} else {
+				assert.Equal(t, tt.wantDeps, deps)
+			}
+		})
+	}
+}

--- a/internal/service/model/executor.go
+++ b/internal/service/model/executor.go
@@ -1,0 +1,434 @@
+package model
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"regexp"
+	"strings"
+
+	"duck-demo/internal/domain"
+)
+
+var validVariableName = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
+
+// ExecutionConfig holds the target resolution for a model run.
+type ExecutionConfig struct {
+	TargetCatalog string
+	TargetSchema  string
+	Variables     map[string]string
+}
+
+// executeRun processes a model run in a background goroutine.
+func (s *Service) executeRun(ctx context.Context, runID string,
+	_ []domain.Model, tiers [][]DAGNode, config ExecutionConfig, principal string) {
+
+	logger := s.logger.With("run_id", runID)
+
+	defer s.runCancels.Delete(runID)
+
+	defer func() {
+		if r := recover(); r != nil {
+			errMsg := fmt.Sprintf("panic: %v", r)
+			logger.Error("model run panicked", "error", errMsg)
+			_ = s.runs.UpdateRunFinished(ctx, runID, domain.ModelRunStatusFailed, &errMsg)
+		}
+	}()
+
+	if err := s.runs.UpdateRunStarted(ctx, runID); err != nil {
+		logger.Error("failed to update run started", "error", err)
+		return
+	}
+
+	// Build step map
+	steps, err := s.runs.ListStepsByRun(ctx, runID)
+	if err != nil {
+		errMsg := fmt.Sprintf("list steps: %v", err)
+		_ = s.runs.UpdateRunFinished(ctx, runID, domain.ModelRunStatusFailed, &errMsg)
+		return
+	}
+	stepByModelID := make(map[string]string, len(steps))
+	for _, st := range steps {
+		stepByModelID[st.ModelID] = st.ID
+	}
+
+	runFailed := false
+	cancelled := false
+
+	for _, tier := range tiers {
+		if runFailed || cancelled {
+			status := domain.ModelRunStatusSkipped
+			if cancelled {
+				status = domain.ModelRunStatusCancelled
+			}
+			for _, node := range tier {
+				stepID := stepByModelID[node.Model.ID]
+				_ = s.runs.UpdateStepFinished(ctx, stepID, status, nil, nil)
+			}
+			continue
+		}
+
+		for _, node := range tier {
+			if ctx.Err() != nil {
+				cancelled = true
+				stepID := stepByModelID[node.Model.ID]
+				_ = s.runs.UpdateStepFinished(ctx, stepID, domain.ModelRunStatusCancelled, nil, nil)
+				continue
+			}
+
+			if runFailed {
+				stepID := stepByModelID[node.Model.ID]
+				_ = s.runs.UpdateStepFinished(ctx, stepID, domain.ModelRunStatusSkipped, nil, nil)
+				continue
+			}
+
+			stepID := stepByModelID[node.Model.ID]
+			if err := s.runs.UpdateStepStarted(ctx, stepID); err != nil {
+				logger.Error("failed to update step started", "model", node.Model.QualifiedName(), "error", err)
+			}
+
+			rowsAffected, err := s.executeSingleModel(ctx, node.Model, config, principal, logger)
+			if err != nil {
+				runFailed = true
+				errMsg := err.Error()
+				_ = s.runs.UpdateStepFinished(ctx, stepID, domain.ModelRunStatusFailed, nil, &errMsg)
+				continue
+			}
+
+			// Post-materialization: contract validation and tests
+			if err := s.postMaterialize(ctx, node.Model, config, stepID, principal, logger); err != nil {
+				runFailed = true
+				errMsg := err.Error()
+				_ = s.runs.UpdateStepFinished(ctx, stepID, domain.ModelRunStatusFailed, rowsAffected, &errMsg)
+				continue
+			}
+
+			_ = s.runs.UpdateStepFinished(ctx, stepID, domain.ModelRunStatusSuccess, rowsAffected, nil)
+		}
+	}
+
+	switch {
+	case cancelled:
+		errMsg := "run was cancelled"
+		_ = s.runs.UpdateRunFinished(ctx, runID, domain.ModelRunStatusCancelled, &errMsg)
+	case runFailed:
+		errMsg := "one or more models failed"
+		_ = s.runs.UpdateRunFinished(ctx, runID, domain.ModelRunStatusFailed, &errMsg)
+	default:
+		_ = s.runs.UpdateRunFinished(ctx, runID, domain.ModelRunStatusSuccess, nil)
+	}
+}
+
+// loadMacros creates all macros on the connection before model execution.
+func (s *Service) loadMacros(ctx context.Context, conn *sql.Conn, principal string) error {
+	if s.macros == nil {
+		return nil
+	}
+
+	macros, err := s.macros.ListAll(ctx)
+	if err != nil {
+		s.logger.Warn("failed to load macros", "error", err)
+		return nil // non-fatal: continue without macros
+	}
+
+	for _, m := range macros {
+		var paramList string
+		if len(m.Parameters) > 0 {
+			paramList = strings.Join(m.Parameters, ", ")
+		}
+
+		var ddl string
+		switch m.MacroType {
+		case domain.MacroTypeTable:
+			ddl = fmt.Sprintf("CREATE OR REPLACE MACRO %s(%s) AS TABLE %s",
+				quoteIdent(m.Name), paramList, m.Body)
+		default:
+			ddl = fmt.Sprintf("CREATE OR REPLACE MACRO %s(%s) AS %s",
+				quoteIdent(m.Name), paramList, m.Body)
+		}
+
+		if err := s.execOnConn(ctx, conn, principal, ddl); err != nil {
+			s.logger.Warn("failed to create macro", "macro", m.Name, "error", err)
+			// Non-fatal: continue with other macros.
+		}
+	}
+	return nil
+}
+
+// executeSingleModel materializes one model on a pinned DuckDB connection.
+func (s *Service) executeSingleModel(ctx context.Context, model *domain.Model,
+	config ExecutionConfig, principal string, logger *slog.Logger) (*int64, error) {
+
+	logger = logger.With("model", model.QualifiedName(), "materialization", model.Materialization)
+
+	conn, err := s.duckDB.Conn(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("acquire connection: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	// Load macros before materialization.
+	if err := s.loadMacros(ctx, conn, principal); err != nil {
+		return nil, err
+	}
+
+	if err := s.injectVariables(ctx, conn, config, model, principal); err != nil {
+		return nil, err
+	}
+
+	switch model.Materialization {
+	case domain.MaterializationView:
+		if err := s.materializeView(ctx, conn, model, config, principal); err != nil {
+			return nil, err
+		}
+		logger.Info("view materialized")
+		return nil, nil
+	case domain.MaterializationTable:
+		n, err := s.materializeTable(ctx, conn, model, config, principal)
+		if err != nil {
+			return nil, err
+		}
+		logger.Info("table materialized", "rows", n)
+		return &n, nil
+	case domain.MaterializationIncremental:
+		n, err := s.materializeIncremental(ctx, conn, model, config, principal)
+		if err != nil {
+			return nil, err
+		}
+		logger.Info("incremental materialized", "rows", n)
+		return &n, nil
+	default:
+		return nil, fmt.Errorf("unsupported materialization: %s", model.Materialization)
+	}
+}
+
+func (s *Service) injectVariables(ctx context.Context, conn *sql.Conn,
+	config ExecutionConfig, model *domain.Model, principal string) error {
+	vars := map[string]string{
+		"target_catalog": config.TargetCatalog,
+		"target_schema":  config.TargetSchema,
+		"model_name":     model.Name,
+		"project_name":   model.ProjectName,
+	}
+	for k, v := range config.Variables {
+		vars[k] = v
+	}
+	for k, v := range vars {
+		if !validVariableName.MatchString(k) {
+			return fmt.Errorf("set variable: %w",
+				domain.ErrValidation("invalid variable name: %s", k))
+		}
+		escaped := strings.ReplaceAll(v, "'", "''")
+		setSQL := fmt.Sprintf("SET VARIABLE %s = '%s'", k, escaped)
+		if err := s.execOnConn(ctx, conn, principal, setSQL); err != nil {
+			return fmt.Errorf("set variable %s: %w", k, err)
+		}
+	}
+	return nil
+}
+
+func (s *Service) materializeView(ctx context.Context, conn *sql.Conn,
+	model *domain.Model, config ExecutionConfig, principal string) error {
+	ddl := fmt.Sprintf("CREATE OR REPLACE VIEW %s.%s AS (%s)",
+		quoteIdent(config.TargetSchema), quoteIdent(model.Name), model.SQL)
+	return s.execOnConn(ctx, conn, principal, ddl)
+}
+
+func (s *Service) materializeTable(ctx context.Context, conn *sql.Conn,
+	model *domain.Model, config ExecutionConfig, principal string) (int64, error) {
+	ddl := fmt.Sprintf("CREATE OR REPLACE TABLE %s.%s AS (%s)",
+		quoteIdent(config.TargetSchema), quoteIdent(model.Name), model.SQL)
+	// Execute and count rows via a separate count query
+	if err := s.execOnConn(ctx, conn, principal, ddl); err != nil {
+		return 0, err
+	}
+	// Count rows in the materialized table
+	countSQL := fmt.Sprintf("SELECT COUNT(*) FROM %s.%s",
+		quoteIdent(config.TargetSchema), quoteIdent(model.Name))
+	rows, err := s.engine.QueryOnConn(ctx, conn, principal, countSQL)
+	if err != nil {
+		return 0, nil // non-fatal: count failure doesn't fail materialization
+	}
+	defer func() { _ = rows.Close() }()
+	var count int64
+	if rows.Next() {
+		_ = rows.Scan(&count)
+	}
+	if err := rows.Err(); err != nil {
+		s.logger.Warn("row count error", "error", err)
+	}
+	return count, nil
+}
+
+func (s *Service) execOnConn(ctx context.Context, conn *sql.Conn, principal, query string) error {
+	rows, err := s.engine.QueryOnConn(ctx, conn, principal, query)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = rows.Close() }()
+	return rows.Err()
+}
+
+// postMaterialize runs contract validation and tests after a model is materialized.
+// It acquires its own connection to avoid lifecycle issues with the materialization connection.
+func (s *Service) postMaterialize(ctx context.Context, model *domain.Model,
+	config ExecutionConfig, stepID, principal string, logger *slog.Logger) error {
+
+	conn, err := s.duckDB.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("acquire connection for post-materialization: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	// Contract validation
+	if err := s.validateContract(ctx, conn, model, config, principal); err != nil {
+		logger.Error("contract validation failed", "model", model.QualifiedName(), "error", err)
+		return err
+	}
+
+	// Test execution
+	if s.tests != nil {
+		anyFailed, err := s.executeTests(ctx, conn, model, config, stepID, principal)
+		if err != nil {
+			logger.Error("test execution error", "model", model.QualifiedName(), "error", err)
+			return fmt.Errorf("test execution for %s: %w", model.QualifiedName(), err)
+		}
+		if anyFailed {
+			return fmt.Errorf("one or more tests failed for %s", model.QualifiedName())
+		}
+	}
+
+	return nil
+}
+
+func (s *Service) materializeIncremental(ctx context.Context, conn *sql.Conn,
+	model *domain.Model, config ExecutionConfig, principal string) (int64, error) {
+
+	targetFQN := quoteIdent(config.TargetSchema) + "." + quoteIdent(model.Name)
+
+	// Check if target table exists
+	exists, err := s.tableExists(ctx, conn, config.TargetSchema, model.Name, principal)
+	if err != nil {
+		return 0, fmt.Errorf("check table existence: %w", err)
+	}
+
+	if !exists {
+		// First run: full refresh
+		return s.materializeTable(ctx, conn, model, config, principal)
+	}
+
+	// Incremental: MERGE INTO
+	uniqueKeys := model.Config.UniqueKey
+	if len(uniqueKeys) == 0 {
+		return 0, domain.ErrValidation("incremental model %s requires unique_key in config", model.Name)
+	}
+
+	// Build ON clause
+	onParts := make([]string, len(uniqueKeys))
+	for i, key := range uniqueKeys {
+		qk := quoteIdent(key)
+		onParts[i] = fmt.Sprintf("target.%s = source.%s", qk, qk)
+	}
+	onClause := strings.Join(onParts, " AND ")
+
+	mergeSQL := fmt.Sprintf(
+		"MERGE INTO %s AS target USING (%s) AS source ON %s WHEN MATCHED THEN UPDATE SET * WHEN NOT MATCHED THEN INSERT *",
+		targetFQN, model.SQL, onClause)
+
+	if err := s.execOnConn(ctx, conn, principal, mergeSQL); err != nil {
+		return 0, err
+	}
+
+	// Count total rows
+	countSQL := fmt.Sprintf("SELECT COUNT(*) FROM %s", targetFQN)
+	rows, err := s.engine.QueryOnConn(ctx, conn, principal, countSQL)
+	if err != nil {
+		return 0, nil
+	}
+	defer func() { _ = rows.Close() }()
+	var count int64
+	if rows.Next() {
+		_ = rows.Scan(&count)
+	}
+	if err := rows.Err(); err != nil {
+		s.logger.Warn("row count error", "error", err)
+	}
+	return count, nil
+}
+
+func (s *Service) tableExists(ctx context.Context, conn *sql.Conn, schema, table, principal string) (bool, error) {
+	checkSQL := fmt.Sprintf(
+		"SELECT 1 FROM information_schema.tables WHERE table_schema = '%s' AND table_name = '%s'",
+		strings.ReplaceAll(schema, "'", "''"),
+		strings.ReplaceAll(table, "'", "''"),
+	)
+	rows, err := s.engine.QueryOnConn(ctx, conn, principal, checkSQL)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = rows.Close() }()
+	exists := rows.Next()
+	if err := rows.Err(); err != nil {
+		return false, err
+	}
+	return exists, nil
+}
+
+func quoteIdent(name string) string {
+	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
+}
+
+// resolveEphemeralModels injects ephemeral model SQL as CTEs into downstream models.
+// Returns only the materializable models (non-ephemeral).
+func resolveEphemeralModels(models []domain.Model) []domain.Model {
+	// Index ephemeral models
+	ephemeral := make(map[string]*domain.Model)
+	for i, m := range models {
+		if m.Materialization == domain.MaterializationEphemeral {
+			ephemeral[m.QualifiedName()] = &models[i]
+		}
+	}
+	if len(ephemeral) == 0 {
+		return models
+	}
+
+	// For each non-ephemeral model, inject dependent ephemeral CTEs
+	var result []domain.Model
+	for _, m := range models {
+		if m.Materialization == domain.MaterializationEphemeral {
+			continue // skip ephemeral models from execution
+		}
+
+		// Collect ephemeral deps (recursive)
+		ctes := collectEphemeralCTEs(&m, ephemeral, make(map[string]bool))
+		if len(ctes) > 0 {
+			// Prepend CTEs to the model SQL
+			var cteParts []string
+			for _, cte := range ctes {
+				cteParts = append(cteParts, fmt.Sprintf("%s AS (%s)", quoteIdent(cte.Name), cte.SQL))
+			}
+			m.SQL = "WITH " + strings.Join(cteParts, ", ") + " " + m.SQL
+		}
+		result = append(result, m)
+	}
+	return result
+}
+
+// collectEphemeralCTEs recursively collects ephemeral model CTEs needed by a model.
+func collectEphemeralCTEs(model *domain.Model, ephemeral map[string]*domain.Model, visited map[string]bool) []domain.Model {
+	var ctes []domain.Model
+	for _, dep := range model.DependsOn {
+		if visited[dep] {
+			continue
+		}
+		if eph, ok := ephemeral[dep]; ok {
+			visited[dep] = true
+			// Recursively resolve ephemeral deps of this ephemeral
+			nested := collectEphemeralCTEs(eph, ephemeral, visited)
+			ctes = append(ctes, nested...)
+			ctes = append(ctes, *eph)
+		}
+	}
+	return ctes
+}

--- a/internal/service/model/freshness.go
+++ b/internal/service/model/freshness.go
@@ -1,0 +1,62 @@
+package model
+
+import (
+	"context"
+	"time"
+
+	"duck-demo/internal/domain"
+)
+
+// CheckFreshness evaluates whether a model is fresh based on its freshness policy.
+func (s *Service) CheckFreshness(ctx context.Context, projectName, modelName string) (*domain.FreshnessStatus, error) {
+	m, err := s.models.GetByName(ctx, projectName, modelName)
+	if err != nil {
+		return nil, err
+	}
+
+	if m.Freshness == nil || m.Freshness.MaxLagSeconds <= 0 {
+		return &domain.FreshnessStatus{
+			IsFresh:       true,
+			MaxLagSeconds: 0,
+		}, nil
+	}
+
+	// Find the last successful run that included this model.
+	runs, _, err := s.runs.ListRuns(ctx, domain.ModelRunFilter{
+		Status: strPtr(domain.ModelRunStatusSuccess),
+		Page:   domain.PageRequest{MaxResults: 1},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	status := &domain.FreshnessStatus{
+		MaxLagSeconds: m.Freshness.MaxLagSeconds,
+	}
+
+	if len(runs) == 0 || runs[0].FinishedAt == nil {
+		// No successful run found — model is stale.
+		status.IsFresh = false
+		return status, nil
+	}
+
+	lastRun := runs[0].FinishedAt
+	status.LastRunAt = lastRun
+
+	deadline := lastRun.Add(time.Duration(m.Freshness.MaxLagSeconds) * time.Second)
+	now := time.Now()
+
+	if now.After(deadline) {
+		status.IsFresh = false
+		staleSince := deadline
+		status.StaleSince = &staleSince
+	} else {
+		status.IsFresh = true
+	}
+
+	return status, nil
+}
+
+func strPtr(s string) *string {
+	return &s
+}

--- a/internal/service/model/selector.go
+++ b/internal/service/model/selector.go
@@ -1,0 +1,147 @@
+package model
+
+import (
+	"strings"
+
+	"duck-demo/internal/domain"
+)
+
+// SelectModels filters models based on a selector string.
+// Supported syntax:
+//   - "" or "*"          — all models
+//   - "model_name"       — single model (unqualified or project.name)
+//   - "model_name+"      — model and all downstream dependents
+//   - "+model_name"      — model and all upstream dependencies
+//   - "+model_name+"     — upstream + model + downstream
+//   - "tag:finance"      — all models with tag "finance"
+//   - "project:sales"    — all models in project "sales"
+func SelectModels(selector string, allModels []domain.Model) ([]domain.Model, error) {
+	selector = strings.TrimSpace(selector)
+	if selector == "" || selector == "*" {
+		return allModels, nil
+	}
+
+	// Tag selector
+	if strings.HasPrefix(selector, "tag:") {
+		tag := strings.TrimPrefix(selector, "tag:")
+		return filterByTag(allModels, tag), nil
+	}
+
+	// Project selector
+	if strings.HasPrefix(selector, "project:") {
+		project := strings.TrimPrefix(selector, "project:")
+		return filterByProject(allModels, project), nil
+	}
+
+	// Graph selectors: +model+, +model, model+, model
+	upstream := strings.HasPrefix(selector, "+")
+	downstream := strings.HasSuffix(selector, "+")
+	modelName := strings.Trim(selector, "+")
+
+	// Find the target model
+	target := findModel(allModels, modelName)
+	if target == nil {
+		return nil, domain.ErrNotFound("model %q not found", modelName)
+	}
+
+	if !upstream && !downstream {
+		return []domain.Model{*target}, nil
+	}
+
+	// Build adjacency for graph traversal
+	byName := indexByQualifiedName(allModels)
+	selected := make(map[string]bool)
+	selected[target.QualifiedName()] = true
+
+	if upstream {
+		collectUpstream(target, byName, selected)
+	}
+	if downstream {
+		collectDownstream(target, allModels, selected)
+	}
+
+	var result []domain.Model
+	for _, m := range allModels {
+		if selected[m.QualifiedName()] {
+			result = append(result, m)
+		}
+	}
+	return result, nil
+}
+
+func filterByTag(models []domain.Model, tag string) []domain.Model {
+	var result []domain.Model
+	for _, m := range models {
+		for _, t := range m.Tags {
+			if t == tag {
+				result = append(result, m)
+				break
+			}
+		}
+	}
+	return result
+}
+
+func filterByProject(models []domain.Model, project string) []domain.Model {
+	var result []domain.Model
+	for _, m := range models {
+		if m.ProjectName == project {
+			result = append(result, m)
+		}
+	}
+	return result
+}
+
+func findModel(models []domain.Model, name string) *domain.Model {
+	// Try qualified name first
+	for i, m := range models {
+		if m.QualifiedName() == name {
+			return &models[i]
+		}
+	}
+	// Try unqualified name
+	for i, m := range models {
+		if m.Name == name {
+			return &models[i]
+		}
+	}
+	return nil
+}
+
+func indexByQualifiedName(models []domain.Model) map[string]*domain.Model {
+	idx := make(map[string]*domain.Model, len(models))
+	for i := range models {
+		idx[models[i].QualifiedName()] = &models[i]
+	}
+	return idx
+}
+
+// collectUpstream traverses the dependency graph upward.
+func collectUpstream(model *domain.Model, byName map[string]*domain.Model, selected map[string]bool) {
+	for _, dep := range model.DependsOn {
+		if selected[dep] {
+			continue
+		}
+		selected[dep] = true
+		if upstream, ok := byName[dep]; ok {
+			collectUpstream(upstream, byName, selected)
+		}
+	}
+}
+
+// collectDownstream traverses the dependency graph downward.
+func collectDownstream(model *domain.Model, allModels []domain.Model, selected map[string]bool) {
+	target := model.QualifiedName()
+	for i, m := range allModels {
+		if selected[m.QualifiedName()] {
+			continue
+		}
+		for _, dep := range m.DependsOn {
+			if dep == target {
+				selected[m.QualifiedName()] = true
+				collectDownstream(&allModels[i], allModels, selected)
+				break
+			}
+		}
+	}
+}

--- a/internal/service/model/selector_test.go
+++ b/internal/service/model/selector_test.go
@@ -1,0 +1,53 @@
+package model
+
+import (
+	"testing"
+
+	"duck-demo/internal/domain"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSelectModels(t *testing.T) {
+	models := []domain.Model{
+		{ProjectName: "p", Name: "a", Tags: []string{"finance"}},
+		{ProjectName: "p", Name: "b", DependsOn: []string{"p.a"}, Tags: []string{"finance", "staging"}},
+		{ProjectName: "p", Name: "c", DependsOn: []string{"p.b"}},
+		{ProjectName: "q", Name: "d", DependsOn: []string{"p.a"}, Tags: []string{"marketing"}},
+	}
+
+	tests := []struct {
+		name     string
+		selector string
+		want     []string // qualified names
+		wantErr  bool
+	}{
+		{name: "all (empty)", selector: "", want: []string{"p.a", "p.b", "p.c", "q.d"}},
+		{name: "all (star)", selector: "*", want: []string{"p.a", "p.b", "p.c", "q.d"}},
+		{name: "single model", selector: "p.a", want: []string{"p.a"}},
+		{name: "single model unqualified", selector: "c", want: []string{"p.c"}},
+		{name: "downstream", selector: "a+", want: []string{"p.a", "p.b", "p.c", "q.d"}},
+		{name: "upstream", selector: "+c", want: []string{"p.a", "p.b", "p.c"}},
+		{name: "both directions", selector: "+b+", want: []string{"p.a", "p.b", "p.c"}},
+		{name: "tag", selector: "tag:finance", want: []string{"p.a", "p.b"}},
+		{name: "project", selector: "project:q", want: []string{"q.d"}},
+		{name: "not found", selector: "nonexistent", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := SelectModels(tt.selector, models)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			var names []string
+			for _, m := range result {
+				names = append(names, m.QualifiedName())
+			}
+			assert.Equal(t, tt.want, names)
+		})
+	}
+}

--- a/internal/service/model/service.go
+++ b/internal/service/model/service.go
@@ -1,0 +1,476 @@
+package model
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"duck-demo/internal/domain"
+)
+
+// Service provides business logic for model management.
+type Service struct {
+	models      domain.ModelRepository
+	runs        domain.ModelRunRepository
+	tests       domain.ModelTestRepository
+	testResults domain.ModelTestResultRepository
+	audit       domain.AuditRepository
+	lineage     domain.LineageRepository
+	colLineage  domain.ColumnLineageRepository
+	macros      domain.MacroRepository
+	notebooks   domain.NotebookProvider
+	engine      domain.SessionEngine
+	duckDB      *sql.DB
+	logger      *slog.Logger
+	runCancels  sync.Map
+}
+
+// NewService creates a new model Service.
+func NewService(
+	models domain.ModelRepository,
+	runs domain.ModelRunRepository,
+	tests domain.ModelTestRepository,
+	testResults domain.ModelTestResultRepository,
+	audit domain.AuditRepository,
+	lineage domain.LineageRepository,
+	colLineage domain.ColumnLineageRepository,
+	engine domain.SessionEngine,
+	duckDB *sql.DB,
+	logger *slog.Logger,
+) *Service {
+	return &Service{
+		models:      models,
+		runs:        runs,
+		tests:       tests,
+		testResults: testResults,
+		audit:       audit,
+		lineage:     lineage,
+		colLineage:  colLineage,
+		engine:      engine,
+		duckDB:      duckDB,
+		logger:      logger,
+	}
+}
+
+// CreateModel creates a new transformation model and auto-extracts its dependencies.
+func (s *Service) CreateModel(ctx context.Context, principal string, req domain.CreateModelRequest) (*domain.Model, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+
+	allModels, err := s.models.ListAll(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list models for dep extraction: %w", err)
+	}
+
+	deps, err := ExtractDependencies(req.SQL, req.ProjectName, allModels)
+	if err != nil {
+		s.logger.Warn("dependency extraction failed", "project", req.ProjectName, "model", req.Name, "error", err)
+		deps = []string{}
+	}
+
+	m := &domain.Model{
+		ProjectName:     req.ProjectName,
+		Name:            req.Name,
+		SQL:             req.SQL,
+		Materialization: req.Materialization,
+		Description:     req.Description,
+		Tags:            req.Tags,
+		DependsOn:       deps,
+		Config:          req.Config,
+		CreatedBy:       principal,
+	}
+
+	result, err := s.models.Create(ctx, m)
+	if err != nil {
+		return nil, err
+	}
+
+	s.logAudit(ctx, principal, "create_model", result.QualifiedName())
+	return result, nil
+}
+
+// GetModel retrieves a model by project and name.
+func (s *Service) GetModel(ctx context.Context, projectName, name string) (*domain.Model, error) {
+	return s.models.GetByName(ctx, projectName, name)
+}
+
+// ListModels returns a paginated list of models, optionally filtered by project.
+func (s *Service) ListModels(ctx context.Context, projectName *string, page domain.PageRequest) ([]domain.Model, int64, error) {
+	return s.models.List(ctx, projectName, page)
+}
+
+// UpdateModel updates a model and re-extracts dependencies if SQL changed.
+func (s *Service) UpdateModel(ctx context.Context, principal, projectName, name string, req domain.UpdateModelRequest) (*domain.Model, error) {
+	existing, err := s.models.GetByName(ctx, projectName, name)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := s.models.Update(ctx, existing.ID, req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Re-extract deps if SQL changed
+	if req.SQL != nil {
+		allModels, err := s.models.ListAll(ctx)
+		if err == nil {
+			deps, depErr := ExtractDependencies(*req.SQL, projectName, allModels)
+			if depErr != nil {
+				s.logger.Warn("dependency re-extraction failed", "model", result.QualifiedName(), "error", depErr)
+			} else {
+				_ = s.models.UpdateDependencies(ctx, result.ID, deps)
+				result.DependsOn = deps
+			}
+		}
+	}
+
+	s.logAudit(ctx, principal, "update_model", result.QualifiedName())
+	return result, nil
+}
+
+// DeleteModel deletes a model.
+func (s *Service) DeleteModel(ctx context.Context, principal, projectName, name string) error {
+	existing, err := s.models.GetByName(ctx, projectName, name)
+	if err != nil {
+		return err
+	}
+
+	if err := s.models.Delete(ctx, existing.ID); err != nil {
+		return err
+	}
+
+	s.logAudit(ctx, principal, "delete_model", existing.QualifiedName())
+	return nil
+}
+
+// GetDAG computes the DAG for all models, optionally filtered by project.
+func (s *Service) GetDAG(ctx context.Context, projectName *string) ([][]DAGNode, error) {
+	var models []domain.Model
+	var err error
+	if projectName != nil {
+		models, _, err = s.models.List(ctx, projectName, domain.PageRequest{MaxResults: 10000})
+	} else {
+		models, err = s.models.ListAll(ctx)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return ResolveDAG(models)
+}
+
+// TriggerRun starts a model run.
+func (s *Service) TriggerRun(ctx context.Context, principal string, req domain.TriggerModelRunRequest) (*domain.ModelRun, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+	if req.TriggerType == "" {
+		req.TriggerType = domain.ModelTriggerTypeManual
+	}
+
+	// Load models
+	allModels, err := s.models.ListAll(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("load models: %w", err)
+	}
+	if len(allModels) == 0 {
+		return nil, domain.ErrValidation("no models defined")
+	}
+
+	selected := allModels
+	if req.Selector != "" {
+		selected, err = SelectModels(req.Selector, allModels)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Resolve ephemeral models: inject CTEs and remove from execution set
+	selected = resolveEphemeralModels(selected)
+
+	// Resolve DAG
+	tiers, err := ResolveDAG(selected)
+	if err != nil {
+		return nil, fmt.Errorf("resolve DAG: %w", err)
+	}
+
+	// Create run
+	run := &domain.ModelRun{
+		Status:        domain.ModelRunStatusPending,
+		TriggerType:   req.TriggerType,
+		TriggeredBy:   principal,
+		TargetCatalog: req.TargetCatalog,
+		TargetSchema:  req.TargetSchema,
+		ModelSelector: req.Selector,
+		Variables:     req.Variables,
+	}
+	run, err = s.runs.CreateRun(ctx, run)
+	if err != nil {
+		return nil, fmt.Errorf("create run: %w", err)
+	}
+
+	// Create steps
+	for _, tier := range tiers {
+		for _, node := range tier {
+			step := &domain.ModelRunStep{
+				RunID:     run.ID,
+				ModelID:   node.Model.ID,
+				ModelName: node.Model.QualifiedName(),
+				Status:    domain.ModelRunStatusPending,
+				Tier:      node.Tier,
+			}
+			if _, err := s.runs.CreateStep(ctx, step); err != nil {
+				return nil, fmt.Errorf("create step for %s: %w", node.Model.QualifiedName(), err)
+			}
+		}
+	}
+
+	// Launch execution goroutine
+	runCtx, cancel := context.WithCancel(context.Background())
+	s.runCancels.Store(run.ID, cancel)
+	config := ExecutionConfig{
+		TargetCatalog: req.TargetCatalog,
+		TargetSchema:  req.TargetSchema,
+		Variables:     req.Variables,
+	}
+	go s.executeRun(runCtx, run.ID, selected, tiers, config, principal)
+
+	s.logAudit(ctx, principal, "trigger_model_run", run.ID)
+	return run, nil
+}
+
+// TriggerRunSync starts a model run and waits for it to complete synchronously.
+// Used by the pipeline executor for MODEL_RUN jobs.
+func (s *Service) TriggerRunSync(ctx context.Context, principal string, req domain.TriggerModelRunRequest) error {
+	if err := req.Validate(); err != nil {
+		return err
+	}
+	if req.TriggerType == "" {
+		req.TriggerType = domain.ModelTriggerTypePipeline
+	}
+
+	// Load models
+	allModels, err := s.models.ListAll(ctx)
+	if err != nil {
+		return fmt.Errorf("load models: %w", err)
+	}
+	if len(allModels) == 0 {
+		return domain.ErrValidation("no models defined")
+	}
+
+	selected := allModels
+	if req.Selector != "" {
+		selected, err = SelectModels(req.Selector, allModels)
+		if err != nil {
+			return err
+		}
+	}
+
+	selected = resolveEphemeralModels(selected)
+
+	tiers, err := ResolveDAG(selected)
+	if err != nil {
+		return fmt.Errorf("resolve DAG: %w", err)
+	}
+
+	// Create run
+	run := &domain.ModelRun{
+		Status:        domain.ModelRunStatusPending,
+		TriggerType:   req.TriggerType,
+		TriggeredBy:   principal,
+		TargetCatalog: req.TargetCatalog,
+		TargetSchema:  req.TargetSchema,
+		ModelSelector: req.Selector,
+		Variables:     req.Variables,
+	}
+	run, err = s.runs.CreateRun(ctx, run)
+	if err != nil {
+		return fmt.Errorf("create run: %w", err)
+	}
+
+	// Create steps
+	for _, tier := range tiers {
+		for _, node := range tier {
+			step := &domain.ModelRunStep{
+				RunID:     run.ID,
+				ModelID:   node.Model.ID,
+				ModelName: node.Model.QualifiedName(),
+				Status:    domain.ModelRunStatusPending,
+				Tier:      node.Tier,
+			}
+			if _, err := s.runs.CreateStep(ctx, step); err != nil {
+				return fmt.Errorf("create step for %s: %w", node.Model.QualifiedName(), err)
+			}
+		}
+	}
+
+	// Execute synchronously (no goroutine)
+	config := ExecutionConfig{
+		TargetCatalog: req.TargetCatalog,
+		TargetSchema:  req.TargetSchema,
+		Variables:     req.Variables,
+	}
+	s.executeRun(ctx, run.ID, selected, tiers, config, principal)
+
+	// Check final status
+	finalRun, err := s.runs.GetRunByID(ctx, run.ID)
+	if err != nil {
+		return fmt.Errorf("get final run status: %w", err)
+	}
+	if finalRun.Status != domain.ModelRunStatusSuccess {
+		msg := "model run failed"
+		if finalRun.ErrorMessage != nil {
+			msg = *finalRun.ErrorMessage
+		}
+		return fmt.Errorf("model run %s: %s", finalRun.Status, msg)
+	}
+
+	return nil
+}
+
+// GetRun retrieves a model run.
+func (s *Service) GetRun(ctx context.Context, runID string) (*domain.ModelRun, error) {
+	return s.runs.GetRunByID(ctx, runID)
+}
+
+// ListRuns returns a filtered list of model runs.
+func (s *Service) ListRuns(ctx context.Context, filter domain.ModelRunFilter) ([]domain.ModelRun, int64, error) {
+	return s.runs.ListRuns(ctx, filter)
+}
+
+// ListRunSteps returns the steps for a model run.
+func (s *Service) ListRunSteps(ctx context.Context, runID string) ([]domain.ModelRunStep, error) {
+	return s.runs.ListStepsByRun(ctx, runID)
+}
+
+// CancelRun cancels a running model execution.
+func (s *Service) CancelRun(ctx context.Context, principal, runID string) error {
+	run, err := s.runs.GetRunByID(ctx, runID)
+	if err != nil {
+		return err
+	}
+	if run.Status != domain.ModelRunStatusPending && run.Status != domain.ModelRunStatusRunning {
+		return domain.ErrValidation("cannot cancel run in status %s", run.Status)
+	}
+
+	if cancelFn, ok := s.runCancels.LoadAndDelete(runID); ok {
+		cancelFn.(context.CancelFunc)()
+	}
+
+	errMsg := "cancelled by " + principal
+	return s.runs.UpdateRunFinished(ctx, runID, domain.ModelRunStatusCancelled, &errMsg)
+}
+
+// SetTestRepos sets the test and test result repositories on the service.
+// This allows injecting these optional dependencies after construction.
+func (s *Service) SetTestRepos(tests domain.ModelTestRepository, testResults domain.ModelTestResultRepository) {
+	s.tests = tests
+	s.testResults = testResults
+}
+
+// SetMacroRepo sets the macro repository for loading macros during model runs.
+func (s *Service) SetMacroRepo(macros domain.MacroRepository) {
+	s.macros = macros
+}
+
+// SetNotebookProvider sets the notebook provider for notebook-to-model promotion.
+func (s *Service) SetNotebookProvider(notebooks domain.NotebookProvider) {
+	s.notebooks = notebooks
+}
+
+// CreateTest creates a new test assertion for a model.
+func (s *Service) CreateTest(ctx context.Context, principal, projectName, modelName string, req domain.CreateModelTestRequest) (*domain.ModelTest, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+	model, err := s.models.GetByName(ctx, projectName, modelName)
+	if err != nil {
+		return nil, err
+	}
+	test := &domain.ModelTest{
+		ModelID:  model.ID,
+		Name:     req.Name,
+		TestType: req.TestType,
+		Column:   req.Column,
+		Config:   req.Config,
+	}
+	result, err := s.tests.Create(ctx, test)
+	if err != nil {
+		return nil, err
+	}
+	s.logAudit(ctx, principal, "create_model_test", model.QualifiedName()+"/"+req.Name)
+	return result, nil
+}
+
+// ListTests returns all tests for a model.
+func (s *Service) ListTests(ctx context.Context, projectName, modelName string) ([]domain.ModelTest, error) {
+	model, err := s.models.GetByName(ctx, projectName, modelName)
+	if err != nil {
+		return nil, err
+	}
+	return s.tests.ListByModel(ctx, model.ID)
+}
+
+// DeleteTest deletes a model test.
+func (s *Service) DeleteTest(ctx context.Context, principal, projectName, modelName, testID string) error {
+	// Verify the model exists.
+	_, err := s.models.GetByName(ctx, projectName, modelName)
+	if err != nil {
+		return err
+	}
+	if err := s.tests.Delete(ctx, testID); err != nil {
+		return err
+	}
+	s.logAudit(ctx, principal, "delete_model_test", testID)
+	return nil
+}
+
+// ListTestResults returns all test results for a model run step.
+func (s *Service) ListTestResults(ctx context.Context, _, stepID string) ([]domain.ModelTestResult, error) {
+	return s.testResults.ListByStep(ctx, stepID)
+}
+
+// PromoteNotebook promotes a notebook cell to a transformation model.
+func (s *Service) PromoteNotebook(ctx context.Context, principal string, req domain.PromoteNotebookRequest) (*domain.Model, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+
+	if s.notebooks == nil {
+		return nil, domain.ErrValidation("notebook provider not configured")
+	}
+
+	// Get SQL blocks from the notebook.
+	blocks, err := s.notebooks.GetSQLBlocks(ctx, req.NotebookID)
+	if err != nil {
+		return nil, fmt.Errorf("get notebook SQL: %w", err)
+	}
+
+	if req.CellIndex >= len(blocks) {
+		return nil, domain.ErrValidation("cell_index %d out of range (notebook has %d SQL cells)", req.CellIndex, len(blocks))
+	}
+
+	sqlBody := blocks[req.CellIndex]
+	if sqlBody == "" {
+		return nil, domain.ErrValidation("selected cell has empty SQL")
+	}
+
+	// Create the model with the extracted SQL.
+	return s.CreateModel(ctx, principal, domain.CreateModelRequest{
+		ProjectName:     req.ProjectName,
+		Name:            req.Name,
+		SQL:             sqlBody,
+		Materialization: req.Materialization,
+	})
+}
+
+func (s *Service) logAudit(ctx context.Context, principal, action, _ string) {
+	_ = s.audit.Insert(ctx, &domain.AuditEntry{
+		PrincipalName: principal,
+		Action:        action,
+		Status:        "SUCCESS",
+	})
+}

--- a/internal/service/model/tests.go
+++ b/internal/service/model/tests.go
@@ -1,0 +1,120 @@
+package model
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"duck-demo/internal/domain"
+)
+
+// generateTestSQL builds the SQL query for a model test.
+// The test passes if 0 rows are returned.
+func generateTestSQL(test domain.ModelTest, targetSchema, modelName string) (string, error) {
+	fqn := quoteIdent(targetSchema) + "." + quoteIdent(modelName)
+	col := quoteIdent(test.Column)
+
+	switch test.TestType {
+	case domain.TestTypeNotNull:
+		return fmt.Sprintf("SELECT * FROM %s WHERE %s IS NULL LIMIT 1", fqn, col), nil
+	case domain.TestTypeUnique:
+		return fmt.Sprintf("SELECT %s, COUNT(*) AS cnt FROM %s GROUP BY %s HAVING cnt > 1 LIMIT 1", col, fqn, col), nil
+	case domain.TestTypeAcceptedValues:
+		if len(test.Config.Values) == 0 {
+			return "", fmt.Errorf("accepted_values test requires values")
+		}
+		vals := make([]string, len(test.Config.Values))
+		for i, v := range test.Config.Values {
+			vals[i] = "'" + strings.ReplaceAll(v, "'", "''") + "'"
+		}
+		return fmt.Sprintf("SELECT * FROM %s WHERE %s NOT IN (%s) LIMIT 1",
+			fqn, col, strings.Join(vals, ", ")), nil
+	case domain.TestTypeRelationships:
+		toFqn := quoteIdent(targetSchema) + "." + quoteIdent(test.Config.ToModel)
+		toCol := quoteIdent(test.Config.ToColumn)
+		return fmt.Sprintf(
+			"SELECT a.%s FROM %s a LEFT JOIN %s b ON a.%s = b.%s WHERE b.%s IS NULL LIMIT 1",
+			col, fqn, toFqn, col, toCol, toCol), nil
+	case domain.TestTypeCustomSQL:
+		return test.Config.SQL, nil
+	default:
+		return "", fmt.Errorf("unknown test type: %s", test.TestType)
+	}
+}
+
+// executeTests runs all tests for a model after materialization.
+// Returns whether any test failed and any error encountered.
+func (s *Service) executeTests(ctx context.Context, conn *sql.Conn,
+	model *domain.Model, config ExecutionConfig, stepID, principal string) (bool, error) {
+
+	tests, err := s.tests.ListByModel(ctx, model.ID)
+	if err != nil {
+		return false, fmt.Errorf("list tests for %s: %w", model.QualifiedName(), err)
+	}
+	if len(tests) == 0 {
+		return false, nil
+	}
+
+	anyFailed := false
+	for _, test := range tests {
+		testSQL, err := generateTestSQL(test, config.TargetSchema, model.Name)
+		if err != nil {
+			// Record error result
+			s.recordTestResult(ctx, stepID, test, domain.TestResultError, nil, err.Error())
+			anyFailed = true
+			continue
+		}
+
+		hasRows, queryErr := s.runTestQuery(ctx, conn, principal, testSQL)
+		if queryErr != nil {
+			s.recordTestResult(ctx, stepID, test, domain.TestResultError, nil, queryErr.Error())
+			anyFailed = true
+			continue
+		}
+
+		if hasRows {
+			var rowCount int64 = 1
+			s.recordTestResult(ctx, stepID, test, domain.TestResultFail, &rowCount, "")
+			anyFailed = true
+		} else {
+			var rowCount int64
+			s.recordTestResult(ctx, stepID, test, domain.TestResultPass, &rowCount, "")
+		}
+	}
+
+	return anyFailed, nil
+}
+
+// runTestQuery executes a test query and returns whether any rows were returned.
+func (s *Service) runTestQuery(ctx context.Context, conn *sql.Conn, principal, testSQL string) (bool, error) {
+	rows, err := s.engine.QueryOnConn(ctx, conn, principal, testSQL)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	hasRows := rows.Next()
+	if err := rows.Err(); err != nil {
+		return false, err
+	}
+	return hasRows, nil
+}
+
+func (s *Service) recordTestResult(ctx context.Context, stepID string, test domain.ModelTest, status string, rowsReturned *int64, errMsg string) {
+	result := &domain.ModelTestResult{
+		RunStepID:    stepID,
+		TestID:       test.ID,
+		TestName:     test.Name,
+		Status:       status,
+		RowsReturned: rowsReturned,
+	}
+	if errMsg != "" {
+		result.ErrorMessage = &errMsg
+	}
+	if s.testResults != nil {
+		if _, err := s.testResults.Create(ctx, result); err != nil {
+			s.logger.Warn("failed to record test result", "test", test.Name, "error", err)
+		}
+	}
+}

--- a/internal/service/model/tests_test.go
+++ b/internal/service/model/tests_test.go
@@ -1,0 +1,85 @@
+package model
+
+import (
+	"testing"
+
+	"duck-demo/internal/domain"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateTestSQL(t *testing.T) {
+	tests := []struct {
+		name    string
+		test    domain.ModelTest
+		schema  string
+		model   string
+		wantSQL string
+		wantErr bool
+	}{
+		{
+			name:    "not_null",
+			test:    domain.ModelTest{TestType: "not_null", Column: "id"},
+			schema:  "analytics",
+			model:   "orders",
+			wantSQL: `SELECT * FROM "analytics"."orders" WHERE "id" IS NULL LIMIT 1`,
+		},
+		{
+			name:    "unique",
+			test:    domain.ModelTest{TestType: "unique", Column: "email"},
+			schema:  "analytics",
+			model:   "users",
+			wantSQL: `SELECT "email", COUNT(*) AS cnt FROM "analytics"."users" GROUP BY "email" HAVING cnt > 1 LIMIT 1`,
+		},
+		{
+			name: "accepted_values",
+			test: domain.ModelTest{
+				TestType: "accepted_values", Column: "status",
+				Config: domain.ModelTestConfig{Values: []string{"active", "inactive"}},
+			},
+			schema:  "analytics",
+			model:   "orders",
+			wantSQL: `SELECT * FROM "analytics"."orders" WHERE "status" NOT IN ('active', 'inactive') LIMIT 1`,
+		},
+		{
+			name: "relationships",
+			test: domain.ModelTest{
+				TestType: "relationships", Column: "customer_id",
+				Config: domain.ModelTestConfig{ToModel: "customers", ToColumn: "id"},
+			},
+			schema:  "analytics",
+			model:   "orders",
+			wantSQL: `SELECT a."customer_id" FROM "analytics"."orders" a LEFT JOIN "analytics"."customers" b ON a."customer_id" = b."id" WHERE b."id" IS NULL LIMIT 1`,
+		},
+		{
+			name: "custom_sql",
+			test: domain.ModelTest{
+				TestType: "custom_sql",
+				Config:   domain.ModelTestConfig{SQL: "SELECT 1 WHERE 1=0"},
+			},
+			schema:  "analytics",
+			model:   "orders",
+			wantSQL: "SELECT 1 WHERE 1=0",
+		},
+		{
+			name:    "unknown type",
+			test:    domain.ModelTest{TestType: "invalid"},
+			schema:  "analytics",
+			model:   "orders",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sql, err := generateTestSQL(tt.test, tt.schema, tt.model)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantSQL, sql)
+		})
+	}
+}

--- a/pkg/apilint/functions.go
+++ b/pkg/apilint/functions.go
@@ -374,7 +374,7 @@ var actionVerbSet = map[string]bool{
 	"loadTableExternalFiles": true, "purgeLineage": true, "cleanupExpiredAPIKeys": true,
 	"createManifest": true, "createUploadUrl": true, "searchCatalog": true,
 	"setDefaultCatalog": true, "reorderCells": true, "executeCell": true,
-	"runAllCells": true, "syncGitRepo": true, "cancelPipelineRun": true,
+	"runAllCells": true, "syncGitRepo": true, "cancelPipelineRun": true, "cancelModelRun": true,
 	"triggerPipelineRun": true,
 }
 

--- a/test/integration/models_http_test.go
+++ b/test/integration/models_http_test.go
@@ -1,0 +1,928 @@
+//go:build integration
+
+package integration
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// Model CRUD
+// ---------------------------------------------------------------------------
+
+// TestHTTP_ModelCRUD exercises the full model lifecycle via the HTTP API:
+// create → get → list → update → delete, with error cases interspersed.
+func TestHTTP_ModelCRUD(t *testing.T) {
+	env := setupHTTPServer(t, httpTestOpts{WithModels: true})
+
+	type step struct {
+		name string
+		fn   func(t *testing.T)
+	}
+
+	steps := []step{
+		{"create_model", func(t *testing.T) {
+			resp := doRequest(t, "POST", env.Server.URL+"/v1/models", env.Keys.Admin, map[string]interface{}{
+				"project_name":    "analytics",
+				"name":            "stg_orders",
+				"sql":             "SELECT 1 AS id, 'test' AS name",
+				"materialization": "VIEW",
+				"description":     "Staging orders model",
+				"tags":            []string{"staging", "orders"},
+			})
+			require.Equal(t, 201, resp.StatusCode)
+
+			var result map[string]interface{}
+			decodeJSON(t, resp, &result)
+			assert.Equal(t, "analytics", result["project_name"])
+			assert.Equal(t, "stg_orders", result["name"])
+			assert.Equal(t, "SELECT 1 AS id, 'test' AS name", result["sql"])
+			assert.Equal(t, "VIEW", result["materialization"])
+			assert.Equal(t, "Staging orders model", result["description"])
+			assert.NotEmpty(t, result["id"])
+			assert.NotNil(t, result["created_at"])
+		}},
+
+		{"create_model_duplicate_409", func(t *testing.T) {
+			resp := doRequest(t, "POST", env.Server.URL+"/v1/models", env.Keys.Admin, map[string]interface{}{
+				"project_name": "analytics",
+				"name":         "stg_orders",
+				"sql":          "SELECT 1",
+			})
+			defer resp.Body.Close() //nolint:errcheck
+			require.Equal(t, 409, resp.StatusCode)
+		}},
+
+		{"create_model_missing_name_400", func(t *testing.T) {
+			resp := doRequest(t, "POST", env.Server.URL+"/v1/models", env.Keys.Admin, map[string]interface{}{
+				"project_name": "analytics",
+				"sql":          "SELECT 1",
+			})
+			defer resp.Body.Close() //nolint:errcheck
+			require.Equal(t, 400, resp.StatusCode)
+		}},
+
+		{"create_model_missing_sql_400", func(t *testing.T) {
+			resp := doRequest(t, "POST", env.Server.URL+"/v1/models", env.Keys.Admin, map[string]interface{}{
+				"project_name": "analytics",
+				"name":         "empty_sql_model",
+			})
+			defer resp.Body.Close() //nolint:errcheck
+			require.Equal(t, 400, resp.StatusCode)
+		}},
+
+		{"get_model", func(t *testing.T) {
+			resp := doRequest(t, "GET", env.Server.URL+"/v1/models/analytics/stg_orders", env.Keys.Admin, nil)
+			require.Equal(t, 200, resp.StatusCode)
+
+			var result map[string]interface{}
+			decodeJSON(t, resp, &result)
+			assert.Equal(t, "analytics", result["project_name"])
+			assert.Equal(t, "stg_orders", result["name"])
+			assert.Equal(t, "VIEW", result["materialization"])
+		}},
+
+		{"get_model_not_found_404", func(t *testing.T) {
+			resp := doRequest(t, "GET", env.Server.URL+"/v1/models/analytics/nonexistent", env.Keys.Admin, nil)
+			defer resp.Body.Close() //nolint:errcheck
+			require.Equal(t, 404, resp.StatusCode)
+		}},
+
+		{"list_models", func(t *testing.T) {
+			resp := doRequest(t, "GET", env.Server.URL+"/v1/models", env.Keys.Admin, nil)
+			require.Equal(t, 200, resp.StatusCode)
+
+			var result map[string]interface{}
+			decodeJSON(t, resp, &result)
+			data := result["data"].([]interface{})
+			assert.GreaterOrEqual(t, len(data), 1)
+		}},
+
+		{"list_models_by_project", func(t *testing.T) {
+			resp := doRequest(t, "GET", env.Server.URL+"/v1/models?project_name=analytics", env.Keys.Admin, nil)
+			require.Equal(t, 200, resp.StatusCode)
+
+			var result map[string]interface{}
+			decodeJSON(t, resp, &result)
+			data := result["data"].([]interface{})
+			assert.GreaterOrEqual(t, len(data), 1)
+			// All returned models should be in the analytics project
+			for _, item := range data {
+				m := item.(map[string]interface{})
+				assert.Equal(t, "analytics", m["project_name"])
+			}
+		}},
+
+		{"update_model", func(t *testing.T) {
+			resp := doRequest(t, "PATCH", env.Server.URL+"/v1/models/analytics/stg_orders", env.Keys.Admin, map[string]interface{}{
+				"sql":         "SELECT 1 AS id, 'updated' AS name",
+				"description": "Updated staging orders",
+			})
+			require.Equal(t, 200, resp.StatusCode)
+
+			var result map[string]interface{}
+			decodeJSON(t, resp, &result)
+			assert.Equal(t, "SELECT 1 AS id, 'updated' AS name", result["sql"])
+			assert.Equal(t, "Updated staging orders", result["description"])
+		}},
+
+		{"update_model_not_found_404", func(t *testing.T) {
+			resp := doRequest(t, "PATCH", env.Server.URL+"/v1/models/analytics/nonexistent", env.Keys.Admin, map[string]interface{}{
+				"description": "nope",
+			})
+			defer resp.Body.Close() //nolint:errcheck
+			require.Equal(t, 404, resp.StatusCode)
+		}},
+
+		{"delete_model", func(t *testing.T) {
+			resp := doRequest(t, "DELETE", env.Server.URL+"/v1/models/analytics/stg_orders", env.Keys.Admin, nil)
+			defer resp.Body.Close() //nolint:errcheck
+			require.Equal(t, 204, resp.StatusCode)
+		}},
+
+		{"delete_model_not_found_404", func(t *testing.T) {
+			resp := doRequest(t, "DELETE", env.Server.URL+"/v1/models/analytics/stg_orders", env.Keys.Admin, nil)
+			defer resp.Body.Close() //nolint:errcheck
+			require.Equal(t, 404, resp.StatusCode)
+		}},
+
+		{"get_deleted_model_404", func(t *testing.T) {
+			resp := doRequest(t, "GET", env.Server.URL+"/v1/models/analytics/stg_orders", env.Keys.Admin, nil)
+			defer resp.Body.Close() //nolint:errcheck
+			require.Equal(t, 404, resp.StatusCode)
+		}},
+	}
+
+	for _, s := range steps {
+		if !t.Run(s.name, s.fn) {
+			t.FailNow()
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Model Dependencies + DAG
+// ---------------------------------------------------------------------------
+
+// TestHTTP_ModelDependenciesAndDAG verifies that auto-dependency extraction
+// populates depends_on and that the DAG endpoint returns correct tiers.
+func TestHTTP_ModelDependenciesAndDAG(t *testing.T) {
+	env := setupHTTPServer(t, httpTestOpts{WithModels: true})
+
+	type step struct {
+		name string
+		fn   func(t *testing.T)
+	}
+
+	steps := []step{
+		{"create_base_model", func(t *testing.T) {
+			resp := doRequest(t, "POST", env.Server.URL+"/v1/models", env.Keys.Admin, map[string]interface{}{
+				"project_name":    "warehouse",
+				"name":            "raw_events",
+				"sql":             "SELECT 1 AS event_id, 'click' AS event_type",
+				"materialization": "TABLE",
+			})
+			require.Equal(t, 201, resp.StatusCode)
+			_ = resp.Body.Close()
+		}},
+
+		{"create_dependent_model", func(t *testing.T) {
+			// This model references warehouse.raw_events — dependency should be auto-extracted.
+			resp := doRequest(t, "POST", env.Server.URL+"/v1/models", env.Keys.Admin, map[string]interface{}{
+				"project_name":    "warehouse",
+				"name":            "stg_events",
+				"sql":             "SELECT event_id, event_type FROM warehouse.raw_events WHERE event_type = 'click'",
+				"materialization": "VIEW",
+			})
+			require.Equal(t, 201, resp.StatusCode)
+
+			var result map[string]interface{}
+			decodeJSON(t, resp, &result)
+			// Verify depends_on was auto-populated
+			deps, ok := result["depends_on"].([]interface{})
+			if assert.True(t, ok, "depends_on should be present") {
+				assert.Contains(t, deps, "warehouse.raw_events")
+			}
+		}},
+
+		{"create_downstream_model", func(t *testing.T) {
+			// References stg_events (same project — resolved as warehouse.stg_events)
+			resp := doRequest(t, "POST", env.Server.URL+"/v1/models", env.Keys.Admin, map[string]interface{}{
+				"project_name":    "warehouse",
+				"name":            "mart_events",
+				"sql":             "SELECT event_id FROM warehouse.stg_events",
+				"materialization": "TABLE",
+			})
+			require.Equal(t, 201, resp.StatusCode)
+
+			var result map[string]interface{}
+			decodeJSON(t, resp, &result)
+			deps, ok := result["depends_on"].([]interface{})
+			if assert.True(t, ok, "depends_on should be present") {
+				assert.Contains(t, deps, "warehouse.stg_events")
+			}
+		}},
+
+		{"get_dag", func(t *testing.T) {
+			resp := doRequest(t, "GET", env.Server.URL+"/v1/models/dag", env.Keys.Admin, nil)
+			require.Equal(t, 200, resp.StatusCode)
+
+			var result map[string]interface{}
+			decodeJSON(t, resp, &result)
+			tiers, ok := result["tiers"].([]interface{})
+			require.True(t, ok, "DAG should have tiers")
+			// With 3 models in a chain: raw_events → stg_events → mart_events
+			// We expect at least 2 tiers (tier 0 = root, tier 1+ = downstream)
+			assert.GreaterOrEqual(t, len(tiers), 2, "DAG should have at least 2 tiers")
+
+			// Verify tier 0 contains raw_events (the root)
+			tier0 := tiers[0].(map[string]interface{})
+			nodes0 := tier0["nodes"].([]interface{})
+			foundRoot := false
+			for _, n := range nodes0 {
+				node := n.(map[string]interface{})
+				if node["model_name"] == "raw_events" {
+					foundRoot = true
+				}
+			}
+			assert.True(t, foundRoot, "tier 0 should contain raw_events")
+		}},
+
+		{"get_dag_filtered_by_project", func(t *testing.T) {
+			resp := doRequest(t, "GET", env.Server.URL+"/v1/models/dag?project_name=warehouse", env.Keys.Admin, nil)
+			require.Equal(t, 200, resp.StatusCode)
+
+			var result map[string]interface{}
+			decodeJSON(t, resp, &result)
+			tiers, ok := result["tiers"].([]interface{})
+			require.True(t, ok)
+			assert.GreaterOrEqual(t, len(tiers), 1)
+		}},
+	}
+
+	for _, s := range steps {
+		if !t.Run(s.name, s.fn) {
+			t.FailNow()
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Model Materialization Variants
+// ---------------------------------------------------------------------------
+
+// TestHTTP_ModelMaterializations verifies that different materialization types
+// can be created and have correct default behavior.
+func TestHTTP_ModelMaterializations(t *testing.T) {
+	env := setupHTTPServer(t, httpTestOpts{WithModels: true})
+
+	tests := []struct {
+		name string
+		mat  string
+	}{
+		{"view", "VIEW"},
+		{"table", "TABLE"},
+		{"incremental", "INCREMENTAL"},
+		{"ephemeral", "EPHEMERAL"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			body := map[string]interface{}{
+				"project_name":    "mattest",
+				"name":            "model_" + tc.name,
+				"sql":             "SELECT 1 AS id",
+				"materialization": tc.mat,
+			}
+			if tc.mat == "INCREMENTAL" {
+				body["config"] = map[string]interface{}{
+					"unique_key":           []string{"id"},
+					"incremental_strategy": "merge",
+				}
+			}
+			resp := doRequest(t, "POST", env.Server.URL+"/v1/models", env.Keys.Admin, body)
+			require.Equal(t, 201, resp.StatusCode)
+
+			var result map[string]interface{}
+			decodeJSON(t, resp, &result)
+			assert.Equal(t, tc.mat, result["materialization"])
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Model Tests CRUD
+// ---------------------------------------------------------------------------
+
+// TestHTTP_ModelTestCRUD exercises model test lifecycle: create test → list → delete.
+func TestHTTP_ModelTestCRUD(t *testing.T) {
+	env := setupHTTPServer(t, httpTestOpts{WithModels: true})
+
+	var testID string
+
+	type step struct {
+		name string
+		fn   func(t *testing.T)
+	}
+
+	steps := []step{
+		{"create_model_for_tests", func(t *testing.T) {
+			resp := doRequest(t, "POST", env.Server.URL+"/v1/models", env.Keys.Admin, map[string]interface{}{
+				"project_name":    "testing",
+				"name":            "users",
+				"sql":             "SELECT 1 AS user_id, 'Alice' AS name, 'active' AS status",
+				"materialization": "TABLE",
+			})
+			require.Equal(t, 201, resp.StatusCode)
+			_ = resp.Body.Close()
+		}},
+
+		{"create_not_null_test", func(t *testing.T) {
+			resp := doRequest(t, "POST",
+				env.Server.URL+"/v1/models/testing/users/tests",
+				env.Keys.Admin, map[string]interface{}{
+					"name":      "user_id_not_null",
+					"test_type": "not_null",
+					"column":    "user_id",
+				})
+			require.Equal(t, 201, resp.StatusCode)
+
+			var result map[string]interface{}
+			decodeJSON(t, resp, &result)
+			assert.Equal(t, "user_id_not_null", result["name"])
+			assert.Equal(t, "not_null", result["test_type"])
+			assert.Equal(t, "user_id", result["column"])
+			assert.NotEmpty(t, result["id"])
+			testID = result["id"].(string)
+		}},
+
+		{"create_unique_test", func(t *testing.T) {
+			resp := doRequest(t, "POST",
+				env.Server.URL+"/v1/models/testing/users/tests",
+				env.Keys.Admin, map[string]interface{}{
+					"name":      "user_id_unique",
+					"test_type": "unique",
+					"column":    "user_id",
+				})
+			require.Equal(t, 201, resp.StatusCode)
+			_ = resp.Body.Close()
+		}},
+
+		{"create_accepted_values_test", func(t *testing.T) {
+			resp := doRequest(t, "POST",
+				env.Server.URL+"/v1/models/testing/users/tests",
+				env.Keys.Admin, map[string]interface{}{
+					"name":      "status_values",
+					"test_type": "accepted_values",
+					"column":    "status",
+					"config": map[string]interface{}{
+						"values": []string{"active", "inactive", "suspended"},
+					},
+				})
+			require.Equal(t, 201, resp.StatusCode)
+			_ = resp.Body.Close()
+		}},
+
+		{"create_test_missing_column_400", func(t *testing.T) {
+			resp := doRequest(t, "POST",
+				env.Server.URL+"/v1/models/testing/users/tests",
+				env.Keys.Admin, map[string]interface{}{
+					"name":      "bad_test",
+					"test_type": "not_null",
+					// missing "column"
+				})
+			defer resp.Body.Close() //nolint:errcheck
+			require.Equal(t, 400, resp.StatusCode)
+		}},
+
+		{"create_test_model_not_found_404", func(t *testing.T) {
+			resp := doRequest(t, "POST",
+				env.Server.URL+"/v1/models/testing/nonexistent/tests",
+				env.Keys.Admin, map[string]interface{}{
+					"name":      "test_on_missing",
+					"test_type": "not_null",
+					"column":    "id",
+				})
+			defer resp.Body.Close() //nolint:errcheck
+			require.Equal(t, 404, resp.StatusCode)
+		}},
+
+		{"list_model_tests", func(t *testing.T) {
+			resp := doRequest(t, "GET",
+				env.Server.URL+"/v1/models/testing/users/tests",
+				env.Keys.Admin, nil)
+			require.Equal(t, 200, resp.StatusCode)
+
+			var result map[string]interface{}
+			decodeJSON(t, resp, &result)
+			data := result["data"].([]interface{})
+			assert.Equal(t, 3, len(data), "should have 3 tests")
+		}},
+
+		{"delete_model_test", func(t *testing.T) {
+			resp := doRequest(t, "DELETE",
+				fmt.Sprintf("%s/v1/models/testing/users/tests/%s", env.Server.URL, testID),
+				env.Keys.Admin, nil)
+			defer resp.Body.Close() //nolint:errcheck
+			require.Equal(t, 204, resp.StatusCode)
+		}},
+
+		{"list_after_delete", func(t *testing.T) {
+			resp := doRequest(t, "GET",
+				env.Server.URL+"/v1/models/testing/users/tests",
+				env.Keys.Admin, nil)
+			require.Equal(t, 200, resp.StatusCode)
+
+			var result map[string]interface{}
+			decodeJSON(t, resp, &result)
+			data := result["data"].([]interface{})
+			assert.Equal(t, 2, len(data), "should have 2 tests after deletion")
+		}},
+	}
+
+	for _, s := range steps {
+		if !t.Run(s.name, s.fn) {
+			t.FailNow()
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Macro CRUD
+// ---------------------------------------------------------------------------
+
+// TestHTTP_MacroCRUD exercises the full macro lifecycle via the HTTP API.
+func TestHTTP_MacroCRUD(t *testing.T) {
+	env := setupHTTPServer(t, httpTestOpts{WithModels: true})
+
+	type step struct {
+		name string
+		fn   func(t *testing.T)
+	}
+
+	steps := []step{
+		{"create_scalar_macro", func(t *testing.T) {
+			resp := doRequest(t, "POST", env.Server.URL+"/v1/macros", env.Keys.Admin, map[string]interface{}{
+				"name":        "double_val",
+				"macro_type":  "SCALAR",
+				"parameters":  []string{"x"},
+				"body":        "x * 2",
+				"description": "Doubles the input value",
+			})
+			require.Equal(t, 201, resp.StatusCode)
+
+			var result map[string]interface{}
+			decodeJSON(t, resp, &result)
+			assert.Equal(t, "double_val", result["name"])
+			assert.Equal(t, "SCALAR", result["macro_type"])
+			assert.Equal(t, "x * 2", result["body"])
+			assert.Equal(t, "Doubles the input value", result["description"])
+			assert.NotEmpty(t, result["id"])
+			assert.NotNil(t, result["created_at"])
+		}},
+
+		{"create_table_macro", func(t *testing.T) {
+			resp := doRequest(t, "POST", env.Server.URL+"/v1/macros", env.Keys.Admin, map[string]interface{}{
+				"name":       "generate_series_custom",
+				"macro_type": "TABLE",
+				"parameters": []string{"n"},
+				"body":       "SELECT * FROM generate_series(1, n)",
+			})
+			require.Equal(t, 201, resp.StatusCode)
+			_ = resp.Body.Close()
+		}},
+
+		{"create_macro_duplicate_409", func(t *testing.T) {
+			resp := doRequest(t, "POST", env.Server.URL+"/v1/macros", env.Keys.Admin, map[string]interface{}{
+				"name": "double_val",
+				"body": "x * 3",
+			})
+			defer resp.Body.Close() //nolint:errcheck
+			require.Equal(t, 409, resp.StatusCode)
+		}},
+
+		{"create_macro_missing_name_400", func(t *testing.T) {
+			resp := doRequest(t, "POST", env.Server.URL+"/v1/macros", env.Keys.Admin, map[string]interface{}{
+				"body": "1 + 1",
+			})
+			defer resp.Body.Close() //nolint:errcheck
+			require.Equal(t, 400, resp.StatusCode)
+		}},
+
+		{"create_macro_missing_body_400", func(t *testing.T) {
+			resp := doRequest(t, "POST", env.Server.URL+"/v1/macros", env.Keys.Admin, map[string]interface{}{
+				"name": "empty_body_macro",
+			})
+			defer resp.Body.Close() //nolint:errcheck
+			require.Equal(t, 400, resp.StatusCode)
+		}},
+
+		{"get_macro", func(t *testing.T) {
+			resp := doRequest(t, "GET", env.Server.URL+"/v1/macros/double_val", env.Keys.Admin, nil)
+			require.Equal(t, 200, resp.StatusCode)
+
+			var result map[string]interface{}
+			decodeJSON(t, resp, &result)
+			assert.Equal(t, "double_val", result["name"])
+			assert.Equal(t, "x * 2", result["body"])
+		}},
+
+		{"get_macro_not_found_404", func(t *testing.T) {
+			resp := doRequest(t, "GET", env.Server.URL+"/v1/macros/nonexistent", env.Keys.Admin, nil)
+			defer resp.Body.Close() //nolint:errcheck
+			require.Equal(t, 404, resp.StatusCode)
+		}},
+
+		{"list_macros", func(t *testing.T) {
+			resp := doRequest(t, "GET", env.Server.URL+"/v1/macros", env.Keys.Admin, nil)
+			require.Equal(t, 200, resp.StatusCode)
+
+			var result map[string]interface{}
+			decodeJSON(t, resp, &result)
+			data := result["data"].([]interface{})
+			assert.GreaterOrEqual(t, len(data), 2, "should have at least 2 macros")
+		}},
+
+		{"update_macro", func(t *testing.T) {
+			resp := doRequest(t, "PATCH", env.Server.URL+"/v1/macros/double_val", env.Keys.Admin, map[string]interface{}{
+				"body":        "x * 3",
+				"description": "Triples the input value",
+			})
+			require.Equal(t, 200, resp.StatusCode)
+
+			var result map[string]interface{}
+			decodeJSON(t, resp, &result)
+			assert.Equal(t, "x * 3", result["body"])
+			assert.Equal(t, "Triples the input value", result["description"])
+		}},
+
+		{"update_macro_not_found_404", func(t *testing.T) {
+			resp := doRequest(t, "PATCH", env.Server.URL+"/v1/macros/nonexistent", env.Keys.Admin, map[string]interface{}{
+				"body": "1",
+			})
+			defer resp.Body.Close() //nolint:errcheck
+			require.Equal(t, 404, resp.StatusCode)
+		}},
+
+		{"delete_macro", func(t *testing.T) {
+			resp := doRequest(t, "DELETE", env.Server.URL+"/v1/macros/double_val", env.Keys.Admin, nil)
+			defer resp.Body.Close() //nolint:errcheck
+			require.Equal(t, 204, resp.StatusCode)
+		}},
+
+		{"delete_macro_idempotent_204", func(t *testing.T) {
+			// Deleting an already-deleted macro returns 204 (idempotent delete).
+			resp := doRequest(t, "DELETE", env.Server.URL+"/v1/macros/double_val", env.Keys.Admin, nil)
+			defer resp.Body.Close() //nolint:errcheck
+			require.Equal(t, 204, resp.StatusCode)
+		}},
+
+		{"get_deleted_macro_404", func(t *testing.T) {
+			resp := doRequest(t, "GET", env.Server.URL+"/v1/macros/double_val", env.Keys.Admin, nil)
+			defer resp.Body.Close() //nolint:errcheck
+			require.Equal(t, 404, resp.StatusCode)
+		}},
+	}
+
+	for _, s := range steps {
+		if !t.Run(s.name, s.fn) {
+			t.FailNow()
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Freshness Check
+// ---------------------------------------------------------------------------
+
+// TestHTTP_ModelFreshness verifies the freshness check endpoint.
+func TestHTTP_ModelFreshness(t *testing.T) {
+	env := setupHTTPServer(t, httpTestOpts{WithModels: true})
+
+	type step struct {
+		name string
+		fn   func(t *testing.T)
+	}
+
+	steps := []step{
+		{"create_model_with_freshness", func(t *testing.T) {
+			// Create a model first (freshness policy is set via update since
+			// create doesn't expose freshness in the OpenAPI schema body)
+			resp := doRequest(t, "POST", env.Server.URL+"/v1/models", env.Keys.Admin, map[string]interface{}{
+				"project_name":    "freshtest",
+				"name":            "stale_model",
+				"sql":             "SELECT 1 AS id",
+				"materialization": "TABLE",
+			})
+			require.Equal(t, 201, resp.StatusCode)
+			_ = resp.Body.Close()
+		}},
+
+		{"check_freshness", func(t *testing.T) {
+			resp := doRequest(t, "GET",
+				env.Server.URL+"/v1/models/freshtest/stale_model/freshness",
+				env.Keys.Admin, nil)
+			require.Equal(t, 200, resp.StatusCode)
+
+			var result map[string]interface{}
+			decodeJSON(t, resp, &result)
+			// Without a freshness policy, should still return a valid status
+			assert.NotNil(t, result["is_fresh"])
+			assert.NotNil(t, result["max_lag_seconds"])
+		}},
+
+		{"check_freshness_not_found_404", func(t *testing.T) {
+			resp := doRequest(t, "GET",
+				env.Server.URL+"/v1/models/freshtest/nonexistent/freshness",
+				env.Keys.Admin, nil)
+			defer resp.Body.Close() //nolint:errcheck
+			require.Equal(t, 404, resp.StatusCode)
+		}},
+	}
+
+	for _, s := range steps {
+		if !t.Run(s.name, s.fn) {
+			t.FailNow()
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Model Runs (listing only — triggering requires DuckDB)
+// ---------------------------------------------------------------------------
+
+// TestHTTP_ModelRunEndpoints verifies model run list endpoints return valid
+// responses. Triggering actual runs requires a DuckDB engine, so we only test
+// the list/get paths here.
+func TestHTTP_ModelRunEndpoints(t *testing.T) {
+	env := setupHTTPServer(t, httpTestOpts{WithModels: true})
+
+	t.Run("list_runs_empty", func(t *testing.T) {
+		resp := doRequest(t, "GET", env.Server.URL+"/v1/model-runs", env.Keys.Admin, nil)
+		require.Equal(t, 200, resp.StatusCode)
+
+		var result map[string]interface{}
+		decodeJSON(t, resp, &result)
+		data := result["data"].([]interface{})
+		assert.Equal(t, 0, len(data), "no runs should exist initially")
+	})
+
+	t.Run("get_run_not_found_404", func(t *testing.T) {
+		resp := doRequest(t, "GET",
+			env.Server.URL+"/v1/model-runs/00000000-0000-0000-0000-000000000000",
+			env.Keys.Admin, nil)
+		defer resp.Body.Close() //nolint:errcheck
+		require.Equal(t, 404, resp.StatusCode)
+	})
+
+	t.Run("list_run_steps_empty_for_nonexistent_run", func(t *testing.T) {
+		resp := doRequest(t, "GET",
+			env.Server.URL+"/v1/model-runs/00000000-0000-0000-0000-000000000000/steps",
+			env.Keys.Admin, nil)
+		require.Equal(t, 200, resp.StatusCode)
+
+		var result map[string]interface{}
+		decodeJSON(t, resp, &result)
+		data := result["data"].([]interface{})
+		assert.Equal(t, 0, len(data), "steps should be empty for nonexistent run")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Model with Config (incremental)
+// ---------------------------------------------------------------------------
+
+// TestHTTP_ModelIncrementalConfig verifies that incremental models with config
+// are correctly stored and returned.
+func TestHTTP_ModelIncrementalConfig(t *testing.T) {
+	env := setupHTTPServer(t, httpTestOpts{WithModels: true})
+
+	type step struct {
+		name string
+		fn   func(t *testing.T)
+	}
+
+	steps := []step{
+		{"create_incremental_model", func(t *testing.T) {
+			resp := doRequest(t, "POST", env.Server.URL+"/v1/models", env.Keys.Admin, map[string]interface{}{
+				"project_name":    "incr",
+				"name":            "orders_incremental",
+				"sql":             "SELECT order_id, amount FROM raw_orders",
+				"materialization": "INCREMENTAL",
+				"config": map[string]interface{}{
+					"unique_key":           []string{"order_id"},
+					"incremental_strategy": "merge",
+				},
+			})
+			require.Equal(t, 201, resp.StatusCode)
+
+			var result map[string]interface{}
+			decodeJSON(t, resp, &result)
+			assert.Equal(t, "INCREMENTAL", result["materialization"])
+
+			cfg, ok := result["config"].(map[string]interface{})
+			if assert.True(t, ok, "config should be present") {
+				assert.Equal(t, "merge", cfg["incremental_strategy"])
+				uniqueKey, ok := cfg["unique_key"].([]interface{})
+				if assert.True(t, ok) {
+					assert.Contains(t, uniqueKey, "order_id")
+				}
+			}
+		}},
+
+		{"update_incremental_config", func(t *testing.T) {
+			resp := doRequest(t, "PATCH", env.Server.URL+"/v1/models/incr/orders_incremental", env.Keys.Admin, map[string]interface{}{
+				"config": map[string]interface{}{
+					"unique_key":           []string{"order_id", "line_id"},
+					"incremental_strategy": "merge",
+				},
+			})
+			require.Equal(t, 200, resp.StatusCode)
+
+			var result map[string]interface{}
+			decodeJSON(t, resp, &result)
+			cfg := result["config"].(map[string]interface{})
+			uniqueKey := cfg["unique_key"].([]interface{})
+			assert.Len(t, uniqueKey, 2)
+		}},
+	}
+
+	for _, s := range steps {
+		if !t.Run(s.name, s.fn) {
+			t.FailNow()
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Custom SQL Test Type
+// ---------------------------------------------------------------------------
+
+// TestHTTP_ModelCustomSQLTest verifies custom_sql test type creation.
+func TestHTTP_ModelCustomSQLTest(t *testing.T) {
+	env := setupHTTPServer(t, httpTestOpts{WithModels: true})
+
+	type step struct {
+		name string
+		fn   func(t *testing.T)
+	}
+
+	steps := []step{
+		{"create_model", func(t *testing.T) {
+			resp := doRequest(t, "POST", env.Server.URL+"/v1/models", env.Keys.Admin, map[string]interface{}{
+				"project_name":    "sqltest",
+				"name":            "orders",
+				"sql":             "SELECT 1 AS order_id, 100.0 AS amount",
+				"materialization": "TABLE",
+			})
+			require.Equal(t, 201, resp.StatusCode)
+			_ = resp.Body.Close()
+		}},
+
+		{"create_custom_sql_test", func(t *testing.T) {
+			resp := doRequest(t, "POST",
+				env.Server.URL+"/v1/models/sqltest/orders/tests",
+				env.Keys.Admin, map[string]interface{}{
+					"name":      "no_negative_amounts",
+					"test_type": "custom_sql",
+					"config": map[string]interface{}{
+						"sql": "SELECT * FROM {{ model }} WHERE amount < 0",
+					},
+				})
+			require.Equal(t, 201, resp.StatusCode)
+
+			var result map[string]interface{}
+			decodeJSON(t, resp, &result)
+			assert.Equal(t, "custom_sql", result["test_type"])
+			cfg := result["config"].(map[string]interface{})
+			assert.Contains(t, cfg["sql"], "amount < 0")
+		}},
+
+		{"create_relationships_test", func(t *testing.T) {
+			resp := doRequest(t, "POST",
+				env.Server.URL+"/v1/models/sqltest/orders/tests",
+				env.Keys.Admin, map[string]interface{}{
+					"name":      "order_customer_fk",
+					"test_type": "relationships",
+					"column":    "order_id",
+					"config": map[string]interface{}{
+						"to_model":  "customers",
+						"to_column": "id",
+					},
+				})
+			require.Equal(t, 201, resp.StatusCode)
+
+			var result map[string]interface{}
+			decodeJSON(t, resp, &result)
+			assert.Equal(t, "relationships", result["test_type"])
+		}},
+	}
+
+	for _, s := range steps {
+		if !t.Run(s.name, s.fn) {
+			t.FailNow()
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Non-admin access
+// ---------------------------------------------------------------------------
+
+// TestHTTP_ModelNonAdminAccess verifies that non-admin users can also perform
+// model operations (models don't require admin privileges for CRUD).
+func TestHTTP_ModelNonAdminAccess(t *testing.T) {
+	env := setupHTTPServer(t, httpTestOpts{WithModels: true})
+
+	type step struct {
+		name string
+		fn   func(t *testing.T)
+	}
+
+	steps := []step{
+		{"analyst_creates_model", func(t *testing.T) {
+			resp := doRequest(t, "POST", env.Server.URL+"/v1/models", env.Keys.Analyst, map[string]interface{}{
+				"project_name": "analyst_project",
+				"name":         "analyst_model",
+				"sql":          "SELECT 1 AS id",
+			})
+			require.Equal(t, 201, resp.StatusCode)
+			_ = resp.Body.Close()
+		}},
+
+		{"analyst_lists_models", func(t *testing.T) {
+			resp := doRequest(t, "GET", env.Server.URL+"/v1/models", env.Keys.Analyst, nil)
+			require.Equal(t, 200, resp.StatusCode)
+
+			var result map[string]interface{}
+			decodeJSON(t, resp, &result)
+			data := result["data"].([]interface{})
+			assert.GreaterOrEqual(t, len(data), 1)
+		}},
+
+		{"analyst_gets_model", func(t *testing.T) {
+			resp := doRequest(t, "GET", env.Server.URL+"/v1/models/analyst_project/analyst_model", env.Keys.Analyst, nil)
+			require.Equal(t, 200, resp.StatusCode)
+			_ = resp.Body.Close()
+		}},
+
+		{"analyst_creates_macro", func(t *testing.T) {
+			resp := doRequest(t, "POST", env.Server.URL+"/v1/macros", env.Keys.Analyst, map[string]interface{}{
+				"name": "analyst_macro",
+				"body": "x + 1",
+			})
+			require.Equal(t, 201, resp.StatusCode)
+			_ = resp.Body.Close()
+		}},
+	}
+
+	for _, s := range steps {
+		if !t.Run(s.name, s.fn) {
+			t.FailNow()
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Macro with Default Type
+// ---------------------------------------------------------------------------
+
+// TestHTTP_MacroDefaultType verifies that omitting macro_type defaults to SCALAR.
+func TestHTTP_MacroDefaultType(t *testing.T) {
+	env := setupHTTPServer(t, httpTestOpts{WithModels: true})
+
+	resp := doRequest(t, "POST", env.Server.URL+"/v1/macros", env.Keys.Admin, map[string]interface{}{
+		"name": "default_type_macro",
+		"body": "42",
+	})
+	require.Equal(t, 201, resp.StatusCode)
+
+	var result map[string]interface{}
+	decodeJSON(t, resp, &result)
+	assert.Equal(t, "SCALAR", result["macro_type"], "default macro_type should be SCALAR")
+}
+
+// ---------------------------------------------------------------------------
+// Model Default Materialization
+// ---------------------------------------------------------------------------
+
+// TestHTTP_ModelDefaultMaterialization verifies that omitting materialization
+// defaults to VIEW.
+func TestHTTP_ModelDefaultMaterialization(t *testing.T) {
+	env := setupHTTPServer(t, httpTestOpts{WithModels: true})
+
+	resp := doRequest(t, "POST", env.Server.URL+"/v1/models", env.Keys.Admin, map[string]interface{}{
+		"project_name": "defaults",
+		"name":         "default_mat_model",
+		"sql":          "SELECT 1",
+	})
+	require.Equal(t, 201, resp.StatusCode)
+
+	var result map[string]interface{}
+	decodeJSON(t, resp, &result)
+	assert.Equal(t, "VIEW", result["materialization"], "default materialization should be VIEW")
+}


### PR DESCRIPTION
## Summary

- Implement comprehensive dbt-like transformation model system with auto-dependency extraction, DAG resolution, and multi-materialization support (VIEW, TABLE, INCREMENTAL with MERGE INTO, EPHEMERAL with CTE injection)
- Add data quality testing framework (not_null, unique, accepted_values, relationships, custom_sql), model contracts with information_schema validation, SQL macros, freshness policies, selector syntax, pipeline integration, and notebook promotion
- Include 5 migrations (034-038), 20+ REST API endpoints, declarative plan/apply/export support, and full HTTP integration test suite

## Phase 1 — Core Models
- Domain types: `Model`, `ModelRun`, `ModelRunStep`, `ModelConfig`
- Auto-dependency extraction via `duckdbsql.CollectTableNames()` — no `ref()` needed
- DAG resolution via Kahn's algorithm for tier-based execution
- Execution engine with pinned `*sql.Conn`, `SET VARIABLE` injection, VIEW + TABLE materialization
- Service layer: full CRUD, DAG visualization, run triggering with background goroutines, cancellation via `sync.Map`
- OpenAPI spec: 11 model endpoints (CRUD, DAG, runs, steps, cancel)
- Declarative config: `KindModel` at layer 8, YAML loader from `models/<project>/` directory tree

## Phase 2 — Testing & Incremental
- Model tests: 5 test types with SQL generation + post-materialization execution
- Model contracts: column type/nullable enforcement via `information_schema` introspection
- INCREMENTAL materialization: `MERGE INTO` with configurable unique keys
- 4 additional API endpoints for test CRUD + test results
- Declarative: `ContractSpec`, `TestSpec` in model YAML with validation

## Phase 3 — Advanced Features
- **Selector syntax**: `model+`, `+model`, `+model+`, `tag:X`, `project:X`
- **Ephemeral models**: CTE injection into downstream consumers
- **SQL macros**: full stack (domain → migration → repo → service → 5 API endpoints → declarative `KindMacro` layer 0)
- **Freshness policies**: `MaxLagSeconds` + `CronSchedule`, staleness check endpoint
- **Pipeline integration**: `MODEL_RUN` job type in pipeline executor, `TriggerRunSync`
- **Notebook promotion**: `POST /models/from-notebook` endpoint

## Testing
- Unit tests: dependency extraction, DAG resolution, selector parsing, test SQL generation, repo tests
- Integration tests: 12 HTTP test functions covering model CRUD, dependencies + DAG, all materializations, model test CRUD, macro CRUD, freshness check, run endpoints, incremental config, custom SQL tests, non-admin access, default behaviors

## Files Changed
- **63 files changed**, **8,731 insertions**, 23 deletions
- 5 new migrations (034-038)
- 39 new files across domain, repository, service, API, declarative, and test layers

Closes #92