### PR TITLE
fix: config set-profile accepts malformed --host values (#254)

### DIFF
--- a/pkg/cli/config_cmd.go
+++ b/pkg/cli/config_cmd.go
@@ -115,6 +115,9 @@ func newConfigSetProfileCmd() *cobra.Command {
 
 			p := cfg.Profiles[name]
 			if cmd.Flags().Changed("host") {
+				if err := validateHostURL(host); err != nil {
+					return err
+				}
 				p.Host = host
 			}
 			if cmd.Flags().Changed("api-key") {

--- a/pkg/cli/config_cmd_test.go
+++ b/pkg/cli/config_cmd_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMaskSecret(t *testing.T) {
@@ -61,4 +62,14 @@ func TestMaskConfig_EmptyProfiles(t *testing.T) {
 
 	masked := maskConfig(cfg)
 	assert.Empty(t, masked.Profiles)
+}
+
+func TestConfigSetProfileRejectsInvalidHost(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	cmd := newConfigSetProfileCmd()
+	cmd.SetArgs([]string{"--name", "bad", "--host", "localhost:8080"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid host")
 }

--- a/pkg/cli/host_helpers.go
+++ b/pkg/cli/host_helpers.go
@@ -1,0 +1,32 @@
+package cli
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+func validateHostURL(host string) error {
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return fmt.Errorf("invalid host %q: host URL cannot be empty", host)
+	}
+
+	u, err := url.Parse(host)
+	if err != nil {
+		return fmt.Errorf("invalid host %q: %w", host, err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("invalid host %q: scheme must be http or https", host)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("invalid host %q: missing host", host)
+	}
+	if u.Path != "" && u.Path != "/" {
+		return fmt.Errorf("invalid host %q: host must not include a path", host)
+	}
+	if u.RawQuery != "" || u.Fragment != "" {
+		return fmt.Errorf("invalid host %q: host must not include query or fragment", host)
+	}
+	return nil
+}

--- a/pkg/cli/host_helpers_test.go
+++ b/pkg/cli/host_helpers_test.go
@@ -1,0 +1,30 @@
+package cli
+
+import "testing"
+
+func TestValidateHostURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		host    string
+		wantErr bool
+	}{
+		{name: "valid http", host: "http://127.0.0.1:8080"},
+		{name: "valid https", host: "https://api.example.com"},
+		{name: "missing scheme", host: "localhost:8080", wantErr: true},
+		{name: "bogus scheme", host: "://bad", wantErr: true},
+		{name: "empty", host: "", wantErr: true},
+		{name: "path not allowed", host: "http://localhost:8080/v1", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateHostURL(tt.host)
+			if tt.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("expected nil error, got %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Root cause
`config set-profile` persisted `--host` exactly as provided without validation. This allowed malformed values like `localhost:8080` and `://bad` to be stored, causing later runtime request failures instead of immediate config-time feedback.

## Fix summary
- Added `validateHostURL()` and wired it into `config set-profile` when `--host` is provided.
- Validation now requires:
  - scheme: `http` or `https`
  - non-empty host
  - no path/query/fragment in host field
- Added targeted tests:
  - `TestValidateHostURL`
  - `TestConfigSetProfileRejectsInvalidHost`

## Repro steps
### Before
```bash
HOME=$(mktemp -d)
/root/.openclaw/workspace/ducklake-dataplatform/bin/duck config set-profile --name bad-missing-scheme --host localhost:8080
# rc=0, profile persisted (incorrect)
```

### After
```bash
go test ./pkg/cli -run 'TestConfigSetProfileRejectsInvalidHost|TestValidateHostURL' -v
# passes; invalid host now rejected with error
```

## Test evidence
- Before repro script output:
  - `rc=0`
  - `Profile "bad-missing-scheme" saved ...`
- After targeted tests:
  - `PASS: TestConfigSetProfileRejectsInvalidHost`
  - `PASS: TestValidateHostURL`
