### PR TITLE
fix: use NotImplementedError for git sync stub

### DIFF
--- a/internal/api/handler_notebooks.go
+++ b/internal/api/handler_notebooks.go
@@ -514,6 +514,8 @@ func (h *APIHandler) SyncGitRepo(ctx context.Context, req SyncGitRepoRequestObje
 	result, err := h.gitRepos.SyncGitRepo(ctx, req.GitRepoId)
 	if err != nil {
 		switch {
+		case errors.As(err, new(*domain.NotImplementedError)):
+			return SyncGitRepo500JSONResponse{InternalErrorJSONResponse{Body: Error{Code: 501, Message: err.Error()}, Headers: InternalErrorResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
 		case errors.As(err, new(*domain.NotFoundError)):
 			return SyncGitRepo404JSONResponse{NotFoundJSONResponse{Body: Error{Code: 404, Message: err.Error()}, Headers: NotFoundResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
 		default:

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -50,3 +50,15 @@ func ErrValidation(format string, args ...interface{}) *ValidationError {
 func ErrConflict(format string, args ...interface{}) *ConflictError {
 	return &ConflictError{Message: fmt.Sprintf(format, args...)}
 }
+
+// NotImplementedError indicates a feature is not yet implemented.
+type NotImplementedError struct {
+	Message string
+}
+
+func (e *NotImplementedError) Error() string { return e.Message }
+
+// ErrNotImplemented creates a NotImplementedError with a formatted message.
+func ErrNotImplemented(format string, args ...interface{}) *NotImplementedError {
+	return &NotImplementedError{Message: fmt.Sprintf(format, args...)}
+}

--- a/internal/service/notebook/git.go
+++ b/internal/service/notebook/git.go
@@ -87,5 +87,5 @@ func (s *GitService) SyncGitRepo(ctx context.Context, id string) (*domain.GitSyn
 	if _, err := s.repo.GetByID(ctx, id); err != nil {
 		return nil, err
 	}
-	return nil, domain.ErrValidation("git sync is not yet implemented")
+	return nil, domain.ErrNotImplemented("git sync is not yet implemented")
 }

--- a/internal/service/notebook/git_test.go
+++ b/internal/service/notebook/git_test.go
@@ -209,7 +209,7 @@ func TestGitService_DeleteGitRepo(t *testing.T) {
 // === SyncGitRepo ===
 
 func TestGitService_SyncGitRepo(t *testing.T) {
-	t.Run("returns_validation_error", func(t *testing.T) {
+	t.Run("returns_not_implemented_error", func(t *testing.T) {
 		svc, repo, _ := setupGitService(t)
 		ctx := context.Background()
 
@@ -220,9 +220,9 @@ func TestGitService_SyncGitRepo(t *testing.T) {
 		result, err := svc.SyncGitRepo(ctx, "repo-1")
 		assert.Nil(t, result)
 		require.Error(t, err)
-		var validationErr *domain.ValidationError
-		require.ErrorAs(t, err, &validationErr)
-		assert.Contains(t, validationErr.Message, "not yet implemented")
+		var notImplErr *domain.NotImplementedError
+		require.ErrorAs(t, err, &notImplErr)
+		assert.Contains(t, notImplErr.Message, "not yet implemented")
 	})
 
 	t.Run("not_found_repo", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add `NotImplementedError` domain error type for unimplemented features
- Change `SyncGitRepo` service to return `NotImplementedError` instead of `ValidationError`
- Handler now catches `NotImplementedError` and returns HTTP 500 with code 501 in the body (HTTP 501 not available in generated types without OpenAPI spec change)
- Updated existing test to assert `NotImplementedError`

Closes #150