### PR TITLE
fix: config show --output table emits table output (#260)

### DIFF
--- a/test-scripts/repro-issue-260-config-show-output.sh
+++ b/test-scripts/repro-issue-260-config-show-output.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_DIR="${1:-$(pwd)}"
+TMP_HOME="$(mktemp -d)"
+trap 'rm -rf "$TMP_HOME"' EXIT
+
+cd "$REPO_DIR"
+CLI_BIN="./cli"
+if [[ ! -x "$CLI_BIN" ]]; then
+  echo "missing executable $CLI_BIN" >&2
+  exit 1
+fi
+
+HOME="$TMP_HOME" "$CLI_BIN" config set-profile --name p1 --host http://localhost:9999 >/dev/null
+HOME="$TMP_HOME" "$CLI_BIN" config show --output table


### PR DESCRIPTION
## Root cause
`config show` only special-cased JSON output and always fell back to YAML for all other formats. Since root-level `--output table` is valid and defaulted for the CLI, this made `config show --output table` silently violate output contract.

## Fix summary
- Added explicit `table` output handling in `newConfigShowCmd`.
- Implemented `renderConfigTable` to print profile rows using `gen.PrintTable`.
- Kept JSON behavior unchanged.
- Added a command-level test (`TestConfigShow_TableOutput`) asserting table headers/row semantics and masked secret behavior.

## Repro steps
### Before
```bash
TMP_HOME=$(mktemp -d)
HOME=$TMP_HOME /root/.openclaw/workspace/ducklake-dataplatform/cli config set-profile --name p1 --host http://localhost:9999 >/dev/null
HOME=$TMP_HOME /root/.openclaw/workspace/ducklake-dataplatform/cli config show --output table
```
Output before fix:
```yaml
current-profile: default
profiles:
    p1:
        host: http://localhost:9999
```

### After
```bash
go build -o ./cli ./cmd/cli
TMP_HOME=$(mktemp -d)
HOME=$TMP_HOME ./cli config set-profile --name p1 --host http://localhost:9999 >/dev/null
HOME=$TMP_HOME ./cli config show --output table
```
Output after fix:
```text
PROFILE  ACTIVE  HOST                   OUTPUT  API_KEY  TOKEN
p1               http://localhost:9999
```

## Test evidence
- Added targeted regression test: `pkg/cli/config_cmd_test.go::TestConfigShow_TableOutput`
- Added script-first repro helper:
  - `test-scripts/repro-issue-260-config-show-output.sh`
