### PR TITLE
fix: server --help starts server instead of printing usage (#263)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net"
 	"net/http"
@@ -32,6 +33,11 @@ import (
 )
 
 func main() {
+	if isHelpArg(os.Args[1:]) {
+		printUsage(os.Stdout)
+		return
+	}
+
 	// Handle admin subcommands before starting the server.
 	if len(os.Args) >= 2 && os.Args[1] == "admin" {
 		if err := runAdmin(os.Args[2:]); err != nil {
@@ -45,6 +51,25 @@ func main() {
 		fmt.Fprintf(os.Stderr, "fatal: %v\n", err)
 		os.Exit(1)
 	}
+}
+
+func isHelpArg(args []string) bool {
+	for _, arg := range args {
+		if arg == "-h" || arg == "--help" || arg == "help" {
+			return true
+		}
+	}
+	return false
+}
+
+func printUsage(w io.Writer) {
+	_, _ = fmt.Fprintln(w, "usage: server [flags]")
+	_, _ = fmt.Fprintln(w)
+	_, _ = fmt.Fprintln(w, "Starts the DuckLake HTTP API server.")
+	_, _ = fmt.Fprintln(w)
+	_, _ = fmt.Fprintln(w, "Admin commands:")
+	_, _ = fmt.Fprintln(w, "  server admin promote --principal=<name> [--create]")
+	_, _ = fmt.Fprintln(w, "  server admin demote  --principal=<name>")
 }
 
 func run() error {

--- a/test-scripts/repro-263-server-help.sh
+++ b/test-scripts/repro-263-server-help.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+mkdir -p bin
+
+go build -o bin/server ./cmd/server
+
+out_dir="test-results"
+mkdir -p "$out_dir"
+out_file="$out_dir/repro-263-server-help.out"
+err_file="$out_dir/repro-263-server-help.err"
+
+set +e
+timeout 3 ./bin/server --help >"$out_file" 2>"$err_file"
+rc=$?
+set -e
+
+echo "exit_code=$rc"
+if [[ $rc -eq 124 ]]; then
+  echo "FAIL: command timed out (server likely started instead of showing help)"
+  exit 1
+fi
+
+if ! grep -qi "usage" "$out_file" && ! grep -qi "usage" "$err_file"; then
+  echo "FAIL: expected usage/help text in output"
+  echo "--- stdout ---"
+  cat "$out_file"
+  echo "--- stderr ---"
+  cat "$err_file"
+  exit 1
+fi
+
+if grep -q "HTTP API listening" "$err_file"; then
+  echo "FAIL: server startup log found while requesting --help"
+  exit 1
+fi
+
+echo "PASS: --help printed usage and did not start server"


### PR DESCRIPTION
## Root cause
`cmd/server/main.go` did not parse any top-level help arguments. The binary always flowed into `run()` (unless the first arg was `admin`), so `server --help` started normal server boot (config load, DB/migrations, HTTP listener) instead of exiting with usage.

## Fix summary
- Add early help-argument guard in `main()` for `-h`, `--help`, and `help`.
- Print concise server usage text and admin subcommand usage.
- Return immediately before startup side effects.
- Add targeted repro script: `test-scripts/repro-263-server-help.sh`.

## Repro steps
Before fix (issue behavior):
```bash
cd /root/.openclaw/workspace/ducklake-dataplatform
(timeout 3 ./bin/server --help) || true
```
Expected from issue report: command should print usage and exit quickly; actual was startup side effects.

With this branch:
```bash
cd /root/.openclaw/workspace/.worktrees/wt-fix-263-night
./test-scripts/repro-263-server-help.sh
```

## Test evidence
Attempted targeted repro script run in this branch:
- `./test-scripts/repro-263-server-help.sh`
- **Blocked by existing main build break**: unresolved generated symbols in `internal/api` and `internal/db/dbstore` (tracked separately in #267).
- This PR keeps scope to #263 and does not attempt to resolve #267 (complex/codegen integration issue).
