### PR TITLE
fix: duck query execute ignores positional SQL arg and still errors without --sql (#269)

### DIFF
--- a/pkg/cli/query_override.go
+++ b/pkg/cli/query_override.go
@@ -15,8 +15,11 @@ import (
 
 func init() {
 	gen.RegisterRunOverride("executeQuery", func(client *gen.Client) func(*cobra.Command, []string) error {
-		return func(cmd *cobra.Command, _ []string) error {
+		return func(cmd *cobra.Command, args []string) error {
 			sql, _ := cmd.Flags().GetString("sql")
+			if sql == "" && len(args) > 0 {
+				sql = strings.TrimSpace(strings.Join(args, " "))
+			}
 
 			// Read from stdin if no --sql flag
 			if sql == "" {

--- a/pkg/cli/query_override_test.go
+++ b/pkg/cli/query_override_test.go
@@ -44,6 +44,19 @@ func TestQueryOverride(t *testing.T) {
 			},
 		},
 		{
+			name:       "SQL from positional arg",
+			args:       []string{"query", "execute", "SELECT 42"},
+			statusCode: http.StatusOK,
+			response:   `{"columns":["42"],"rows":[[42]],"row_count":1}`,
+			wantErr:    false,
+			checkReq: func(t *testing.T, c captured) {
+				t.Helper()
+				var body map[string]interface{}
+				require.NoError(t, json.Unmarshal(c.body, &body))
+				assert.Equal(t, "SELECT 42", body["sql"])
+			},
+		},
+		{
 			name:       "no SQL provided",
 			args:       []string{"query", "execute"},
 			statusCode: http.StatusOK,

--- a/test-scripts/repro-269-positional-query.sh
+++ b/test-scripts/repro-269-positional-query.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+go test ./pkg/cli -run TestQueryOverride/SQL_from_positional_arg -count=1


### PR DESCRIPTION
## Root cause
The `executeQuery` CLI run-override ignored positional arguments (`args []string`) and only considered `--sql` or stdin. As a result, `duck query execute "select 1"` dropped the positional SQL and failed local validation with `provide SQL via --sql flag or stdin pipe`.

## Fix summary
- Updated `pkg/cli/query_override.go` to consume positional args when `--sql` is not set.
- Positional args are joined and trimmed, then sent as the query SQL body.
- Added regression coverage in `pkg/cli/query_override_test.go` for `query execute "SELECT 42"`.
- Added targeted repro script: `test-scripts/repro-269-positional-query.sh`.

## Repro steps
Before fix:
1. `go test ./pkg/cli -run TestQueryOverride/SQL_from_positional_arg -count=1`
2. Observe failure with `provide SQL via --sql flag or stdin pipe`.

After fix:
1. `./test-scripts/repro-269-positional-query.sh`
2. Observe pass (`ok duck-demo/pkg/cli`).

## Test evidence
- ✅ `go test ./pkg/cli -run TestQueryOverride/SQL_from_positional_arg -count=1` (passes after fix)
- ✅ `go test ./pkg/cli -run TestQueryOverride -count=1`

Closes #269
