### PR TITLE
refactor: remove low-confidence compatibility fallbacks

### DIFF
--- a/internal/api/handler_compute.go
+++ b/internal/api/handler_compute.go
@@ -180,8 +180,6 @@ func (h *APIHandler) CreateComputeAssignment(ctx context.Context, req CreateComp
 	}
 	if req.Body.IsDefault != nil {
 		domReq.IsDefault = *req.Body.IsDefault
-	} else {
-		domReq.IsDefault = true
 	}
 	if req.Body.FallbackLocal != nil {
 		domReq.FallbackLocal = *req.Body.FallbackLocal

--- a/internal/api/handler_compute_test.go
+++ b/internal/api/handler_compute_test.go
@@ -552,8 +552,12 @@ func TestHandler_CreateComputeAssignment(t *testing.T) {
 			name:         "happy path returns 201",
 			endpointName: "analytics-xl",
 			body:         CreateComputeAssignmentJSONRequestBody{PrincipalId: "user-1", PrincipalType: CreateComputeAssignmentRequestPrincipalTypeUser},
-			svcFn: func(_ context.Context, _ string, _ string, _ domain.CreateComputeAssignmentRequest) (*domain.ComputeAssignment, error) {
+			svcFn: func(_ context.Context, _ string, _ string, req domain.CreateComputeAssignmentRequest) (*domain.ComputeAssignment, error) {
+				if req.IsDefault {
+					return nil, domain.ErrValidation("is_default must be explicit")
+				}
 				a := sampleComputeAssignment()
+				a.IsDefault = req.IsDefault
 				return &a, nil
 			},
 			assertFn: func(t *testing.T, resp CreateComputeAssignmentResponseObject, err error) {

--- a/internal/api/handler_query.go
+++ b/internal/api/handler_query.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"net/http"
-	"strings"
 
 	"duck-demo/internal/domain"
 	"duck-demo/internal/service/query"
@@ -71,9 +70,7 @@ func (h *APIHandler) CreateManifest(ctx context.Context, req CreateManifestReque
 		schemaName = *req.Body.Schema
 	}
 
-	catalogName, parsedSchema, tableName := parseManifestTableRef(schemaName, req.Body.Table)
-
-	result, err := h.manifest.GetManifest(ctx, principal, catalogName, parsedSchema, tableName)
+	result, err := h.manifest.GetManifest(ctx, principal, "", schemaName, req.Body.Table)
 	if err != nil {
 		code := errorCodeFromError(err)
 		msg := err.Error()
@@ -108,16 +105,4 @@ func (h *APIHandler) CreateManifest(ctx context.Context, req CreateManifestReque
 		},
 		Headers: CreateManifest200ResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset},
 	}, nil
-}
-
-func parseManifestTableRef(defaultSchema, tableInput string) (catalogName, schemaName, tableName string) {
-	parts := strings.Split(tableInput, ".")
-	switch len(parts) {
-	case 3:
-		return parts[0], parts[1], parts[2]
-	case 2:
-		return "", parts[0], parts[1]
-	default:
-		return "", defaultSchema, tableInput
-	}
 }

--- a/internal/api/handler_query_test.go
+++ b/internal/api/handler_query_test.go
@@ -188,15 +188,15 @@ func TestHandler_CreateManifest(t *testing.T) {
 			},
 		},
 		{
-			name: "qualified table string is parsed into catalog schema table",
+			name: "qualified table string is passed through without parsing",
 			body: CreateManifestJSONRequestBody{Table: "demo.titanic.passengers"},
 			svcFn: func(_ context.Context, _ string, catalogName, schemaName, tableName string) (*query.ManifestResult, error) {
-				if catalogName != "demo" || schemaName != "titanic" || tableName != "passengers" {
-					return nil, domain.ErrValidation("unexpected parsed table reference")
+				if catalogName != "" || schemaName != "main" || tableName != "demo.titanic.passengers" {
+					return nil, domain.ErrValidation("unexpected table reference")
 				}
 				return &query.ManifestResult{
-					Table:       "passengers",
-					Schema:      "titanic",
+					Table:       "demo.titanic.passengers",
+					Schema:      "main",
 					Columns:     []query.ManifestColumn{{Name: "id", Type: "INTEGER"}},
 					Files:       []string{"s3://bucket/data/file.parquet"},
 					RowFilters:  []string{},

--- a/internal/api/handler_storage.go
+++ b/internal/api/handler_storage.go
@@ -76,8 +76,6 @@ func (h *APIHandler) CreateStorageCredential(ctx context.Context, req CreateStor
 	}
 	if req.Body.UrlStyle != nil {
 		domReq.URLStyle = *req.Body.UrlStyle
-	} else {
-		domReq.URLStyle = "path"
 	}
 	// Azure fields
 	if req.Body.AzureAccountName != nil {

--- a/internal/api/handler_storage_test.go
+++ b/internal/api/handler_storage_test.go
@@ -274,8 +274,12 @@ func TestHandler_CreateStorageCredential(t *testing.T) {
 		{
 			name: "happy path returns 201",
 			body: CreateStorageCredentialJSONRequestBody{Name: "my-s3-cred", CredentialType: ct},
-			svcFn: func(_ context.Context, _ string, _ domain.CreateStorageCredentialRequest) (*domain.StorageCredential, error) {
+			svcFn: func(_ context.Context, _ string, req domain.CreateStorageCredentialRequest) (*domain.StorageCredential, error) {
+				if req.URLStyle != "" {
+					return nil, domain.ErrValidation("url_style must be explicit")
+				}
 				c := sampleStorageCredential()
+				c.URLStyle = req.URLStyle
 				return &c, nil
 			},
 			assertFn: func(t *testing.T, resp CreateStorageCredentialResponseObject, err error) {


### PR DESCRIPTION
## Summary
- remove low-confidence runtime tolerance in API handlers by requiring explicit request values (`is_default`, `url_style`) and by removing manifest table reference auto-parsing
- remove CLI best-effort compatibility behavior so declarative state reads and `duck describe` fail fast on non-2xx endpoint responses
- update API and CLI tests to assert strict behavior for these paths

## Validation
- ran `go test ./internal/api ./pkg/cli` (pass)
- ran `task check` before commit (fails due existing broader-suite issues, including `internal/service/query`, `internal/db/repository` search tests, and integration declarative/api-key panics on this stacked branch)