### PR TITLE
fix: PATCH /v1/models returns 500 on invalid materialization enum (#193)

### DIFF
--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -112,6 +112,21 @@ type UpdateModelRequest struct {
 	Freshness       *FreshnessPolicy
 }
 
+// Validate checks that the update payload is well-formed.
+func (r *UpdateModelRequest) Validate() error {
+	if r.Materialization == nil {
+		return nil
+	}
+	validMat := map[string]bool{
+		MaterializationView: true, MaterializationTable: true,
+		MaterializationIncremental: true, MaterializationEphemeral: true,
+	}
+	if !validMat[*r.Materialization] {
+		return ErrValidation("materialization must be VIEW, TABLE, INCREMENTAL, or EPHEMERAL")
+	}
+	return nil
+}
+
 // FreshnessStatus holds the result of a freshness check.
 type FreshnessStatus struct {
 	IsFresh       bool

--- a/internal/domain/model_test.go
+++ b/internal/domain/model_test.go
@@ -1,0 +1,28 @@
+package domain
+
+import "testing"
+
+func TestUpdateModelRequestValidate(t *testing.T) {
+	t.Run("nil materialization allowed", func(t *testing.T) {
+		req := UpdateModelRequest{}
+		if err := req.Validate(); err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+	})
+
+	t.Run("valid materialization accepted", func(t *testing.T) {
+		mat := MaterializationIncremental
+		req := UpdateModelRequest{Materialization: &mat}
+		if err := req.Validate(); err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+	})
+
+	t.Run("invalid materialization rejected", func(t *testing.T) {
+		mat := "bad_case"
+		req := UpdateModelRequest{Materialization: &mat}
+		if err := req.Validate(); err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+}

--- a/internal/service/model/service.go
+++ b/internal/service/model/service.go
@@ -104,6 +104,10 @@ func (s *Service) ListModels(ctx context.Context, projectName *string, page doma
 
 // UpdateModel updates a model and re-extracts dependencies if SQL changed.
 func (s *Service) UpdateModel(ctx context.Context, principal, projectName, name string, req domain.UpdateModelRequest) (*domain.Model, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+
 	existing, err := s.models.GetByName(ctx, projectName, name)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Root cause
`UpdateModel` accepted arbitrary `materialization` strings and passed them directly to the repository layer. Invalid values only failed at SQLite CHECK constraint time, surfacing as a 500 with internal DB details.

## Fix summary
- Added `UpdateModelRequest.Validate()` to enforce allowed enum values (`VIEW|TABLE|INCREMENTAL|EPHEMERAL`) for PATCH payloads.
- Called `req.Validate()` at the start of `model.Service.UpdateModel`.
- Added unit tests for update-request validation in `internal/domain/model_test.go`.

## Repro steps
### Before fix (baseline `origin/main`)
1. Build server from baseline branch.
2. Run targeted repro script:
   - `SERVER_BIN=/tmp/server-193-before /tmp/repro-issue-193.sh`
3. Observe PATCH with `{"materialization":"bad_case"}` returns 500.

### After fix (this branch)
1. Build server from this branch.
2. Run targeted repro script:
   - `SERVER_BIN=/tmp/server-193-after /tmp/repro-issue-193.sh`
3. Observe same PATCH now returns 400 with validation message.

## Test evidence
- Targeted repro script output (before):
  - `http_code=500`
  - `CHECK constraint failed: materialization IN ('VIEW','TABLE','INCREMENTAL','EPHEMERAL')`
- Targeted repro script output (after):
  - `http_code=400`
  - `{"code":400,"message":"materialization must be VIEW, TABLE, INCREMENTAL, or EPHEMERAL"}`
- Unit tests:
  - `go test ./internal/domain ./internal/service/model` ✅

Fixes #193