### PR TITLE
test: enforce mutation audit governance

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -200,6 +200,7 @@ func New(ctx context.Context, deps Deps) (*App, error) {
 	catalogRegSvc := catalog.NewCatalogRegistrationService(catalog.RegistrationServiceDeps{
 		Repo:               catalogRegRepo,
 		Attacher:           secretMgr,
+		Audit:              auditRepo,
 		ControlPlaneDBPath: cfg.MetaDBPath,
 		Logger:             deps.Logger.With("component", "catalog-registration"),
 		MetastoreFactory:   metastoreFactory,

--- a/internal/architecture/audit_rules_test.go
+++ b/internal/architecture/audit_rules_test.go
@@ -1,0 +1,202 @@
+package architecture_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var auditMutationPrefixes = []string{
+	"Create",
+	"Update",
+	"Delete",
+	"Cancel",
+	"Close",
+	"Purge",
+	"Register",
+	"Profile",
+	"Bind",
+	"Unbind",
+	"Assign",
+	"Unassign",
+	"Trigger",
+	"Reorder",
+	"Execute",
+	"Run",
+	"Set",
+	"Attach",
+}
+
+// Explicit exceptions for methods that are intentionally non-audited.
+// Key format: "path/to/file.go:Receiver.Method".
+var auditRuleExceptions = map[string]string{
+	"internal/service/catalog/registration.go:CatalogRegistrationService.AttachAll": "startup reconciliation path; audit policy handled at caller/system level",
+	"internal/service/notebook/session.go:SessionManager.ExecuteCell":               "high-volume cell execution path; auditing policy handled at run/job level",
+	"internal/service/notebook/session.go:SessionManager.RunAll":                    "delegates execution to ExecuteCell; avoid duplicate per-run noise",
+}
+
+func TestServiceMutations_AreAudited(t *testing.T) {
+	t.Helper()
+
+	serviceRoot := filepath.Join(repoRootDir(), "internal", "service")
+	files, err := collectGoFiles(serviceRoot)
+	require.NoError(t, err)
+
+	violations := make([]string, 0)
+
+	for _, file := range files {
+		if shouldSkipProductionGovernanceFile(file) {
+			continue
+		}
+
+		fset := token.NewFileSet()
+		parsed, parseErr := parser.ParseFile(fset, file, nil, 0)
+		require.NoErrorf(t, parseErr, "parse file for audit rules: %s", file)
+
+		relPath := relToRepoRoot(file)
+		for _, decl := range parsed.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Recv == nil || fn.Body == nil {
+				continue
+			}
+
+			receiver := receiverTypeName(fn)
+			if !isAuditedReceiver(receiver) {
+				continue
+			}
+			if !isMutatingMethod(fn.Name.Name) {
+				continue
+			}
+			if !hasContextParam(fn) {
+				continue
+			}
+
+			key := relPath + ":" + receiver + "." + fn.Name.Name
+			if _, ok := auditRuleExceptions[key]; ok {
+				continue
+			}
+
+			if !containsAuditCall(fn.Body) {
+				violations = append(violations, key)
+			}
+		}
+	}
+
+	sort.Strings(violations)
+	require.Empty(t, violations,
+		"service mutating methods must emit audit logs (add logAudit/audit.Insert or add explicit exception):\n%s",
+		strings.Join(violations, "\n"),
+	)
+}
+
+func receiverTypeName(fn *ast.FuncDecl) string {
+	if fn.Recv == nil || len(fn.Recv.List) == 0 {
+		return ""
+	}
+
+	switch rt := fn.Recv.List[0].Type.(type) {
+	case *ast.StarExpr:
+		if id, ok := rt.X.(*ast.Ident); ok {
+			return id.Name
+		}
+	case *ast.Ident:
+		return rt.Name
+	}
+
+	return ""
+}
+
+func isAuditedReceiver(receiver string) bool {
+	if receiver == "" {
+		return false
+	}
+	return strings.HasSuffix(receiver, "Service") || strings.HasSuffix(receiver, "Manager")
+}
+
+func isMutatingMethod(name string) bool {
+	for _, prefix := range auditMutationPrefixes {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasContextParam(fn *ast.FuncDecl) bool {
+	if fn.Type == nil || fn.Type.Params == nil {
+		return false
+	}
+
+	for _, field := range fn.Type.Params.List {
+		t, ok := field.Type.(*ast.SelectorExpr)
+		if !ok {
+			continue
+		}
+
+		pkg, ok := t.X.(*ast.Ident)
+		if ok && pkg.Name == "context" && t.Sel.Name == "Context" {
+			return true
+		}
+	}
+
+	return false
+}
+
+func containsAuditCall(body *ast.BlockStmt) bool {
+	found := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+
+		switch fun := call.Fun.(type) {
+		case *ast.Ident:
+			if fun.Name == "logAudit" {
+				found = true
+				return false
+			}
+		case *ast.SelectorExpr:
+			if fun.Sel.Name == "logAudit" {
+				found = true
+				return false
+			}
+			if fun.Sel.Name == "Insert" && expressionContainsAudit(fun.X) {
+				found = true
+				return false
+			}
+		}
+
+		return true
+	})
+
+	return found
+}
+
+func expressionContainsAudit(expr ast.Expr) bool {
+	if expr == nil {
+		return false
+	}
+
+	switch v := expr.(type) {
+	case *ast.Ident:
+		return strings.Contains(strings.ToLower(v.Name), "audit")
+	case *ast.SelectorExpr:
+		if strings.Contains(strings.ToLower(v.Sel.Name), "audit") {
+			return true
+		}
+		return expressionContainsAudit(v.X)
+	}
+
+	return false
+}

--- a/internal/service/model/service.go
+++ b/internal/service/model/service.go
@@ -336,6 +336,7 @@ func (s *Service) TriggerRunSync(ctx context.Context, principal string, req doma
 		return fmt.Errorf("model run %s: %s", finalRun.Status, msg)
 	}
 
+	s.logAudit(ctx, principal, "trigger_model_run_sync", run.ID)
 	return nil
 }
 

--- a/internal/service/notebook/notebook.go
+++ b/internal/service/notebook/notebook.go
@@ -224,5 +224,12 @@ func (s *Service) ReorderCells(ctx context.Context, principal string, isAdmin bo
 	if err := s.repo.ReorderCells(ctx, notebookID, req.CellIDs); err != nil {
 		return nil, err
 	}
+
+	_ = s.audit.Insert(ctx, &domain.AuditEntry{
+		PrincipalName: principal,
+		Action:        "REORDER_CELLS",
+		Status:        "ALLOWED",
+	})
+
 	return s.repo.ListCells(ctx, notebookID)
 }

--- a/internal/service/notebook/session.go
+++ b/internal/service/notebook/session.go
@@ -388,6 +388,16 @@ func (m *SessionManager) RunAllAsync(ctx context.Context, sessionID string, prin
 		return nil, fmt.Errorf("create job: %w", err)
 	}
 
+	auditPrincipal := caller
+	if auditPrincipal == "" {
+		auditPrincipal = s.principal
+	}
+	_ = m.audit.Insert(ctx, &domain.AuditEntry{
+		PrincipalName: auditPrincipal,
+		Action:        "RUN_ALL_ASYNC",
+		Status:        "ALLOWED",
+	})
+
 	// Launch async execution using the session's cancellable context
 	// instead of context.Background() so that CloseSession/CloseAll
 	// can stop the goroutine.

--- a/internal/service/security/column_mask.go
+++ b/internal/service/security/column_mask.go
@@ -60,7 +60,15 @@ func (s *ColumnMaskService) Delete(ctx context.Context, id string) error {
 	if err := requireAdmin(ctx); err != nil {
 		return err
 	}
-	return s.repo.Delete(ctx, id)
+	if err := s.repo.Delete(ctx, id); err != nil {
+		return err
+	}
+	_ = s.audit.Insert(ctx, &domain.AuditEntry{
+		PrincipalName: callerName(ctx),
+		Action:        "DELETE_COLUMN_MASK",
+		Status:        "ALLOWED",
+	})
+	return nil
 }
 
 // Bind associates a column mask with a principal or group. Requires admin privileges.
@@ -77,7 +85,15 @@ func (s *ColumnMaskService) Bind(ctx context.Context, req domain.BindColumnMaskR
 		PrincipalType: req.PrincipalType,
 		SeeOriginal:   req.SeeOriginal,
 	}
-	return s.repo.Bind(ctx, b)
+	if err := s.repo.Bind(ctx, b); err != nil {
+		return err
+	}
+	_ = s.audit.Insert(ctx, &domain.AuditEntry{
+		PrincipalName: callerName(ctx),
+		Action:        "BIND_COLUMN_MASK",
+		Status:        "ALLOWED",
+	})
+	return nil
 }
 
 // Unbind removes a column mask binding from a principal or group. Requires admin privileges.
@@ -93,7 +109,15 @@ func (s *ColumnMaskService) Unbind(ctx context.Context, req domain.BindColumnMas
 		PrincipalID:   req.PrincipalID,
 		PrincipalType: req.PrincipalType,
 	}
-	return s.repo.Unbind(ctx, b)
+	if err := s.repo.Unbind(ctx, b); err != nil {
+		return err
+	}
+	_ = s.audit.Insert(ctx, &domain.AuditEntry{
+		PrincipalName: callerName(ctx),
+		Action:        "UNBIND_COLUMN_MASK",
+		Status:        "ALLOWED",
+	})
+	return nil
 }
 
 // ListBindings returns all bindings for a column mask. Requires admin privileges.


### PR DESCRIPTION
## Summary
- add an architecture governance test that enforces audit logging for mutating service/manager methods across `internal/service`
- expand mutation prefix coverage and add explicit policy exceptions for high-volume/system paths
- add missing audit emits in catalog registration, column mask bind/delete/unbind, notebook reorder/run-async, and model synchronous run paths

## Testing
- go test ./internal/architecture -run TestServiceMutations_AreAudited -v
- go test ./internal/architecture
- go test ./internal/service/catalog/... ./internal/service/security/... ./internal/service/notebook/... ./internal/service/model/... ./internal/app/...
- task check