### PR TITLE
fix: set-default endpoint maps validation errors to 400 contract (#241)

### DIFF
--- a/internal/api/handler_catalogs.go
+++ b/internal/api/handler_catalogs.go
@@ -143,7 +143,7 @@ func (h *APIHandler) SetDefaultCatalog(ctx context.Context, request SetDefaultCa
 		case errors.As(err, new(*domain.NotFoundError)):
 			return SetDefaultCatalog404JSONResponse{NotFoundJSONResponse{Body: Error{Code: 404, Message: err.Error()}, Headers: NotFoundResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
 		case errors.As(err, new(*domain.ValidationError)):
-			return SetDefaultCatalog403JSONResponse{ForbiddenJSONResponse{Body: Error{Code: 400, Message: err.Error()}, Headers: ForbiddenResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+			return SetDefaultCatalog400JSONResponse{BadRequestJSONResponse{Body: Error{Code: 400, Message: err.Error()}, Headers: BadRequestResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
 		default:
 			return nil, err
 		}

--- a/internal/api/handler_catalogs_test.go
+++ b/internal/api/handler_catalogs_test.go
@@ -446,6 +446,19 @@ func TestHandler_SetDefaultCatalog(t *testing.T) {
 				assert.Equal(t, int32(404), notFound.Body.Code)
 			},
 		},
+		{
+			name: "validation returns 400",
+			svcFn: func(_ context.Context, _ string) (*domain.CatalogRegistration, error) {
+				return nil, domain.ErrValidation("catalog must be ACTIVE")
+			},
+			assertFn: func(t *testing.T, resp SetDefaultCatalogResponseObject, err error) {
+				t.Helper()
+				require.NoError(t, err)
+				badReq, ok := resp.(SetDefaultCatalog400JSONResponse)
+				require.True(t, ok, "expected 400 response, got %T", resp)
+				assert.Equal(t, int32(400), badReq.Body.Code)
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/test-scripts/repro-issue-241-setdefault-status.sh
+++ b/test-scripts/repro-issue-241-setdefault-status.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE="${1:-before}"
+FILE="internal/api/handler_catalogs.go"
+
+if [[ "$MODE" == "before" ]]; then
+  echo "[repro-before] Expecting buggy 403 response type in ValidationError branch"
+  grep -q 'SetDefaultCatalog403JSONResponse{ForbiddenJSONResponse{Body: Error{Code: 400' "$FILE"
+  echo "Bug reproduced: validation is mapped to 403 response type with code 400 body."
+elif [[ "$MODE" == "after" ]]; then
+  echo "[verify-after] Expecting 400 response type in ValidationError branch"
+  grep -q 'SetDefaultCatalog400JSONResponse{BadRequestJSONResponse{Body: Error{Code: 400' "$FILE"
+  if grep -q 'SetDefaultCatalog403JSONResponse{ForbiddenJSONResponse{Body: Error{Code: 400' "$FILE"; then
+    echo "Unexpected old buggy mapping still present"
+    exit 1
+  fi
+  echo "Fix verified: ValidationError now maps to 400 response type."
+else
+  echo "Usage: $0 [before|after]"
+  exit 2
+fi


### PR DESCRIPTION
## Root cause
`SetDefaultCatalog` handled `domain.ValidationError` using `SetDefaultCatalog403JSONResponse` (forbidden response type) while setting `Body.Code=400`.
This created a response type/status mismatch versus the OpenAPI contract.

## Fix summary
- Map `domain.ValidationError` to `SetDefaultCatalog400JSONResponse` with `BadRequestJSONResponse` headers/body.
- Add handler test coverage for the validation path (`validation returns 400`).
- Add a targeted repro/verification script:
  - `test-scripts/repro-issue-241-setdefault-status.sh before|after`

## Repro steps
### Before fix (bug present)
```bash
cd /root/.openclaw/workspace/wt-fix-240
grep -q "SetDefaultCatalog403JSONResponse{ForbiddenJSONResponse{Body: Error{Code: 400" internal/api/handler_catalogs.go && echo "before: bug present"
```

### After fix (verified)
```bash
cd /root/.openclaw/workspace/wt-fix-241
./test-scripts/repro-issue-241-setdefault-status.sh after
```

## Test evidence
- Static repro before fix confirms buggy mapping exists.
- Post-fix script confirms validation branch now uses `SetDefaultCatalog400JSONResponse` and old mapping is absent.
- Note: full `go test ./internal/api` is currently blocked by separate known main-branch build drift (`#231`), intentionally not addressed in this PR.
