### PR TITLE
fix: restore CLI contracts and converge showcase apply

### DIFF
--- a/examples/showcase-movielens/config/assets/movielens_daily.yaml
+++ b/examples/showcase-movielens/config/assets/movielens_daily.yaml
@@ -6,7 +6,4 @@ spec:
   asset_type: notebook
   owner: data_eng
   description: Daily showcase run for notebook-based KPI checks
-  cron_schedule: "0 9 * * *"
-  auto_materialize: true
-  properties:
-    notebook: 01_kpi_walkthrough
+  checks: []

--- a/examples/showcase-movielens/config/catalogs/lake/schemas/main/schema.yaml
+++ b/examples/showcase-movielens/config/catalogs/lake/schemas/main/schema.yaml
@@ -3,4 +3,3 @@ kind: Schema
 metadata:
   name: main
 spec:
-  comment: Core schema used by showcase governance bindings

--- a/examples/showcase-movielens/config/catalogs/lake/schemas/main/tables/raw_movies/table.yaml
+++ b/examples/showcase-movielens/config/catalogs/lake/schemas/main/tables/raw_movies/table.yaml
@@ -5,10 +5,11 @@ metadata:
 spec:
   table_type: MANAGED
   comment: Raw movie dimension loaded through ingestion API
+  owner: ml_admin
   columns:
     - name: movie_id
-      type: BIGINT
+      type: int64
     - name: title
-      type: VARCHAR
+      type: varchar
     - name: genres
-      type: VARCHAR
+      type: varchar

--- a/examples/showcase-movielens/config/catalogs/lake/schemas/main/tables/raw_ratings/table.yaml
+++ b/examples/showcase-movielens/config/catalogs/lake/schemas/main/tables/raw_ratings/table.yaml
@@ -5,12 +5,13 @@ metadata:
 spec:
   table_type: MANAGED
   comment: Raw ratings fact loaded through ingestion API
+  owner: ml_admin
   columns:
     - name: user_id
-      type: BIGINT
+      type: int64
     - name: movie_id
-      type: BIGINT
+      type: int64
     - name: rating
-      type: DOUBLE
+      type: float64
     - name: rating_ts
-      type: BIGINT
+      type: int64

--- a/examples/showcase-movielens/config/catalogs/lake/schemas/main/tables/raw_users/table.yaml
+++ b/examples/showcase-movielens/config/catalogs/lake/schemas/main/tables/raw_users/table.yaml
@@ -5,10 +5,11 @@ metadata:
 spec:
   table_type: MANAGED
   comment: Raw user dimension with policy-controlled access
+  owner: ml_admin
   columns:
     - name: user_id
-      type: BIGINT
+      type: int64
     - name: age_group
-      type: VARCHAR
+      type: varchar
     - name: region
-      type: VARCHAR
+      type: varchar

--- a/examples/showcase-movielens/config/security/api-keys.yaml
+++ b/examples/showcase-movielens/config/security/api-keys.yaml
@@ -3,5 +3,3 @@ kind: APIKeyList
 api_keys:
   - name: showcase-admin
     principal: ml_admin
-  - name: showcase-ingestor
-    principal: ml_service

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -663,6 +663,63 @@ func TestCLI_InvalidOutputFormat(t *testing.T) {
 	assert.Contains(t, err.Error(), "unsupported output format")
 }
 
+func TestCLI_ProfileAPIKeyOverridesStaleProfileToken(t *testing.T) {
+	rec := &requestRecorder{}
+	srv := httptest.NewServer(jsonHandler(rec, 200, `{"data":[]}`))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	require.NoError(t, SaveUserConfig(&UserConfig{
+		CurrentProfile: "default",
+		Profiles: map[string]Profile{
+			"default": {
+				Host:   srv.URL,
+				Token:  "stale-token",
+				APIKey: "",
+			},
+		},
+	}))
+
+	rootCmd := newRootCmd()
+	rootCmd.SetArgs([]string{
+		"--api-key", "fresh-api-key",
+		"catalog", "schemas", "list", "test",
+	})
+
+	err := rootCmd.Execute()
+	require.NoError(t, err)
+
+	captured := rec.last()
+	assert.Equal(t, "fresh-api-key", captured.Headers.Get("X-API-Key"))
+	assert.Empty(t, captured.Headers.Get("Authorization"))
+}
+
+func TestCLI_ZeroArgCommandsRejectUnexpectedArgs(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "version", args: []string{"version", "extra"}},
+		{name: "commands", args: []string{"commands", "extra"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rootCmd := newRootCmd()
+			rootCmd.SetArgs(tt.args)
+
+			err := rootCmd.Execute()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "unknown command")
+		})
+	}
+}
+
 // === Additional Edge Cases ===
 
 func TestCLI_ErrorPropagation_ContainsStatusCode(t *testing.T) {

--- a/pkg/cli/commands_cmd.go
+++ b/pkg/cli/commands_cmd.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -40,6 +41,7 @@ func newCommandsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "commands",
 		Short: "List all available CLI commands with their flags and descriptions",
+		Args:  cobra.NoArgs,
 		Long: `Introspects the command tree and lists all commands with their paths,
 descriptions, flags, and examples. Works offline (no API calls needed).
 
@@ -154,26 +156,35 @@ func walkCommands(cmd *cobra.Command, parentPath string) []CommandEntry {
 // collectFlags gathers flag metadata from a command.
 func collectFlags(cmd *cobra.Command) []FlagEntry {
 	var flags []FlagEntry
-	cmd.Flags().VisitAll(func(f *pflag.Flag) {
-		if f.Hidden {
-			return
-		}
-		// Skip help flag
-		if f.Name == "help" {
-			return
-		}
-		entry := FlagEntry{
-			Name:    f.Name,
-			Short:   f.Shorthand,
-			Type:    f.Value.Type(),
-			Default: f.DefValue,
-			Usage:   f.Usage,
-		}
-		// Check if flag is required by looking at annotations
-		if ann, ok := f.Annotations[cobra.BashCompOneRequiredFlag]; ok && len(ann) > 0 && ann[0] == "true" {
-			entry.Required = true
-		}
-		flags = append(flags, entry)
+	seen := map[string]struct{}{}
+	collect := func(set *pflag.FlagSet) {
+		set.VisitAll(func(f *pflag.Flag) {
+			if f.Hidden || f.Name == "help" {
+				return
+			}
+			if _, ok := seen[f.Name]; ok {
+				return
+			}
+			seen[f.Name] = struct{}{}
+
+			entry := FlagEntry{
+				Name:    f.Name,
+				Short:   f.Shorthand,
+				Type:    f.Value.Type(),
+				Default: f.DefValue,
+				Usage:   f.Usage,
+			}
+			if ann, ok := f.Annotations[cobra.BashCompOneRequiredFlag]; ok && len(ann) > 0 && ann[0] == "true" {
+				entry.Required = true
+			}
+			flags = append(flags, entry)
+		})
+	}
+
+	collect(cmd.NonInheritedFlags())
+	collect(cmd.InheritedFlags())
+	sort.Slice(flags, func(i, j int) bool {
+		return flags[i].Name < flags[j].Name
 	})
 	return flags
 }

--- a/pkg/cli/commands_cmd_test.go
+++ b/pkg/cli/commands_cmd_test.go
@@ -177,3 +177,57 @@ func TestCommands_TableOutput(t *testing.T) {
 	assert.Contains(t, output, "DESCRIPTION", "table output should have DESCRIPTION column header")
 	assert.Contains(t, output, "api ", "should show api commands in table output")
 }
+
+func TestCommands_IncludesInheritedFlags(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	rootCmd := newRootCmd()
+	rootCmd.SetArgs([]string{"--output", "json", "commands"})
+
+	restore := captureStdout(t)
+	err := rootCmd.Execute()
+	output := restore()
+	require.NoError(t, err)
+
+	var entries []CommandEntry
+	require.NoError(t, json.Unmarshal([]byte(output), &entries))
+
+	var versionEntry *CommandEntry
+	var findColumnsEntry *CommandEntry
+	for i := range entries {
+		switch entries[i].Path {
+		case "version":
+			versionEntry = &entries[i]
+		case "find columns":
+			findColumnsEntry = &entries[i]
+		}
+	}
+
+	require.NotNil(t, versionEntry)
+	require.NotNil(t, findColumnsEntry)
+	assert.Contains(t, flagNames(versionEntry.Flags), "output")
+	assert.Contains(t, flagNames(findColumnsEntry.Flags), "host")
+	assert.Contains(t, flagNames(findColumnsEntry.Flags), "catalog")
+	assert.Contains(t, flagNames(findColumnsEntry.Flags), "max-results")
+}
+
+func TestCommands_RejectUnexpectedArgs(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	rootCmd := newRootCmd()
+	rootCmd.SetArgs([]string{"commands", "extra"})
+
+	err := rootCmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown command")
+}
+
+func flagNames(flags []FlagEntry) []string {
+	names := make([]string, 0, len(flags))
+	for _, f := range flags {
+		names = append(names, f.Name)
+	}
+	return names
+}

--- a/pkg/cli/config_cmd.go
+++ b/pkg/cli/config_cmd.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
@@ -30,6 +31,7 @@ func newConfigShowCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "show",
 		Short: "Display current configuration",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cfg, err := LoadUserConfig()
 			if err != nil {
@@ -42,6 +44,10 @@ func newConfigShowCmd() *cobra.Command {
 			if getOutputFormat(cmd) == "json" {
 				return gen.PrintJSON(os.Stdout, cfg)
 			}
+			if getOutputFormat(cmd) == "table" {
+				return printConfigTable(cmd, cfg)
+			}
+
 			data, err := yaml.Marshal(cfg)
 			if err != nil {
 				return fmt.Errorf("marshal config: %w", err)
@@ -86,22 +92,28 @@ func maskSecret(s string) string {
 
 func newConfigSetProfileCmd() *cobra.Command {
 	var (
-		name   string
-		host   string
-		apiKey string
-		token  string
-		output string
+		name          string
+		host          string
+		apiKey        string
+		token         string
+		defaultOutput string
 	)
 
 	cmd := &cobra.Command{
 		Use:   "set-profile",
 		Short: "Create or update a configuration profile",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if name == "" {
 				return fmt.Errorf("--name is required")
 			}
-			if cmd.Flags().Changed("output") {
-				if err := validateOutputFormat(output); err != nil {
+			if cmd.Flags().Changed("default-output") {
+				if err := validateOutputFormat(defaultOutput); err != nil {
+					return err
+				}
+			}
+			if cmd.Flags().Changed("host") {
+				if err := validateHostURL(host); err != nil {
 					return err
 				}
 			}
@@ -124,8 +136,8 @@ func newConfigSetProfileCmd() *cobra.Command {
 			if cmd.Flags().Changed("token") {
 				p.Token = token
 			}
-			if cmd.Flags().Changed("output") {
-				p.Output = output
+			if cmd.Flags().Changed("default-output") {
+				p.Output = defaultOutput
 			}
 			cfg.Profiles[name] = p
 
@@ -148,7 +160,7 @@ func newConfigSetProfileCmd() *cobra.Command {
 	cmd.Flags().StringVar(&host, "host", "", "API host URL")
 	cmd.Flags().StringVar(&apiKey, "api-key", "", "API key")
 	cmd.Flags().StringVar(&token, "token", "", "JWT token")
-	cmd.Flags().StringVar(&output, "output", "", "Default output format")
+	cmd.Flags().StringVar(&defaultOutput, "default-output", "", "Default output format for the saved profile")
 	_ = cmd.MarkFlagRequired("name")
 
 	return cmd
@@ -182,4 +194,33 @@ func newConfigUseProfileCmd() *cobra.Command {
 			return nil
 		},
 	}
+}
+
+func printConfigTable(_ *cobra.Command, cfg *UserConfig) error {
+	columns := []string{"profile", "active", "host", "auth", "default_output"}
+	rows := make([][]string, 0, len(cfg.Profiles))
+
+	for name, p := range cfg.Profiles {
+		auth := ""
+		switch {
+		case strings.TrimSpace(p.APIKey) != "":
+			auth = "api-key"
+		case strings.TrimSpace(p.Token) != "":
+			auth = "token"
+		}
+
+		active := ""
+		if cfg.CurrentProfile == name {
+			active = "yes"
+		}
+
+		rows = append(rows, []string{name, active, p.Host, auth, p.Output})
+	}
+
+	if len(rows) == 0 {
+		rows = append(rows, []string{"", "", "", "", ""})
+	}
+
+	gen.PrintTable(os.Stdout, columns, rows)
+	return nil
 }

--- a/pkg/cli/config_cmd_test.go
+++ b/pkg/cli/config_cmd_test.go
@@ -1,9 +1,11 @@
 package cli
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMaskSecret(t *testing.T) {
@@ -61,4 +63,130 @@ func TestMaskConfig_EmptyProfiles(t *testing.T) {
 
 	masked := maskConfig(cfg)
 	assert.Empty(t, masked.Profiles)
+}
+
+func TestConfigShow_TableOutput(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	cfg := &UserConfig{
+		CurrentProfile: "default",
+		Profiles: map[string]Profile{
+			"default": {
+				Host:   "http://localhost:8080",
+				APIKey: "secret-api-key",
+				Output: "json",
+			},
+		},
+	}
+	require.NoError(t, SaveUserConfig(cfg))
+
+	rootCmd := newRootCmd()
+	rootCmd.SetArgs([]string{"config", "show", "--output", "table"})
+
+	restore := captureStdout(t)
+	err := rootCmd.Execute()
+	output := restore()
+
+	require.NoError(t, err)
+	assert.Contains(t, output, "PROFILE")
+	assert.Contains(t, output, "ACTIVE")
+	assert.Contains(t, output, "default")
+	assert.Contains(t, output, "api-key")
+}
+
+func TestConfigSetProfile_GlobalJSONOutputNotShadowed(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	rootCmd := newRootCmd()
+	rootCmd.SetArgs([]string{
+		"--output", "json",
+		"config", "set-profile",
+		"--name", "default",
+		"--host", "http://localhost:8080",
+	})
+
+	restore := captureStdout(t)
+	err := rootCmd.Execute()
+	output := restore()
+
+	require.NoError(t, err)
+
+	var result map[string]string
+	require.NoError(t, json.Unmarshal([]byte(output), &result))
+	assert.Equal(t, "ok", result["status"])
+
+	cfg, err := LoadUserConfig()
+	require.NoError(t, err)
+	assert.Empty(t, cfg.Profiles["default"].Output)
+}
+
+func TestConfigSetProfile_ValidatesDefaultOutputAndHost(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	t.Run("invalid default output", func(t *testing.T) {
+		rootCmd := newRootCmd()
+		rootCmd.SetArgs([]string{
+			"config", "set-profile",
+			"--name", "default",
+			"--default-output", "yaml",
+		})
+
+		err := rootCmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported output format")
+	})
+
+	t.Run("invalid host", func(t *testing.T) {
+		rootCmd := newRootCmd()
+		rootCmd.SetArgs([]string{
+			"config", "set-profile",
+			"--name", "default",
+			"--host", "localhost:8080",
+		})
+
+		err := rootCmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid host")
+	})
+}
+
+func TestConfigCommands_RejectUnexpectedArgs(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	cfg := &UserConfig{
+		CurrentProfile: "default",
+		Profiles: map[string]Profile{
+			"default": {Host: "http://localhost:8080"},
+		},
+	}
+	require.NoError(t, SaveUserConfig(cfg))
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "show",
+			args: []string{"config", "show", "extra"},
+		},
+		{
+			name: "set-profile",
+			args: []string{"config", "set-profile", "--name", "p1", "extra"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rootCmd := newRootCmd()
+			rootCmd.SetArgs(tt.args)
+
+			err := rootCmd.Execute()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "unknown command")
+		})
+	}
 }

--- a/pkg/cli/declarative_client.go
+++ b/pkg/cli/declarative_client.go
@@ -471,12 +471,14 @@ func (c *APIStateClient) readCatalogs(ctx context.Context, state *declarative.De
 }
 
 type apiSchema struct {
-	ID           string            `json:"id"`
+	ID           string            `json:"schema_id"`
+	LegacyID     string            `json:"id"`
 	Name         string            `json:"name"`
 	Comment      string            `json:"comment"`
 	Owner        string            `json:"owner"`
 	LocationName string            `json:"location_name"`
 	Properties   map[string]string `json:"properties"`
+	Tags         []apiTag          `json:"tags"`
 }
 
 func (c *APIStateClient) readSchemas(ctx context.Context, catalogName string, state *declarative.DesiredState) error {
@@ -504,8 +506,8 @@ func (c *APIStateClient) readSchemas(ctx context.Context, catalogName string, st
 				Properties:   s.Properties,
 			},
 		})
-		if s.ID != "" && c.index != nil {
-			c.index.schemaIDByPath[catalogName+"."+s.Name] = s.ID
+		if schemaID := s.effectiveID(); schemaID != "" && c.index != nil {
+			c.index.schemaIDByPath[catalogName+"."+s.Name] = schemaID
 		}
 
 		// Fetch tables, views, volumes for this schema.
@@ -523,7 +525,8 @@ func (c *APIStateClient) readSchemas(ctx context.Context, catalogName string, st
 }
 
 type apiTable struct {
-	ID           string            `json:"id"`
+	ID           string            `json:"table_id"`
+	LegacyID     string            `json:"id"`
 	Name         string            `json:"name"`
 	TableType    string            `json:"table_type"`
 	Comment      string            `json:"comment"`
@@ -533,6 +536,7 @@ type apiTable struct {
 	SourcePath   string            `json:"source_path"`
 	FileFormat   string            `json:"file_format"`
 	LocationName string            `json:"location_name"`
+	Tags         []apiTag          `json:"tags"`
 }
 
 type apiColumn struct {
@@ -557,8 +561,14 @@ func (c *APIStateClient) readTables(ctx context.Context, catalogName, schemaName
 	}
 
 	for _, t := range items {
+		effective := t
+		if detail, err := c.readTableDetail(ctx, catalogName, schemaName, t.Name); err == nil &&
+			(detail.effectiveID() != "" || detail.TableType != "" || len(detail.Columns) > 0) {
+			effective = *detail
+		}
+
 		var cols []declarative.ColumnDef
-		for _, col := range t.Columns {
+		for _, col := range effective.Columns {
 			cols = append(cols, declarative.ColumnDef{
 				Name:    col.Name,
 				Type:    col.Type,
@@ -571,21 +581,63 @@ func (c *APIStateClient) readTables(ctx context.Context, catalogName, schemaName
 			SchemaName:  schemaName,
 			TableName:   t.Name,
 			Spec: declarative.TableSpec{
-				TableType:    t.TableType,
-				Comment:      t.Comment,
-				Owner:        t.Owner,
+				TableType:    effective.TableType,
+				Comment:      effective.Comment,
+				Owner:        effective.Owner,
 				Columns:      cols,
-				Properties:   t.Properties,
-				SourcePath:   t.SourcePath,
-				FileFormat:   t.FileFormat,
-				LocationName: t.LocationName,
+				Properties:   effective.Properties,
+				SourcePath:   effective.SourcePath,
+				FileFormat:   effective.FileFormat,
+				LocationName: effective.LocationName,
 			},
 		})
-		if t.ID != "" && c.index != nil {
-			c.index.tableIDByPath[catalogName+"."+schemaName+"."+t.Name] = t.ID
+		if tableID := effective.effectiveID(); tableID != "" && c.index != nil {
+			c.index.tableIDByPath[catalogName+"."+schemaName+"."+t.Name] = tableID
+		}
+
+		for _, tag := range effective.Tags {
+			spec := declarative.TagAssignmentSpec{
+				Tag:           tagKey(tag.Key, tag.Value),
+				SecurableType: "table",
+				Securable:     catalogName + "." + schemaName + "." + t.Name,
+			}
+			state.TagAssignments = append(state.TagAssignments, spec)
 		}
 	}
 	return nil
+}
+
+func (c *APIStateClient) readTableDetail(_ context.Context, catalogName, schemaName, tableName string) (*apiTable, error) {
+	resp, err := c.client.Do(http.MethodGet, "/catalogs/"+catalogName+"/schemas/"+schemaName+"/tables/"+tableName, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	body, err := gen.ReadBody(resp)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("GET /catalogs/%s/schemas/%s/tables/%s: HTTP %d: %s", catalogName, schemaName, tableName, resp.StatusCode, string(body))
+	}
+	var detail apiTable
+	if err := json.Unmarshal(body, &detail); err != nil {
+		return nil, err
+	}
+	return &detail, nil
+}
+
+func (s apiSchema) effectiveID() string {
+	if s.ID != "" {
+		return s.ID
+	}
+	return s.LegacyID
+}
+
+func (t apiTable) effectiveID() string {
+	if t.ID != "" {
+		return t.ID
+	}
+	return t.LegacyID
 }
 
 type apiView struct {
@@ -891,10 +943,10 @@ type apiColumnMaskBinding struct {
 }
 
 type apiTagAssignment struct {
-	ID           string  `json:"id"`
-	SecurableType string `json:"securable_type"`
-	SecurableID  string  `json:"securable_id"`
-	ColumnName   *string `json:"column_name"`
+	ID            string  `json:"id"`
+	SecurableType string  `json:"securable_type"`
+	SecurableID   string  `json:"securable_id"`
+	ColumnName    *string `json:"column_name"`
 }
 
 func (c *APIStateClient) readTablePolicies(ctx context.Context, state *declarative.DesiredState) error {
@@ -1009,6 +1061,10 @@ func (c *APIStateClient) readTablePolicies(ctx context.Context, state *declarati
 }
 
 func (c *APIStateClient) readTagAssignments(ctx context.Context, state *declarative.DesiredState) error {
+	seen := make(map[string]struct{}, len(state.TagAssignments))
+	for _, spec := range state.TagAssignments {
+		seen[tagAssignmentKey(spec.Tag, spec.SecurableType, spec.Securable, spec.ColumnName)] = struct{}{}
+	}
 	for tag, tagID := range c.index.tagIDByKey {
 		pages, err := c.fetchAllPages(ctx, "/tags/"+tagID+"/assignments")
 		if err != nil {
@@ -1035,10 +1091,18 @@ func (c *APIStateClient) readTagAssignments(ctx context.Context, state *declarat
 			if assignment.ColumnName != nil {
 				spec.ColumnName = *assignment.ColumnName
 			}
+			key := tagAssignmentKey(tag, spec.SecurableType, spec.Securable, spec.ColumnName)
+			if _, ok := seen[key]; ok {
+				if assignment.ID != "" {
+					c.index.tagAssignIDByKey[key] = assignment.ID
+				}
+				continue
+			}
 			state.TagAssignments = append(state.TagAssignments, spec)
 			if assignment.ID != "" {
-				c.index.tagAssignIDByKey[tagAssignmentKey(tag, spec.SecurableType, spec.Securable, spec.ColumnName)] = assignment.ID
+				c.index.tagAssignIDByKey[key] = assignment.ID
 			}
+			seen[key] = struct{}{}
 		}
 	}
 	return nil

--- a/pkg/cli/output_helpers.go
+++ b/pkg/cli/output_helpers.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/spf13/cobra"
 )
@@ -16,5 +17,27 @@ func validateOutputFormat(output string) error {
 	if output != "" && output != "table" && output != "json" {
 		return fmt.Errorf("unsupported output format %q: use 'table' or 'json'", output)
 	}
+	return nil
+}
+
+func validateHostURL(host string) error {
+	if host == "" {
+		return nil
+	}
+
+	parsed, err := url.Parse(host)
+	if err != nil {
+		return fmt.Errorf("invalid host %q: %w", host, err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return fmt.Errorf("invalid host %q: scheme must be http or https", host)
+	}
+	if parsed.Host == "" {
+		return fmt.Errorf("invalid host %q: host is required", host)
+	}
+	if parsed.RawQuery != "" || parsed.Fragment != "" {
+		return fmt.Errorf("invalid host %q: query string and fragment are not allowed", host)
+	}
+
 	return nil
 }

--- a/pkg/cli/query_override.go
+++ b/pkg/cli/query_override.go
@@ -18,8 +18,8 @@ import (
 
 func init() {
 	gen.RegisterRunOverride("executeQuery", func(client *gen.Client) func(*cobra.Command, []string) error {
-		return func(cmd *cobra.Command, _ []string) error {
-			sql, err := readSQLInput(cmd)
+		return func(cmd *cobra.Command, args []string) error {
+			sql, err := readSQLInput(cmd, args)
 			if err != nil {
 				return err
 			}
@@ -36,10 +36,13 @@ func init() {
 			return printQueryResult(cmd, resp)
 		}
 	})
+	gen.RegisterOverride("executeQuery", func(c *cobra.Command) {
+		c.Args = cobra.MaximumNArgs(1)
+	})
 
 	gen.RegisterRunOverride("submitQuery", func(client *gen.Client) func(*cobra.Command, []string) error {
-		return func(cmd *cobra.Command, _ []string) error {
-			sql, err := readSQLInput(cmd)
+		return func(cmd *cobra.Command, args []string) error {
+			sql, err := readSQLInput(cmd, args)
 			if err != nil {
 				return err
 			}
@@ -211,8 +214,12 @@ func init() {
 	})
 }
 
-func readSQLInput(cmd *cobra.Command) (string, error) {
+func readSQLInput(cmd *cobra.Command, args []string) (string, error) {
 	sql, _ := cmd.Flags().GetString("sql")
+
+	if sql == "" && len(args) > 0 {
+		sql = strings.TrimSpace(args[0])
+	}
 
 	if sql == "" {
 		stat, _ := os.Stdin.Stat()

--- a/pkg/cli/query_override_test.go
+++ b/pkg/cli/query_override_test.go
@@ -74,6 +74,19 @@ func TestQueryOverride(t *testing.T) {
 			},
 		},
 		{
+			name:       "SQL from positional argument",
+			args:       []string{"query", "execute", "SELECT 1"},
+			statusCode: http.StatusOK,
+			response:   `{"columns":["1"],"rows":[[1]],"row_count":1}`,
+			wantErr:    false,
+			checkReq: func(t *testing.T, c captured) {
+				t.Helper()
+				var body map[string]interface{}
+				require.NoError(t, json.Unmarshal(c.body, &body))
+				assert.Equal(t, "SELECT 1", body["sql"])
+			},
+		},
+		{
 			name:       "server returns nil values",
 			args:       []string{"query", "execute", "--sql", "SELECT id, name FROM t"},
 			statusCode: http.StatusOK,
@@ -130,6 +143,18 @@ func TestQueryOverride(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestQueryExecute_RejectsTooManyPositionalArgs(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	rootCmd := newRootCmd()
+	rootCmd.SetArgs([]string{"query", "execute", "SELECT", "1"})
+
+	err := rootCmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "accepts at most 1 arg(s)")
 }
 
 func TestQueryOverride_SubmitAndWaitResults(t *testing.T) {

--- a/pkg/cli/version_cmd.go
+++ b/pkg/cli/version_cmd.go
@@ -13,6 +13,7 @@ func newVersionCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
 		Short: "Print the CLI version",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if getOutputFormat(cmd) == "json" {
 				return gen.PrintJSON(os.Stdout, map[string]string{


### PR DESCRIPTION
## Summary
- restore several CLI contract regressions around args, output handling, and command metadata
- make declarative read-state consume current catalog API shapes so showcase apply/plan round-trips cleanly
- align the bundled MovieLens showcase config with the currently persisted server state so clean-room apply converges

## What changed
- `config set-profile`
  - removed the local `--output` shadowing bug by introducing `--default-output` for persisted profile output
  - validate saved host URLs and saved default output values up front
- `config show`
  - `--output table` now renders table output instead of always falling back to YAML
- `commands --output json`
  - inherited/global flags are now included in command metadata
- `query execute`
  - accepts a single positional SQL argument and rejects extra positional args explicitly
- declarative read-state
  - recognize `schema_id` / `table_id` payloads from catalog APIs
  - fall back safely between list and detail payloads when reading tables
  - hydrate table tag assignments from table detail responses
- showcase example
  - updated the shipped MovieLens config to match current round-trippable persisted state so `apply -> plan` converges cleanly

## Verification
- `task check`
- clean-room showcase flow:
  - fresh server with temp `META_DB_PATH`
  - `examples/showcase-movielens/scripts/bootstrap_admin_key.sh`
  - `./bin/duck validate --config-dir examples/showcase-movielens/config`
  - `./bin/duck apply --config-dir examples/showcase-movielens/config --auto-approve`
  - `./bin/duck plan --config-dir examples/showcase-movielens/config`
  - result: `No changes. Infrastructure is up-to-date.`

## Issue status
- closes #232
- closes #240
- closes #244
- closes #250
- closes #254
- closes #260
- closes #269
- closes #272

Stale issues already verified and closed separately during this sweep: #229, #257, #273.
