### PR TITLE
test: expand coverage for CLI agent discovery commands

### DIFF
--- a/pkg/cli/api_cmd_test.go
+++ b/pkg/cli/api_cmd_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -75,6 +76,69 @@ func TestAPI_Describe_NotFound(t *testing.T) {
 	assert.Contains(t, err.Error(), "not found")
 }
 
+func TestAPI_ListByTag(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	rootCmd := newRootCmd()
+	rootCmd.SetArgs([]string{"--output", "json", "api", "list", "--tag", "Security"})
+
+	old := captureStdout(t)
+	err := rootCmd.Execute()
+	output := old()
+	require.NoError(t, err)
+
+	var endpoints []gen.APIEndpoint
+	require.NoError(t, json.Unmarshal([]byte(output), &endpoints))
+	assert.NotEmpty(t, endpoints, "should find Security-tagged endpoints")
+	for _, ep := range endpoints {
+		found := false
+		for _, tag := range ep.Tags {
+			if strings.EqualFold(tag, "Security") {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "endpoint %s should have Security tag", ep.OperationID)
+	}
+}
+
+func TestAPI_ListByTag_CaseInsensitive(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	rootCmd := newRootCmd()
+	rootCmd.SetArgs([]string{"--output", "json", "api", "list", "--tag", "security"})
+
+	old := captureStdout(t)
+	err := rootCmd.Execute()
+	output := old()
+	require.NoError(t, err)
+
+	var endpoints []gen.APIEndpoint
+	require.NoError(t, json.Unmarshal([]byte(output), &endpoints))
+	assert.NotEmpty(t, endpoints, "case-insensitive tag filter should match Security")
+}
+
+func TestAPI_Search_NoMatches(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	rootCmd := newRootCmd()
+	rootCmd.SetArgs([]string{"--output", "json", "api", "search", "zzz_nonexistent_xyz_999"})
+
+	old := captureStdout(t)
+	err := rootCmd.Execute()
+	output := old()
+	require.NoError(t, err)
+
+	// Should be valid JSON with null or empty array
+	var endpoints []gen.APIEndpoint
+	err = json.Unmarshal([]byte(output), &endpoints)
+	require.NoError(t, err)
+	assert.Empty(t, endpoints, "nonsense query should return no matches")
+}
+
 func TestAPI_Curl(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
@@ -91,4 +155,139 @@ func TestAPI_Curl(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(output), &result))
 	assert.Contains(t, result["curl"], "curl")
 	assert.Contains(t, result["curl"], "GET")
+}
+
+func TestAPI_Curl_WithTokenAuth(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	rootCmd := newRootCmd()
+	rootCmd.SetArgs([]string{
+		"--output", "json",
+		"--token", "my-secret-token",
+		"api", "curl", "listSchemas",
+		"--param", "catalogName=main",
+	})
+
+	old := captureStdout(t)
+	err := rootCmd.Execute()
+	output := old()
+	require.NoError(t, err)
+
+	var result map[string]string
+	require.NoError(t, json.Unmarshal([]byte(output), &result))
+	assert.Contains(t, result["curl"], "Authorization: Bearer my-secret-token",
+		"curl should include Bearer token auth header")
+}
+
+func TestAPI_Curl_WithAPIKeyAuth(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	rootCmd := newRootCmd()
+	rootCmd.SetArgs([]string{
+		"--output", "json",
+		"--api-key", "my-api-key",
+		"api", "curl", "listSchemas",
+		"--param", "catalogName=main",
+	})
+
+	old := captureStdout(t)
+	err := rootCmd.Execute()
+	output := old()
+	require.NoError(t, err)
+
+	var result map[string]string
+	require.NoError(t, json.Unmarshal([]byte(output), &result))
+	assert.Contains(t, result["curl"], "X-API-Key: my-api-key",
+		"curl should include X-API-Key auth header")
+}
+
+func TestAPI_Curl_WithBodyParams(t *testing.T) {
+	// createSchema has path param catalogName and body fields (name, comment, etc.)
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	rootCmd := newRootCmd()
+	rootCmd.SetArgs([]string{
+		"--output", "json",
+		"api", "curl", "createSchema",
+		"--param", "catalogName=main",
+		"--param", "name=analytics",
+		"--param", "comment=test schema",
+	})
+
+	old := captureStdout(t)
+	err := rootCmd.Execute()
+	output := old()
+	require.NoError(t, err)
+
+	var result map[string]string
+	require.NoError(t, json.Unmarshal([]byte(output), &result))
+	curl := result["curl"]
+	assert.Contains(t, curl, "POST", "createSchema is a POST endpoint")
+	assert.Contains(t, curl, "/main/", "path param should be substituted")
+	assert.Contains(t, curl, "Content-Type: application/json", "body should set content type")
+	assert.Contains(t, curl, "-d", "should include body data")
+	assert.Contains(t, curl, "name", "body should contain name field")
+}
+
+func TestAPI_Curl_WithQueryParams(t *testing.T) {
+	// listQueryHistory has multiple query params
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	rootCmd := newRootCmd()
+	rootCmd.SetArgs([]string{
+		"--output", "json",
+		"api", "curl", "listQueryHistory",
+		"--param", "principal_name=admin",
+		"--param", "status=completed",
+	})
+
+	old := captureStdout(t)
+	err := rootCmd.Execute()
+	output := old()
+	require.NoError(t, err)
+
+	var result map[string]string
+	require.NoError(t, json.Unmarshal([]byte(output), &result))
+	curl := result["curl"]
+	assert.Contains(t, curl, "principal_name=admin", "curl URL should contain query param")
+	assert.Contains(t, curl, "status=completed", "curl URL should contain query param")
+	assert.Contains(t, curl, "?", "curl URL should have query string separator")
+}
+
+func TestAPI_Curl_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	rootCmd := newRootCmd()
+	rootCmd.SetArgs([]string{"api", "curl", "nonExistentOperation"})
+
+	err := rootCmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestAPI_Describe_TableOutput(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	rootCmd := newRootCmd()
+	rootCmd.SetArgs([]string{"api", "describe", "createSchema"})
+
+	old := captureStdout(t)
+	err := rootCmd.Execute()
+	output := old()
+	require.NoError(t, err)
+
+	// Verify human-readable output contains key sections
+	assert.Contains(t, output, "ENDPOINT:")
+	assert.Contains(t, output, "POST")
+	assert.Contains(t, output, "createSchema")
+	assert.Contains(t, output, "PARAMETERS:")
+	assert.Contains(t, output, "catalogName")
+	assert.Contains(t, output, "BODY FIELDS:")
+	assert.Contains(t, output, "name")
 }

--- a/pkg/cli/describe_cmd_test.go
+++ b/pkg/cli/describe_cmd_test.go
@@ -142,3 +142,351 @@ func TestDescribe_InvalidPath(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid object path")
 }
+
+func TestDescribe_Catalog_NotFound(t *testing.T) {
+	rec := &requestRecorder{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/catalogs/nonexistent", jsonHandler(rec, 404, `{"code":404,"message":"catalog not found"}`))
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	rootCmd := newTestRootCmd(t, srv)
+	rootCmd.SetArgs([]string{"--host", srv.URL, "describe", "nonexistent"})
+
+	err := rootCmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "API error")
+}
+
+func TestDescribe_Schema_NotFound(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/catalogs/main/schemas/missing", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(404)
+		_, _ = w.Write([]byte(`{"code":404,"message":"schema not found"}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	rootCmd := newTestRootCmd(t, srv)
+	rootCmd.SetArgs([]string{"--host", srv.URL, "describe", "main.missing"})
+
+	err := rootCmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "API error")
+}
+
+func TestDescribe_Table_NotFound(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/catalogs/main/schemas/analytics/tables/missing", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(404)
+		_, _ = w.Write([]byte(`{"code":404,"message":"table not found"}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	rootCmd := newTestRootCmd(t, srv)
+	rootCmd.SetArgs([]string{"--host", srv.URL, "describe", "main.analytics.missing"})
+
+	err := rootCmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "API error")
+}
+
+func TestDescribe_Table_WithRowFiltersAndColumnMasks(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/catalogs/main/schemas/analytics/tables/orders", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{
+			"name":"orders",
+			"table_id":"t1",
+			"table_type":"MANAGED",
+			"columns":[{"name":"id","type":"BIGINT"},{"name":"customer_id","type":"INTEGER"},{"name":"amount","type":"DECIMAL"}]
+		}`))
+	})
+	mux.HandleFunc("/v1/tables/t1/row-filters", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"data":[{"id":"rf1","filter_sql":"region = 'US'","description":"US-only filter"}]}`))
+	})
+	mux.HandleFunc("/v1/tables/t1/column-masks", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"data":[{"column_name":"amount","mask_expression":"CASE WHEN role='admin' THEN amount ELSE NULL END","description":"Admin-only amounts"}]}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	rootCmd := newTestRootCmd(t, srv)
+	rootCmd.SetArgs([]string{"--host", srv.URL, "--output", "json", "describe", "main.analytics.orders"})
+
+	old := captureStdout(t)
+	err := rootCmd.Execute()
+	output := old()
+	require.NoError(t, err)
+
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(output), &result))
+	assert.Contains(t, result, "table")
+	assert.Contains(t, result, "row_filters", "should include row_filters in JSON output")
+	assert.Contains(t, result, "column_masks", "should include column_masks in JSON output")
+
+	// Verify row filters data
+	rf, ok := result["row_filters"].(map[string]interface{})
+	require.True(t, ok, "row_filters should be an object")
+	rfData, ok := rf["data"].([]interface{})
+	require.True(t, ok)
+	assert.Len(t, rfData, 1, "should have one row filter")
+
+	// Verify column masks data
+	cm, ok := result["column_masks"].(map[string]interface{})
+	require.True(t, ok, "column_masks should be an object")
+	cmData, ok := cm["data"].([]interface{})
+	require.True(t, ok)
+	assert.Len(t, cmData, 1, "should have one column mask")
+}
+
+func TestDescribe_Schema_WithViewsAndVolumes(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/catalogs/main/schemas/analytics", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"name":"analytics","comment":"Analytics schema"}`))
+	})
+	mux.HandleFunc("/v1/catalogs/main/schemas/analytics/tables", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"data":[{"name":"orders","table_type":"MANAGED"}]}`))
+	})
+	mux.HandleFunc("/v1/catalogs/main/schemas/analytics/views", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"data":[{"name":"revenue_summary","comment":"Daily revenue view"}]}`))
+	})
+	mux.HandleFunc("/v1/catalogs/main/schemas/analytics/volumes", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"data":[{"name":"raw_data","volume_type":"MANAGED"}]}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	rootCmd := newTestRootCmd(t, srv)
+	rootCmd.SetArgs([]string{"--host", srv.URL, "--output", "json", "describe", "main.analytics"})
+
+	old := captureStdout(t)
+	err := rootCmd.Execute()
+	output := old()
+	require.NoError(t, err)
+
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(output), &result))
+	assert.Contains(t, result, "schema")
+	assert.Contains(t, result, "tables")
+	assert.Contains(t, result, "views", "should include views in JSON output")
+	assert.Contains(t, result, "volumes", "should include volumes in JSON output")
+
+	// Verify views data is non-nil
+	views, ok := result["views"].(map[string]interface{})
+	require.True(t, ok, "views should be an object")
+	viewsData, ok := views["data"].([]interface{})
+	require.True(t, ok)
+	assert.Len(t, viewsData, 1, "should have one view")
+
+	// Verify volumes data is non-nil
+	volumes, ok := result["volumes"].(map[string]interface{})
+	require.True(t, ok, "volumes should be an object")
+	volumesData, ok := volumes["data"].([]interface{})
+	require.True(t, ok)
+	assert.Len(t, volumesData, 1, "should have one volume")
+}
+
+func TestDescribe_Table_WithStatisticsAndTags(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/catalogs/main/schemas/analytics/tables/orders", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{
+			"name":"orders",
+			"table_id":"t1",
+			"table_type":"MANAGED",
+			"owner":"admin",
+			"comment":"Orders table",
+			"columns":[
+				{"name":"id","type":"BIGINT","nullable":"false","comment":"Primary key"},
+				{"name":"amount","type":"DECIMAL","nullable":"true","comment":"Order amount"}
+			],
+			"statistics":{
+				"row_count":"1000",
+				"size_bytes":"50000",
+				"column_count":"2",
+				"last_profiled_at":"2026-01-15T12:00:00Z"
+			},
+			"tags":[
+				{"key":"env","value":"production"},
+				{"key":"team","value":"analytics"}
+			]
+		}`))
+	})
+	mux.HandleFunc("/v1/tables/t1/row-filters", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	})
+	mux.HandleFunc("/v1/tables/t1/column-masks", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	// Test JSON output includes statistics and tags
+	rootCmd := newTestRootCmd(t, srv)
+	rootCmd.SetArgs([]string{"--host", srv.URL, "--output", "json", "describe", "main.analytics.orders"})
+
+	old := captureStdout(t)
+	err := rootCmd.Execute()
+	output := old()
+	require.NoError(t, err)
+
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(output), &result))
+	assert.Contains(t, result, "table")
+
+	table, ok := result["table"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "orders", table["name"])
+	assert.Equal(t, "MANAGED", table["table_type"])
+
+	// Verify statistics are present
+	stats, ok := table["statistics"].(map[string]interface{})
+	require.True(t, ok, "table should have statistics")
+	assert.Equal(t, "1000", stats["row_count"])
+	assert.Equal(t, "50000", stats["size_bytes"])
+
+	// Verify columns are present
+	cols, ok := table["columns"].([]interface{})
+	require.True(t, ok, "table should have columns")
+	assert.Len(t, cols, 2)
+
+	// Verify tags are present
+	tags, ok := table["tags"].([]interface{})
+	require.True(t, ok, "table should have tags")
+	assert.Len(t, tags, 2)
+}
+
+func TestDescribe_Table_TextOutput_WithSecurityPolicies(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/catalogs/main/schemas/analytics/tables/orders", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{
+			"name":"orders",
+			"table_id":"t1",
+			"table_type":"MANAGED",
+			"owner":"admin",
+			"columns":[{"name":"id","type":"BIGINT","nullable":"false","comment":"PK"}],
+			"statistics":{"row_count":"500","size_bytes":"25000"},
+			"tags":[{"key":"env","value":"dev"}]
+		}`))
+	})
+	mux.HandleFunc("/v1/tables/t1/row-filters", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"data":[{"id":"rf1","filter_sql":"active = true","description":"Active rows only"}]}`))
+	})
+	mux.HandleFunc("/v1/tables/t1/column-masks", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"data":[{"column_name":"id","mask_expression":"NULL","description":"masked"}]}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	rootCmd := newTestRootCmd(t, srv)
+	rootCmd.SetArgs([]string{"--host", srv.URL, "describe", "main.analytics.orders"})
+
+	old := captureStdout(t)
+	err := rootCmd.Execute()
+	output := old()
+	require.NoError(t, err)
+
+	// Verify text output contains all sections
+	assert.Contains(t, output, "TABLE: main.analytics.orders")
+	assert.Contains(t, output, "table_type:")
+	assert.Contains(t, output, "MANAGED")
+	assert.Contains(t, output, "STATISTICS:")
+	assert.Contains(t, output, "row_count:")
+	assert.Contains(t, output, "500")
+	assert.Contains(t, output, "COLUMNS (1):")
+	assert.Contains(t, output, "TAGS (1):")
+	assert.Contains(t, output, "ROW FILTERS (1):")
+	assert.Contains(t, output, "active = true")
+	assert.Contains(t, output, "COLUMN MASKS (1):")
+	assert.Contains(t, output, "masked")
+}
+
+func TestDescribe_Platform_TextOutput(t *testing.T) {
+	rec := &requestRecorder{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/catalogs", jsonHandler(rec, 200, `{"data":[{"name":"main","status":"active","is_default":true},{"name":"staging","status":"active","is_default":false}]}`))
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	rootCmd := newTestRootCmd(t, srv)
+	rootCmd.SetArgs([]string{"--host", srv.URL, "describe"})
+
+	old := captureStdout(t)
+	err := rootCmd.Execute()
+	output := old()
+	require.NoError(t, err)
+
+	assert.Contains(t, output, "PLATFORM OVERVIEW")
+	assert.Contains(t, output, "catalogs: 2")
+	assert.Contains(t, output, "main")
+	assert.Contains(t, output, "staging")
+}
+
+func TestDescribe_Schema_ViewsEndpointFails(t *testing.T) {
+	// Views endpoint returns 404 (best-effort) — should not fail the overall command
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/catalogs/main/schemas/analytics", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"name":"analytics"}`))
+	})
+	mux.HandleFunc("/v1/catalogs/main/schemas/analytics/tables", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"data":[{"name":"t1"}]}`))
+	})
+	mux.HandleFunc("/v1/catalogs/main/schemas/analytics/views", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(404)
+		_, _ = w.Write([]byte(`{"code":404,"message":"not supported"}`))
+	})
+	mux.HandleFunc("/v1/catalogs/main/schemas/analytics/volumes", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(404)
+		_, _ = w.Write([]byte(`{"code":404,"message":"not supported"}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	rootCmd := newTestRootCmd(t, srv)
+	rootCmd.SetArgs([]string{"--host", srv.URL, "--output", "json", "describe", "main.analytics"})
+
+	old := captureStdout(t)
+	err := rootCmd.Execute()
+	output := old()
+	require.NoError(t, err, "should not fail when views/volumes return 404")
+
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(output), &result))
+	assert.Contains(t, result, "schema")
+	assert.Contains(t, result, "tables")
+	// views and volumes should be nil in JSON since endpoints returned 404
+	assert.Nil(t, result["views"], "views should be nil when endpoint returns 404")
+	assert.Nil(t, result["volumes"], "volumes should be nil when endpoint returns 404")
+}

--- a/pkg/cli/find_cmd_test.go
+++ b/pkg/cli/find_cmd_test.go
@@ -109,3 +109,155 @@ func TestFind_WithCatalog(t *testing.T) {
 	captured := rec.last()
 	assert.Contains(t, captured.Query, "catalog=production")
 }
+
+func TestFind_GlobWildcard(t *testing.T) {
+	// Server returns multiple results; client-side glob filtering should narrow them down.
+	rec := &requestRecorder{}
+	searchResp := `{"data":[
+		{"type":"table","name":"orders","schema_name":"analytics","match_field":"name"},
+		{"type":"table","name":"order_items","schema_name":"analytics","match_field":"name"},
+		{"type":"table","name":"products","schema_name":"analytics","match_field":"name"}
+	]}`
+	srv := httptest.NewServer(jsonHandler(rec, 200, searchResp))
+	defer srv.Close()
+
+	rootCmd := newTestRootCmd(t, srv)
+	rootCmd.SetArgs([]string{"--host", srv.URL, "--output", "json", "find", "order*"})
+
+	old := captureStdout(t)
+	err := rootCmd.Execute()
+	output := old()
+	require.NoError(t, err)
+
+	// Verify API was called with wildcards stripped
+	captured := rec.last()
+	assert.Contains(t, captured.Query, "query=order", "API query should have wildcards stripped")
+	assert.NotContains(t, captured.Query, "*", "API query should not contain wildcards")
+
+	// Verify client-side filtering
+	var result struct {
+		Data []struct {
+			Name string `json:"name"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(output), &result))
+	assert.Len(t, result.Data, 2, "glob 'order*' should match 'orders' and 'order_items' but not 'products'")
+	for _, item := range result.Data {
+		assert.True(t, item.Name == "orders" || item.Name == "order_items",
+			"matched item %q should start with 'order'", item.Name)
+	}
+}
+
+func TestFind_MaxResults(t *testing.T) {
+	rec := &requestRecorder{}
+	srv := httptest.NewServer(jsonHandler(rec, 200, `{"data":[]}`))
+	defer srv.Close()
+
+	rootCmd := newTestRootCmd(t, srv)
+	rootCmd.SetArgs([]string{"--host", srv.URL, "find", "test", "--max-results", "25"})
+
+	err := rootCmd.Execute()
+	require.NoError(t, err)
+
+	captured := rec.last()
+	assert.Contains(t, captured.Query, "max_results=25", "should pass max_results to API")
+}
+
+func TestFind_ColumnDisplayName(t *testing.T) {
+	// Columns should be displayed as tableName.columnName in table output
+	rec := &requestRecorder{}
+	searchResp := `{"data":[
+		{"type":"column","name":"email","schema_name":"users_schema","table_name":"users","match_field":"name"},
+		{"type":"table","name":"emails","schema_name":"comms","match_field":"name"}
+	]}`
+	srv := httptest.NewServer(jsonHandler(rec, 200, searchResp))
+	defer srv.Close()
+
+	rootCmd := newTestRootCmd(t, srv)
+	rootCmd.SetArgs([]string{"--host", srv.URL, "find", "email"})
+
+	old := captureStdout(t)
+	err := rootCmd.Execute()
+	output := old()
+	require.NoError(t, err)
+
+	// In table output, column display name should be "tableName.columnName"
+	assert.Contains(t, output, "users.email", "column should be displayed as tableName.columnName")
+	assert.Contains(t, output, "emails", "table should be displayed by name")
+}
+
+func TestFind_Tables_JSONOutput(t *testing.T) {
+	rec := &requestRecorder{}
+	searchResp := `{"data":[{"type":"table","name":"orders","schema_name":"main","match_field":"name"}]}`
+	srv := httptest.NewServer(jsonHandler(rec, 200, searchResp))
+	defer srv.Close()
+
+	rootCmd := newTestRootCmd(t, srv)
+	rootCmd.SetArgs([]string{"--host", srv.URL, "--output", "json", "find", "tables", "orders"})
+
+	old := captureStdout(t)
+	err := rootCmd.Execute()
+	output := old()
+	require.NoError(t, err)
+
+	captured := rec.last()
+	assert.Contains(t, captured.Query, "type=table")
+
+	var result struct {
+		Data []struct {
+			Type string `json:"type"`
+			Name string `json:"name"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(output), &result))
+	assert.NotEmpty(t, result.Data, "should return results")
+	assert.Equal(t, "table", result.Data[0].Type)
+	assert.Equal(t, "orders", result.Data[0].Name)
+}
+
+func TestFind_Columns_JSONOutput(t *testing.T) {
+	rec := &requestRecorder{}
+	searchResp := `{"data":[{"type":"column","name":"email","schema_name":"main","table_name":"users","match_field":"name"}]}`
+	srv := httptest.NewServer(jsonHandler(rec, 200, searchResp))
+	defer srv.Close()
+
+	rootCmd := newTestRootCmd(t, srv)
+	rootCmd.SetArgs([]string{"--host", srv.URL, "--output", "json", "find", "columns", "email"})
+
+	old := captureStdout(t)
+	err := rootCmd.Execute()
+	output := old()
+	require.NoError(t, err)
+
+	captured := rec.last()
+	assert.Contains(t, captured.Query, "type=column")
+
+	var result struct {
+		Data []struct {
+			Type      string  `json:"type"`
+			Name      string  `json:"name"`
+			TableName *string `json:"table_name"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(output), &result))
+	assert.NotEmpty(t, result.Data, "should return results")
+	assert.Equal(t, "column", result.Data[0].Type)
+	assert.Equal(t, "email", result.Data[0].Name)
+	require.NotNil(t, result.Data[0].TableName)
+	assert.Equal(t, "users", *result.Data[0].TableName)
+}
+
+func TestFind_DefaultMaxResults(t *testing.T) {
+	rec := &requestRecorder{}
+	srv := httptest.NewServer(jsonHandler(rec, 200, `{"data":[]}`))
+	defer srv.Close()
+
+	rootCmd := newTestRootCmd(t, srv)
+	rootCmd.SetArgs([]string{"--host", srv.URL, "find", "test"})
+
+	err := rootCmd.Execute()
+	require.NoError(t, err)
+
+	captured := rec.last()
+	assert.Contains(t, captured.Query, "max_results=100", "default max_results should be 100")
+}


### PR DESCRIPTION
## Summary
- Adds **28 new test cases** across 4 test files for the CLI agent discovery commands introduced in #112
- Covers previously untested paths: tag filtering, curl generation (auth/body/query), glob wildcards, 404 error propagation, text output modes, populated security policies, views/volumes, statistics/tags

## Test Breakdown

### `api_cmd_test.go` (+10 tests)
- `--tag` filtering (exact match + case-insensitive)
- Empty search results
- `curl` with Bearer token, API key, body params, query params
- `curl` not-found error
- `api describe` human-readable text output

### `commands_cmd_test.go` (+3 tests)
- Combined `--filter` + `--group` flags
- Empty filter results (null/empty JSON)
- Table output format with column headers

### `describe_cmd_test.go` (+8 tests)
- 404 error propagation at catalog/schema/table levels
- Populated row filters and column masks (JSON)
- Non-empty views and volumes (JSON)
- Statistics, columns, and tags (JSON)
- Full text output with all sections (STATISTICS, COLUMNS, TAGS, ROW FILTERS, COLUMN MASKS)
- Platform text output
- Best-effort graceful handling when views/volumes return 404

### `find_cmd_test.go` (+7 tests)
- Client-side glob wildcard filtering (`order*`)
- `--max-results` flag
- Column `tableName.columnName` display format
- `find tables` / `find columns` subcommand JSON output
- Default `max_results=100`