### PR TITLE
chore: add GHCR image publish and Coolify compose stack

### DIFF
--- a/.env.coolify.example
+++ b/.env.coolify.example
@@ -1,0 +1,21 @@
+# GHCR image coordinates
+GHCR_OWNER=yacobolo
+GHCR_REPO=ducklake-dataplatform
+IMAGE_TAG=main-latest
+
+# Control plane / agent shared secrets
+AGENT_TOKEN=change-me
+JWT_SECRET=change-me
+ENCRYPTION_KEY=0000000000000000000000000000000000000000000000000000000000000000
+
+# Hetzner Object Storage (existing bucket)
+S3_ACCESS_KEY=change-me
+S3_SECRET_KEY=change-me
+S3_ENDPOINT=fsn1.your-objectstorage.com
+S3_REGION=fsn1
+S3_BUCKET=your-existing-bucket
+
+# Postgres for DuckLake catalog metadata
+POSTGRES_DB=ducklake
+POSTGRES_USER=ducklake
+POSTGRES_PASSWORD=change-me

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -1,0 +1,57 @@
+name: Publish Images
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    name: Build and push GHCR images
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Prepare image coordinates
+        id: prep
+        run: |
+          OWNER="${GITHUB_REPOSITORY_OWNER,,}"
+          REPO="${GITHUB_REPOSITORY#*/}"
+          echo "owner=$OWNER" >> "$GITHUB_OUTPUT"
+          echo "repo=$REPO" >> "$GITHUB_OUTPUT"
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push control-plane image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ steps.prep.outputs.owner }}/${{ steps.prep.outputs.repo }}-control-plane:main-latest
+            ghcr.io/${{ steps.prep.outputs.owner }}/${{ steps.prep.outputs.repo }}-control-plane:sha-${{ github.sha }}
+
+      - name: Build and push compute-agent image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.compute-agent
+          push: true
+          tags: |
+            ghcr.io/${{ steps.prep.outputs.owner }}/${{ steps.prep.outputs.repo }}-compute-agent:main-latest
+            ghcr.io/${{ steps.prep.outputs.owner }}/${{ steps.prep.outputs.repo }}-compute-agent:sha-${{ github.sha }}

--- a/Dockerfile.compute-agent
+++ b/Dockerfile.compute-agent
@@ -1,0 +1,32 @@
+# syntax=docker/dockerfile:1
+
+# === Build stage ===
+FROM golang:1.25-alpine AS builder
+
+RUN apk add --no-cache gcc musl-dev
+
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+# Build the compute-agent binary with CGO enabled.
+RUN CGO_ENABLED=1 go build -o /bin/compute-agent ./cmd/compute-agent
+
+# === Runtime stage ===
+FROM alpine:3.21
+
+RUN apk add --no-cache ca-certificates tzdata wget
+
+COPY --from=builder /bin/compute-agent /usr/local/bin/compute-agent
+
+EXPOSE 9443 9444
+
+ENV LISTEN_ADDR=:9443 \
+    GRPC_LISTEN_ADDR=:9444
+
+HEALTHCHECK --interval=10s --timeout=3s --start-period=10s --retries=5 \
+    CMD wget -qO- http://localhost:9443/health || exit 1
+
+ENTRYPOINT ["compute-agent"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,91 @@
+services:
+  control-plane:
+    image: ghcr.io/${GHCR_OWNER}/${GHCR_REPO}-control-plane:${IMAGE_TAG:-main-latest}
+    pull_policy: always
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+    ports:
+      - "8080:8080"
+      - "32010:32010"
+      - "5433:5433"
+    environment:
+      LISTEN_ADDR: ":8080"
+      META_DB_PATH: "/data/ducklake_meta.sqlite"
+      LOG_LEVEL: "info"
+
+      # Keep ENV=development for local testing convenience.
+      ENV: "development"
+      JWT_SECRET: "${JWT_SECRET:-dev-jwt-secret-change-me}"
+      ENCRYPTION_KEY: "${ENCRYPTION_KEY:-0000000000000000000000000000000000000000000000000000000000000000}"
+
+      # Protocol and distributed execution flags.
+      FEATURE_REMOTE_ROUTING: "true"
+      FEATURE_ASYNC_QUEUE: "true"
+      FEATURE_CURSOR_MODE: "true"
+      FEATURE_INTERNAL_GRPC: "true"
+      FEATURE_FLIGHT_SQL: "true"
+      FEATURE_PG_WIRE: "true"
+      FLIGHT_SQL_LISTEN_ADDR: ":32010"
+      PG_WIRE_LISTEN_ADDR: ":5433"
+
+      # Optional S3-compatible config for control-plane ingestion/catalog paths.
+      KEY_ID: "${S3_ACCESS_KEY:-duckdemo}"
+      SECRET: "${S3_SECRET_KEY:-duckdemo-secret}"
+      ENDPOINT: "${S3_ENDPOINT}"
+      REGION: "${S3_REGION}"
+      BUCKET: "${S3_BUCKET}"
+    volumes:
+      - control_plane_data:/data
+
+  compute-agent:
+    image: ghcr.io/${GHCR_OWNER}/${GHCR_REPO}-compute-agent:${IMAGE_TAG:-main-latest}
+    pull_policy: always
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+    ports:
+      - "9443:9443"
+      - "9444:9444"
+    environment:
+      AGENT_TOKEN: "${AGENT_TOKEN:-dev-agent-token-change-me}"
+      LISTEN_ADDR: ":9443"
+      GRPC_LISTEN_ADDR: ":9444"
+      MAX_MEMORY_GB: "${AGENT_MAX_MEMORY_GB:-2}"
+      QUERY_RESULT_TTL: "${AGENT_QUERY_RESULT_TTL:-10m}"
+      QUERY_CLEANUP_INTERVAL: "${AGENT_QUERY_CLEANUP_INTERVAL:-1m}"
+      FEATURE_CURSOR_MODE: "true"
+      FEATURE_INTERNAL_GRPC: "true"
+
+      # DuckLake metadata catalog in Postgres.
+      CATALOG_DSN: "host=postgres port=5432 dbname=${POSTGRES_DB:-ducklake} user=${POSTGRES_USER:-ducklake} password=${POSTGRES_PASSWORD:-ducklake} sslmode=disable"
+
+      # S3-compatible object storage for DuckLake data files.
+      S3_KEY_ID: "${S3_ACCESS_KEY:-duckdemo}"
+      S3_SECRET: "${S3_SECRET_KEY:-duckdemo-secret}"
+      S3_ENDPOINT: "${S3_ENDPOINT}"
+      S3_REGION: "${S3_REGION}"
+      S3_BUCKET: "${S3_BUCKET}"
+
+  postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: "${POSTGRES_DB:-ducklake}"
+      POSTGRES_USER: "${POSTGRES_USER:-ducklake}"
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:-ducklake}"
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-ducklake} -d ${POSTGRES_DB:-ducklake}"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+volumes:
+  control_plane_data:
+  postgres_data:


### PR DESCRIPTION
## Summary
- add a dedicated `publish-images` GitHub Actions workflow that builds and pushes both control-plane and compute-agent images to GHCR on every push to `main`
- add a `Dockerfile.compute-agent` image build for `cmd/compute-agent`
- add a Coolify-ready `docker-compose.yml` that runs control-plane + compute-agent + postgres with persistent volumes and external S3/Object Storage configuration
- add `.env.coolify.example` documenting required GHCR, Hetzner Object Storage, and Postgres environment variables

## Notes
- compose is intentionally simplified for the Hetzner Object Storage use case (no MinIO service)
- SQLite control-plane metadata is persisted at `/data/ducklake_meta.sqlite` via the `control_plane_data` named volume