### PR TITLE
fix: harden error handling and audit coverage

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -180,7 +180,7 @@ func New(ctx context.Context, deps Deps) (*App, error) {
 	columnMaskSvc := security.NewColumnMaskService(columnMaskRepo, auditRepo)
 	auditSvc := governance.NewAuditService(auditRepo)
 	queryHistorySvc := governance.NewQueryHistoryService(queryHistoryRepo)
-	lineageSvc := governance.NewLineageService(lineageRepo, colLineageRepo)
+	lineageSvc := governance.NewLineageService(lineageRepo, colLineageRepo, auditRepo)
 	searchRepoFactory := repository.NewSearchRepoFactory(deps.ReadDB, catalogRegRepo)
 	searchSvc := catalog.NewSearchService(searchRepo, searchRepoFactory)
 	tagSvc := governance.NewTagService(tagRepo, auditRepo)

--- a/internal/service/catalog/catalog.go
+++ b/internal/service/catalog/catalog.go
@@ -434,7 +434,13 @@ func (s *CatalogService) ProfileTable(ctx context.Context, catalogName string, p
 	}
 
 	// Return stored stats (which now has LastProfiledAt set by the DB)
-	return s.stats.Get(ctx, securableName)
+	result, err := s.stats.Get(ctx, securableName)
+	if err != nil {
+		return nil, err
+	}
+
+	s.logAudit(ctx, principal, "PROFILE_TABLE", fmt.Sprintf("Profiled table %q.%q", schemaName, tableName))
+	return result, nil
 }
 
 func (s *CatalogService) enrichSchemaTags(ctx context.Context, schema *domain.SchemaDetail) {


### PR DESCRIPTION
## Summary
- propagate previously swallowed errors in model materialization count paths, model dependency updates, and notebook result persistence
- add missing audit events for notebook cell lifecycle, session close, pipeline job create/delete, lineage delete/purge, model run cancel, and catalog table profiling
- normalize pipeline/model audit status values to the documented `ALLOWED` taxonomy and wire lineage service auditing in app setup

## Testing
- task check