### PR TITLE
fix: prevent apply from revoking active API key auth

### DIFF
--- a/pkg/cli/apply_cmd.go
+++ b/pkg/cli/apply_cmd.go
@@ -98,6 +98,12 @@ func newApplyCmd(client *gen.Client) *cobra.Command {
 				}
 			}
 
+			// 6.5. Fail fast if this apply would revoke the API key currently
+			// used by the CLI itself.
+			if err := stateClient.ValidateNoSelfAPIKeyDeletion(cmd.Context(), plan.Actions); err != nil {
+				return fmt.Errorf("preflight auth validation: %w", err)
+			}
+
 			// 7. Execute each action.
 			type actionResult struct {
 				Operation    string `json:"operation"`


### PR DESCRIPTION
## Summary
- add a declarative apply preflight that blocks plans which delete or update the API key currently used for CLI authentication
- compare planned API key deletions against the authenticated key prefix from the active `--api-key` value
- keep existing API key execution paths, and add focused tests for blocked self-deletion and token-auth bypass

## Testing
- task check