### PR TITLE
feat: add development-only localhost UI auth bypass

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -83,6 +83,7 @@ AUTH_AUDIENCE=
 # AUTH_WEB_SESSION_ABSOLUTE_TTL=24h
 # AUTH_WEB_SESSION_COOKIE_NAME=ui_session
 # AUTH_WEB_SESSION_REAPER_INTERVAL=5m
+# AUTH_UI_DEV_BYPASS=false
 
 # 64-character hex string (32-byte AES-256-GCM key) for encrypting stored
 # credentials at rest in SQLite.

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ docs/node_modules/
 docs/.vitepress/dist/
 docs/.vitepress/cache/
 web/node_modules/
+.playwright-cli/

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Scenario templates are also available: `.env.local-only.sample`, `.env.hybrid.sa
 | `AUTH_WEB_SESSION_ABSOLUTE_TTL` | `24h` | UI session absolute max lifetime |
 | `AUTH_WEB_SESSION_COOKIE_NAME` | `ui_session` | Opaque UI session cookie name |
 | `AUTH_WEB_SESSION_REAPER_INTERVAL` | `5m` | Cleanup cadence for expired/revoked UI sessions |
+| `AUTH_UI_DEV_BYPASS` | `false` | Development-only localhost bypass for `/ui` auth (ignored in production) |
 | `ENCRYPTION_KEY` | (insecure default) | 64-char hex AES-256 key for credential encryption |
 | `ENCRYPTION_KEY_FILE` | `` | Read encryption key from file (e.g. Docker/K8s secret mount) |
 | `JWT_SECRET_FILE` | `` | Read local JWT secret from file |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,6 +38,7 @@ type AuthConfig struct {
 	WebSessionAbsoluteTTL    time.Duration // max absolute lifetime for browser sessions (default: 24h)
 	WebSessionCookieName     string        // cookie name for UI sessions (default: ui_session)
 	WebSessionReaperInterval time.Duration // reaper interval for expired/revoked sessions (default: 5m)
+	UIDevBypass              bool          // bypass UI auth for localhost in development only (default: false)
 }
 
 // OIDCEnabled returns true when an external identity provider is configured.
@@ -281,6 +282,7 @@ func LoadFromEnv() (*Config, error) {
 		NameClaim:            os.Getenv("AUTH_NAME_CLAIM"),
 		BootstrapAdmin:       os.Getenv("AUTH_BOOTSTRAP_ADMIN"),
 		WebSessionCookieName: os.Getenv("AUTH_WEB_SESSION_COOKIE_NAME"),
+		UIDevBypass:          parseBoolEnvDefault("AUTH_UI_DEV_BYPASS", false),
 	}
 
 	if v := os.Getenv("AUTH_ALLOWED_ISSUERS"); v != "" {
@@ -388,6 +390,9 @@ func LoadFromEnv() (*Config, error) {
 
 	// Production mode: insecure defaults are fatal errors.
 	if cfg.IsProduction() {
+		if cfg.Auth.UIDevBypass {
+			return nil, fmt.Errorf("AUTH_UI_DEV_BYPASS is not allowed in production (ENV=production)")
+		}
 		if !cfg.Auth.HasEnabledMethod() {
 			return nil, fmt.Errorf("at least one auth method must be configured in production")
 		}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -57,6 +57,7 @@ func TestLoadFromEnv_Defaults(t *testing.T) {
 	assert.Equal(t, 24*time.Hour, cfg.Auth.WebSessionAbsoluteTTL)
 	assert.Equal(t, "ui_session", cfg.Auth.WebSessionCookieName)
 	assert.Equal(t, 5*time.Minute, cfg.Auth.WebSessionReaperInterval)
+	assert.False(t, cfg.Auth.UIDevBypass)
 }
 
 func TestLoadFromEnv_WebSessionConfig(t *testing.T) {
@@ -64,6 +65,7 @@ func TestLoadFromEnv_WebSessionConfig(t *testing.T) {
 	t.Setenv("AUTH_WEB_SESSION_ABSOLUTE_TTL", "36h")
 	t.Setenv("AUTH_WEB_SESSION_COOKIE_NAME", "duck_ui")
 	t.Setenv("AUTH_WEB_SESSION_REAPER_INTERVAL", "2m")
+	t.Setenv("AUTH_UI_DEV_BYPASS", "true")
 
 	cfg, err := LoadFromEnv()
 	require.NoError(t, err)
@@ -72,6 +74,20 @@ func TestLoadFromEnv_WebSessionConfig(t *testing.T) {
 	assert.Equal(t, 36*time.Hour, cfg.Auth.WebSessionAbsoluteTTL)
 	assert.Equal(t, "duck_ui", cfg.Auth.WebSessionCookieName)
 	assert.Equal(t, 2*time.Minute, cfg.Auth.WebSessionReaperInterval)
+	assert.True(t, cfg.Auth.UIDevBypass)
+}
+
+func TestLoadFromEnv_ProductionRejectsUIDevBypass(t *testing.T) {
+	t.Setenv("ENV", "production")
+	t.Setenv("AUTH_JWKS_URL", "https://auth.example.com/jwks.json")
+	t.Setenv("ENCRYPTION_KEY", "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789")
+	t.Setenv("CORS_ALLOWED_ORIGINS", "https://app.example.com")
+	t.Setenv("TRUST_DOWNSTREAM_PROXY", "true")
+	t.Setenv("AUTH_UI_DEV_BYPASS", "true")
+
+	_, err := LoadFromEnv()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "AUTH_UI_DEV_BYPASS is not allowed in production")
 }
 
 func TestLoadFromEnv_WebSessionInvalidBounds(t *testing.T) {

--- a/internal/ui/handlers_auth.go
+++ b/internal/ui/handlers_auth.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"context"
 	"net"
 	"net/http"
 	"strings"
@@ -68,6 +69,12 @@ func (h *Handler) Logout(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) RequireWebSession(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if h.Auth.UIDevBypass && !h.Production && isLoopbackRequest(r) {
+			ctx := domain.WithPrincipal(r.Context(), h.uiDevBypassPrincipal(r.Context()))
+			next.ServeHTTP(w, r.WithContext(ctx))
+			return
+		}
+
 		if h.WebSessionService == nil {
 			RedirectToLogin(w, r)
 			return
@@ -146,4 +153,42 @@ func clientIP(r *http.Request) string {
 		return host
 	}
 	return strings.TrimSpace(r.RemoteAddr)
+}
+
+func isLoopbackRequest(r *http.Request) bool {
+	host, _, err := net.SplitHostPort(strings.TrimSpace(r.RemoteAddr))
+	if err != nil {
+		host = strings.TrimSpace(r.RemoteAddr)
+	}
+	ip := net.ParseIP(host)
+	if ip != nil {
+		return ip.IsLoopback()
+	}
+	return strings.EqualFold(host, "localhost")
+}
+
+func (h *Handler) uiDevBypassPrincipal(ctx context.Context) domain.ContextPrincipal {
+	if h.PrincipalResolver != nil {
+		principal, err := h.PrincipalResolver.ResolveOrProvision(ctx, domain.ResolveOrProvisionRequest{
+			Issuer:      "dev-local",
+			ExternalID:  "ui-dev-bypass",
+			DisplayName: "dev-admin",
+			IsBootstrap: true,
+		})
+		if err == nil {
+			return domain.ContextPrincipal{
+				ID:      principal.ID,
+				Name:    principal.Name,
+				Type:    principal.Type,
+				IsAdmin: principal.IsAdmin,
+			}
+		}
+	}
+
+	return domain.ContextPrincipal{
+		ID:      "ui-dev-bypass",
+		Name:    "dev-admin",
+		Type:    "user",
+		IsAdmin: true,
+	}
 }

--- a/internal/ui/handlers_auth_test.go
+++ b/internal/ui/handlers_auth_test.go
@@ -17,6 +17,7 @@ import (
 	"duck-demo/internal/config"
 	internaldb "duck-demo/internal/db"
 	"duck-demo/internal/db/repository"
+	"duck-demo/internal/domain"
 	authsvc "duck-demo/internal/service/auth"
 )
 
@@ -89,6 +90,67 @@ func TestUIAuth_TokenCookieIgnored(t *testing.T) {
 
 	assert.Equal(t, http.StatusSeeOther, w.Code)
 	assert.Equal(t, "/ui/login", w.Header().Get("Location"))
+}
+
+func TestUIAuth_UIDevBypassLoopbackAllowsHome(t *testing.T) {
+	h := NewHandler(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, config.AuthConfig{UIDevBypass: true}, false)
+	r := chi.NewRouter()
+	r.Route("/ui", func(r chi.Router) {
+		MountRoutes(r, h)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/ui/", nil)
+	req.RemoteAddr = "127.0.0.1:12345"
+	resp := httptest.NewRecorder()
+	r.ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusOK, resp.Code)
+}
+
+func TestUIAuth_UIDevBypassNonLoopbackStillRedirects(t *testing.T) {
+	h := NewHandler(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, config.AuthConfig{UIDevBypass: true}, false)
+	r := chi.NewRouter()
+	r.Route("/ui", func(r chi.Router) {
+		MountRoutes(r, h)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/ui/", nil)
+	req.RemoteAddr = "10.0.0.1:12345"
+	resp := httptest.NewRecorder()
+	r.ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusSeeOther, resp.Code)
+	assert.Equal(t, "/ui/login", resp.Header().Get("Location"))
+}
+
+func TestUIAuth_UIDevBypassUsesPrincipalResolverWhenAvailable(t *testing.T) {
+	h := NewHandler(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, &stubPrincipalResolver{principal: &domain.Principal{ID: "p-dev", Name: "resolver-admin", Type: "user", IsAdmin: true}}, config.AuthConfig{UIDevBypass: true}, false)
+	r := chi.NewRouter()
+	r.Route("/ui", func(r chi.Router) {
+		MountRoutes(r, h)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/ui/", nil)
+	req.RemoteAddr = "127.0.0.1:23456"
+	resp := httptest.NewRecorder()
+	r.ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusOK, resp.Code)
+	body := resp.Body.String()
+	assert.Contains(t, body, "resolver-admin")
+	assert.Contains(t, body, "admin")
+}
+
+type stubPrincipalResolver struct {
+	principal *domain.Principal
+	err       error
+}
+
+func (s *stubPrincipalResolver) ResolveOrProvision(_ context.Context, _ domain.ResolveOrProvisionRequest) (*domain.Principal, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.principal, nil
 }
 
 func newUITestRouter(t *testing.T) (*chi.Mux, string) {


### PR DESCRIPTION
## Summary
- add `AUTH_UI_DEV_BYPASS` to allow bypassing `/ui` authentication in development for localhost/loopback requests only
- preserve normal auth behavior for non-loopback requests and all `/v1` API routes, and reject this flag in production
- add config/UI tests and docs updates, and ignore Playwright artifacts via `.gitignore`

## Validation
- `go test ./internal/config ./internal/ui`
- manual check with Playwright CLI confirmed `/ui` opens to Overview when `AUTH_UI_DEV_BYPASS=true`