### PR TITLE
fix: resolve catalog-qualified table lookup regression

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -139,6 +139,13 @@ func New(ctx context.Context, deps Deps) (*App, error) {
 		rowFilterRepo, columnMaskRepo, introspectionRepo,
 		extTableRepo,
 	)
+	authSvc.SetCatalogTableLookup(func(ctx context.Context, catalogName, schemaName, tableName string) (*domain.TableDetail, error) {
+		repo, err := catalogRepoFactory.ForCatalog(ctx, catalogName)
+		if err != nil {
+			return nil, err
+		}
+		return repo.GetTable(ctx, schemaName, tableName)
+	})
 
 	// === Check for empty database and log bootstrap instructions ===
 	_, total, _ := principalRepo.List(ctx, domain.PageRequest{MaxResults: 1})


### PR DESCRIPTION
## Summary
- wire catalog-aware table lookup into `AuthorizationService.LookupTableID` for three-part references like `catalog.schema.table`
- configure the authorization service in app wiring to resolve table IDs through the catalog repo factory before fallback metastore lookup
- add a regression unit test covering `demo.titanic.passengers` resolution through the new catalog-aware path

Closes #199

## Verification
- task check