### PR TITLE
fix: CLI accepts unexpected positional args on zero-arg commands (#244)

### DIFF
--- a/pkg/cli/commands_cmd.go
+++ b/pkg/cli/commands_cmd.go
@@ -55,6 +55,7 @@ This is designed for AI agents to discover available CLI capabilities in a singl
 
   # Get full command metadata for agent consumption
   duck commands --output json`,
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			entries := walkCommands(cmd.Root(), "")
 

--- a/pkg/cli/config_cmd.go
+++ b/pkg/cli/config_cmd.go
@@ -29,6 +29,7 @@ func newConfigShowCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "show",
 		Short: "Display current configuration",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cfg, err := LoadUserConfig()
 			if err != nil {
@@ -95,6 +96,7 @@ func newConfigSetProfileCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "set-profile",
 		Short: "Create or update a configuration profile",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if name == "" {
 				return fmt.Errorf("--name is required")

--- a/pkg/cli/version_cmd.go
+++ b/pkg/cli/version_cmd.go
@@ -13,6 +13,7 @@ func newVersionCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
 		Short: "Print the CLI version",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if getOutputFormat(cmd) == "json" {
 				return gen.PrintJSON(os.Stdout, map[string]string{

--- a/pkg/cli/zero_args_validation_test.go
+++ b/pkg/cli/zero_args_validation_test.go
@@ -1,0 +1,36 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestZeroArgCommandsRejectUnexpectedPositionalArgs(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	bootstrap := newRootCmd()
+	bootstrap.SetArgs([]string{"config", "set-profile", "--name", "default", "--host", "http://127.0.0.1:65535"})
+	require.NoError(t, bootstrap.Execute())
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "version", args: []string{"version", "extra"}},
+		{name: "commands", args: []string{"commands", "extra"}},
+		{name: "config show", args: []string{"config", "show", "extra"}},
+		{name: "commands json", args: []string{"commands", "--output", "json", "extra"}},
+		{name: "config set-profile", args: []string{"config", "set-profile", "--name", "p", "--host", "http://127.0.0.1:65535", "extra"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := newRootCmd()
+			cmd.SetArgs(tc.args)
+			err := cmd.Execute()
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "unknown command \"extra\"")
+		})
+	}
+}

--- a/test-scripts/repro-issue-244-zero-arg-positional.sh
+++ b/test-scripts/repro-issue-244-zero-arg-positional.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+MODE="${1:-report}" # report|expect-bug|expect-fixed
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="$ROOT_DIR/bin/duck"
+TEST_HOME="/tmp/duckcli-issue-244"
+
+mkdir -p "$ROOT_DIR/bin"
+go build -o "$BIN" "$ROOT_DIR/cmd/cli"
+
+rm -rf "$TEST_HOME"
+mkdir -p "$TEST_HOME"
+export HOME="$TEST_HOME"
+"$BIN" config set-profile --name default --host http://127.0.0.1:65535 >/dev/null
+
+run_case() {
+  local name="$1"; shift
+  local out rc
+  set +e
+  out=$("$@" 2>&1)
+  rc=$?
+  set -e
+  echo "CASE: $name"
+  echo "EXIT: $rc"
+  echo "$out"
+  echo "---"
+
+  if [[ "$MODE" == "expect-bug" ]]; then
+    [[ $rc -eq 0 ]] || { echo "expected buggy success for '$name'"; return 1; }
+  elif [[ "$MODE" == "expect-fixed" ]]; then
+    [[ $rc -ne 0 ]] || { echo "expected non-zero for '$name'"; return 1; }
+  fi
+}
+
+run_case "version extra" "$BIN" version extra
+run_case "commands extra" "$BIN" commands extra
+run_case "config show extra" "$BIN" config show extra
+run_case "commands --output json extra" "$BIN" commands --output json extra
+run_case "config set-profile ... extra" "$BIN" config set-profile --name p --host http://127.0.0.1:65535 extra
+
+echo "done mode=$MODE"


### PR DESCRIPTION
## Root cause
Several hand-written zero-argument commands (`version`, `commands`, `config show`, `config set-profile`) did not declare a positional-argument policy (`Args: cobra.NoArgs`). As a result, trailing positional tokens were silently accepted/ignored in built CLI flows.

## Fix summary
- Added `Args: cobra.NoArgs` to:
  - `version`
  - `commands`
  - `config show`
  - `config set-profile`
- Added a targeted regression test:
  - `TestZeroArgCommandsRejectUnexpectedPositionalArgs`
- Added script-first repro/verification script:
  - `test-scripts/repro-issue-244-zero-arg-positional.sh`

## Repro steps
Before fix:
```bash
test-scripts/repro-issue-244-zero-arg-positional.sh expect-bug
```
Observed all five cases exited `0`.

After fix:
```bash
test-scripts/repro-issue-244-zero-arg-positional.sh expect-fixed
```
Observed all five cases exit non-zero with `unknown command "extra"`.

## Test evidence
```bash
go test ./pkg/cli -run TestZeroArgCommandsRejectUnexpectedPositionalArgs -count=1
```
Passes on this branch.
