### PR TITLE
fix(cli): ensure --api-key overrides profile token

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -162,6 +162,38 @@ func TestCLI_MissingArgs(t *testing.T) {
 	assert.Contains(t, err.Error(), "accepts 1 arg(s)")
 }
 
+func TestCLI_APIKeyFlagOverridesProfileToken(t *testing.T) {
+	rec := &requestRecorder{}
+	srv := httptest.NewServer(jsonHandler(rec, 200, `{"data":[]}`))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	require.NoError(t, SaveUserConfig(&UserConfig{
+		CurrentProfile: "default",
+		Profiles: map[string]Profile{
+			"default": {
+				Host:  srv.URL,
+				Token: "profile-token",
+			},
+		},
+	}))
+
+	rootCmd := newRootCmd()
+	rootCmd.SetArgs([]string{
+		"--host", srv.URL,
+		"--api-key", "api-key-123",
+		"catalog", "schemas", "list", "test",
+	})
+
+	err := rootCmd.Execute()
+	require.NoError(t, err)
+
+	captured := rec.last()
+	assert.Equal(t, "api-key-123", captured.Headers.Get("X-API-Key"))
+	assert.Empty(t, captured.Headers.Get("Authorization"))
+}
+
 // === Path Parameter Substitution Tests (issue #100) ===
 
 func TestCLI_PathParamSubstitution(t *testing.T) {

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -46,6 +46,9 @@ func newRootCmd() *cobra.Command {
 		output  string
 		profile string
 		quiet   bool
+
+		apiKeyPriority int
+		tokenPriority  int
 	)
 
 	rootCmd := &cobra.Command{
@@ -55,6 +58,9 @@ func newRootCmd() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			apiKeyPriority = 0
+			tokenPriority = 0
+
 			// Load config from profile if flags/env not set
 			cfg, err := LoadUserConfig()
 			if err != nil {
@@ -81,22 +87,38 @@ func newRootCmd() *cobra.Command {
 			if !cmd.Flags().Changed("api-key") {
 				if v := os.Getenv("DUCK_API_KEY"); v != "" {
 					apiKey = v
+					apiKeyPriority = 30
 				} else if p.APIKey != "" {
 					apiKey = p.APIKey
+					apiKeyPriority = 10
 				}
+			} else if apiKey != "" {
+				apiKeyPriority = 50
 			}
 			if !cmd.Flags().Changed("token") {
 				if v := os.Getenv("DUCK_TOKEN"); v != "" {
 					token = v
+					tokenPriority = 40
 				} else if p.Token != "" {
 					token = p.Token
+					tokenPriority = 20
 				}
+			} else if token != "" {
+				tokenPriority = 60
 			}
 			if !cmd.Flags().Changed("output") {
 				if v := os.Getenv("DUCK_OUTPUT"); v != "" {
 					output = v
 				} else if p.Output != "" {
 					output = p.Output
+				}
+			}
+
+			if apiKey != "" && token != "" {
+				if tokenPriority > apiKeyPriority {
+					apiKey = ""
+				} else {
+					token = ""
 				}
 			}
 


### PR DESCRIPTION
## Summary
- add a regression test that fails when `--api-key` is ignored because a profile token is present
- update CLI auth resolution to choose a single auth mechanism by precedence, so explicit API key usage is not shadowed by profile JWT
- preserve explicit token precedence when `--token` is provided