### PR TITLE
fix: resolve catalog-qualified managed table privilege checks

### DIFF
--- a/internal/service/security/authorization.go
+++ b/internal/service/security/authorization.go
@@ -115,7 +115,19 @@ func (s *AuthorizationService) LookupTableID(ctx context.Context, tableName stri
 	if catalogName != "" && schemaName != "" && s.lookupCatalogTable != nil {
 		tbl, lookupErr := s.lookupCatalogTable(ctx, catalogName, schemaName, bareTableName)
 		if lookupErr == nil {
-			return tbl.TableID, "", strings.EqualFold(tbl.TableType, domain.TableTypeExternal), nil
+			isExternal := strings.EqualFold(tbl.TableType, domain.TableTypeExternal)
+
+			if !isExternal {
+				if managed, managedErr := s.lookupManagedTableBySchema(ctx, schemaName, bareTableName); managedErr == nil {
+					return managed.ID, managed.SchemaID, false, nil
+				}
+			}
+
+			if sch, schErr := s.introspection.GetSchemaByName(ctx, schemaName); schErr == nil {
+				return tbl.TableID, sch.ID, isExternal, nil
+			}
+
+			return tbl.TableID, "", isExternal, nil
 		}
 
 		var notFoundErr *domain.NotFoundError

--- a/internal/service/security/authorization_test.go
+++ b/internal/service/security/authorization_test.go
@@ -634,6 +634,43 @@ func TestLookupTableID_CatalogQualified(t *testing.T) {
 	assert.False(t, isExternal)
 }
 
+func TestCheckPrivilege_CatalogQualifiedTableUsesCanonicalManagedID(t *testing.T) {
+	cat, q, ctx := setupTestService(t)
+
+	user, err := q.CreatePrincipal(ctx, dbstore.CreatePrincipalParams{ID: uuid.New().String(),
+		Name: "catalog_qualified_reader", Type: "user", IsAdmin: 0,
+	})
+	require.NoError(t, err)
+
+	_, err = q.GrantPrivilege(ctx, dbstore.GrantPrivilegeParams{
+		ID: uuid.New().String(), PrincipalID: user.ID, PrincipalType: "user",
+		SecurableType: SecurableSchema, SecurableID: "0",
+		Privilege: PrivUsage,
+	})
+	require.NoError(t, err)
+	_, err = q.GrantPrivilege(ctx, dbstore.GrantPrivilegeParams{
+		ID: uuid.New().String(), PrincipalID: user.ID, PrincipalType: "user",
+		SecurableType: SecurableTable, SecurableID: "1",
+		Privilege: PrivSelect,
+	})
+	require.NoError(t, err)
+
+	cat.SetCatalogTableLookup(func(_ context.Context, catalogName, schemaName, tableName string) (*domain.TableDetail, error) {
+		require.Equal(t, "demo", catalogName)
+		require.Equal(t, "main", schemaName)
+		require.Equal(t, "titanic", tableName)
+		return &domain.TableDetail{TableID: "table-42", TableType: domain.TableTypeManaged}, nil
+	})
+
+	tableID, _, isExternal, err := cat.LookupTableID(ctx, "demo.main.titanic")
+	require.NoError(t, err)
+	assert.False(t, isExternal)
+
+	allowed, err := cat.CheckPrivilege(ctx, "catalog_qualified_reader", SecurableTable, tableID, PrivSelect)
+	require.NoError(t, err)
+	assert.True(t, allowed)
+}
+
 func TestLookupTableID_ViewSchemaQualified(t *testing.T) {
 	cat, q, ctx := setupTestService(t)
 


### PR DESCRIPTION
## Summary
- update `LookupTableID` to normalize catalog-qualified managed tables back to canonical managed table IDs/schema IDs before authorization checks
- preserve external-table behavior while improving managed-table resolution path when catalog lookup succeeds
- add integration regression coverage for `demo.main.titanic` to ensure `CheckPrivilege` evaluates the canonical managed table securable

## Why
Catalog-qualified lookups can return a catalog-level table identifier that does not match the managed-table securable ID used by grants. This causes false negatives in privilege checks for managed tables. The fix maps those lookups to the managed table identity used by authorization.

## Testing
- `go test ./internal/service/security`
- `go test -tags integration -count=1 -run TestCheckPrivilege_CatalogQualifiedTableUsesCanonicalManagedID ./internal/service/security`