### PR TITLE
fix: allow local startup without OIDC configuration

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -58,8 +58,10 @@ func run() error {
 	if err != nil {
 		return fmt.Errorf("config: %w", err)
 	}
-	if err := cfg.Auth.Validate(); err != nil {
-		return fmt.Errorf("auth config: %w", err)
+	if cfg.Auth.OIDCEnabled() {
+		if err := cfg.Auth.Validate(); err != nil {
+			return fmt.Errorf("auth config: %w", err)
+		}
 	}
 
 	// Create structured logger


### PR DESCRIPTION
## Summary
- gate startup auth config validation behind `cfg.Auth.OIDCEnabled()` in `cmd/server/main.go`
- keep strict validation when OIDC is configured, but allow local/dev startup when OIDC env vars are intentionally unset
- restore API-key-first local workflows (for demo/project retests) without relaxing production checks in `LoadFromEnv`

## Testing
- `go test ./internal/config`
- `go test ./cmd/server`