### PR TITLE
fix: resolve qualified table lookups and apply index-resolution regressions

### DIFF
--- a/internal/api/handler_query.go
+++ b/internal/api/handler_query.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"strings"
 
 	"duck-demo/internal/domain"
 	"duck-demo/internal/service/query"
@@ -70,9 +71,9 @@ func (h *APIHandler) CreateManifest(ctx context.Context, req CreateManifestReque
 		schemaName = *req.Body.Schema
 	}
 
-	// The manifest endpoint is not catalog-scoped in the URL; use empty string
-	// to let the service resolve the default catalog.
-	result, err := h.manifest.GetManifest(ctx, principal, "", schemaName, req.Body.Table)
+	catalogName, parsedSchema, tableName := parseManifestTableRef(schemaName, req.Body.Table)
+
+	result, err := h.manifest.GetManifest(ctx, principal, catalogName, parsedSchema, tableName)
 	if err != nil {
 		code := errorCodeFromError(err)
 		msg := err.Error()
@@ -107,4 +108,16 @@ func (h *APIHandler) CreateManifest(ctx context.Context, req CreateManifestReque
 		},
 		Headers: CreateManifest200ResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset},
 	}, nil
+}
+
+func parseManifestTableRef(defaultSchema, tableInput string) (catalogName, schemaName, tableName string) {
+	parts := strings.Split(tableInput, ".")
+	switch len(parts) {
+	case 3:
+		return parts[0], parts[1], parts[2]
+	case 2:
+		return "", parts[0], parts[1]
+	default:
+		return "", defaultSchema, tableInput
+	}
 }

--- a/internal/service/security/authorization_test.go
+++ b/internal/service/security/authorization_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/uuid"
 	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	internaldb "duck-demo/internal/db"
@@ -532,6 +533,60 @@ func TestLookupTableIDNotFound(t *testing.T) {
 	if err == nil {
 		t.Error("expected error for nonexistent table")
 	}
+}
+
+func TestLookupTableID_SchemaQualified(t *testing.T) {
+	cat, _, ctx := setupTestService(t)
+
+	tableID, schemaID, _, err := cat.LookupTableID(ctx, "main.titanic")
+	require.NoError(t, err)
+	assert.Equal(t, "1", tableID)
+	assert.Equal(t, "0", schemaID)
+}
+
+func TestLookupTableID_AmbiguousUnqualified(t *testing.T) {
+	db, _ := internaldb.OpenTestSQLite(t)
+
+	_, err := db.ExecContext(ctx, `
+		CREATE TABLE ducklake_schema (
+			schema_id INTEGER PRIMARY KEY,
+			schema_uuid TEXT,
+			begin_snapshot INTEGER,
+			end_snapshot INTEGER,
+			schema_name TEXT,
+			path TEXT,
+			path_is_relative INTEGER
+		);
+		CREATE TABLE ducklake_table (
+			table_id INTEGER,
+			table_uuid TEXT,
+			begin_snapshot INTEGER,
+			end_snapshot INTEGER,
+			schema_id INTEGER,
+			table_name TEXT,
+			path TEXT,
+			path_is_relative INTEGER
+		);
+		INSERT INTO ducklake_schema (schema_id, schema_name, begin_snapshot)
+		VALUES (0, 'main', 0), (3, 'analytics', 0);
+		INSERT INTO ducklake_table (table_id, table_name, schema_id, begin_snapshot)
+		VALUES (1, 'titanic', 0, 1), (9, 'titanic', 3, 1);
+	`)
+	require.NoError(t, err)
+
+	cat := NewAuthorizationService(
+		repository.NewPrincipalRepo(db),
+		repository.NewGroupRepo(db),
+		repository.NewGrantRepo(db),
+		repository.NewRowFilterRepo(db),
+		repository.NewColumnMaskRepo(db),
+		repository.NewIntrospectionRepo(db),
+		nil,
+	)
+
+	_, _, _, err = cat.LookupTableID(context.Background(), "titanic")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ambiguous")
 }
 
 func TestLookupSchemaID(t *testing.T) {

--- a/internal/sqlrewrite/sqlrewrite_test.go
+++ b/internal/sqlrewrite/sqlrewrite_test.go
@@ -87,6 +87,32 @@ func TestExtractTableNames_InvalidSQL(t *testing.T) {
 	}
 }
 
+func TestExtractTableRefs_QualifiedThreePart(t *testing.T) {
+	refs, err := ExtractTableRefs("SELECT * FROM demo.titanic.passengers")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("expected 1 ref, got %d", len(refs))
+	}
+	if refs[0].Catalog != "demo" || refs[0].Schema != "titanic" || refs[0].Name != "passengers" {
+		t.Fatalf("unexpected ref: %+v", refs[0])
+	}
+}
+
+func TestExtractTableRefs_SchemaQualified(t *testing.T) {
+	refs, err := ExtractTableRefs("SELECT * FROM analytics.orders")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("expected 1 ref, got %d", len(refs))
+	}
+	if refs[0].Catalog != "" || refs[0].Schema != "analytics" || refs[0].Name != "orders" {
+		t.Fatalf("unexpected ref: %+v", refs[0])
+	}
+}
+
 // --- RewriteQuery tests (backward-compatible RLSRule API) ---
 
 func TestRewriteQuery_NoRules(t *testing.T) {

--- a/pkg/cli/apply_cmd.go
+++ b/pkg/cli/apply_cmd.go
@@ -108,7 +108,11 @@ func newApplyCmd(client *gen.Client) *cobra.Command {
 			}
 			var results []actionResult
 			var succeeded, failed int
+			stop := false
 			for _, action := range plan.Actions {
+				if stop {
+					break
+				}
 				if !isJSON {
 					_, _ = fmt.Fprintf(os.Stdout, "  %s %s %q ... ",
 						action.Operation, action.ResourceKind, action.ResourceName)
@@ -126,6 +130,7 @@ func newApplyCmd(client *gen.Client) *cobra.Command {
 						Error:        err.Error(),
 					})
 					failed++
+					stop = true
 				} else {
 					if !isJSON {
 						_, _ = fmt.Fprintln(os.Stdout, "succeeded")


### PR DESCRIPTION
## Summary
- preserve catalog/schema/table references through SQL parsing and query/manifest authorization so `demo.titanic.passengers` resolves correctly after apply
- make unqualified table lookup deterministic by surfacing ambiguity errors when a name exists in multiple schemas
- stop `duck apply` on the first failure and hydrate schema/table IDs from GET lookups on create conflict responses to prevent index-resolution cascades

## Verification
- task check
- go test ./internal/duckdbsql ./internal/sqlrewrite ./internal/service/security ./internal/service/query ./internal/api ./internal/engine ./internal/db/repository ./pkg/cli

Closes #147
Closes #197