### PR TITLE
fix: improve server runtime startup and help paths

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"flag"
 	"fmt"
 	"log/slog"
 	"net"
@@ -35,9 +36,17 @@ import (
 )
 
 func main() {
+	if wantsServerHelp(os.Args[1:]) {
+		printServerUsage()
+		return
+	}
+
 	// Handle admin subcommands before starting the server.
 	if len(os.Args) >= 2 && os.Args[1] == "admin" {
 		if err := runAdmin(os.Args[2:]); err != nil {
+			if errors.Is(err, flag.ErrHelp) {
+				return
+			}
 			fmt.Fprintf(os.Stderr, "fatal: %v\n", err)
 			os.Exit(1)
 		}
@@ -475,6 +484,10 @@ func runAdmin(args []string) error {
 	if len(args) < 1 {
 		return fmt.Errorf("usage: server admin <promote|demote> [flags]")
 	}
+	if isHelpFlag(args[0]) {
+		printAdminUsage()
+		return flag.ErrHelp
+	}
 	action := args[0]
 	if action != "promote" && action != "demote" {
 		return fmt.Errorf("unknown admin action %q; use 'promote' or 'demote'", action)
@@ -555,4 +568,34 @@ func runAdmin(args []string) error {
 
 	fmt.Printf("principal %q %sd successfully\n", principalName, action)
 	return nil
+}
+
+func wantsServerHelp(args []string) bool {
+	return len(args) > 0 && isHelpFlag(args[0])
+}
+
+func isHelpFlag(arg string) bool {
+	return arg == "--help" || arg == "-h" || arg == "help"
+}
+
+func printServerUsage() {
+	_, _ = fmt.Fprintln(os.Stdout, "DuckDB Data Platform server")
+	_, _ = fmt.Fprintln(os.Stdout)
+	_, _ = fmt.Fprintln(os.Stdout, "Usage:")
+	_, _ = fmt.Fprintln(os.Stdout, "  server")
+	_, _ = fmt.Fprintln(os.Stdout, "  server admin <promote|demote> [flags]")
+	_, _ = fmt.Fprintln(os.Stdout)
+	_, _ = fmt.Fprintln(os.Stdout, "Environment:")
+	_, _ = fmt.Fprintln(os.Stdout, "  LISTEN_ADDR              HTTP listen address (default :8080)")
+	_, _ = fmt.Fprintln(os.Stdout, "  META_DB_PATH             SQLite metastore path")
+	_, _ = fmt.Fprintln(os.Stdout, "  FLIGHT_SQL_LISTEN_ADDR   Flight SQL listen address")
+	_, _ = fmt.Fprintln(os.Stdout, "  PG_WIRE_LISTEN_ADDR      PG-wire listen address")
+	_, _ = fmt.Fprintln(os.Stdout)
+	_, _ = fmt.Fprintln(os.Stdout, "Use `server admin --help` for admin subcommand usage.")
+}
+
+func printAdminUsage() {
+	_, _ = fmt.Fprintln(os.Stdout, "Usage:")
+	_, _ = fmt.Fprintln(os.Stdout, "  server admin promote --principal=<name> [--create]")
+	_, _ = fmt.Fprintln(os.Stdout, "  server admin demote --principal=<name>")
 }

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"flag"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCurlHostForListenAddr(t *testing.T) {
@@ -36,4 +38,21 @@ func TestCurlHostForListenAddr(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestWantsServerHelp(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, wantsServerHelp([]string{"--help"}))
+	assert.True(t, wantsServerHelp([]string{"-h"}))
+	assert.True(t, wantsServerHelp([]string{"help"}))
+	assert.False(t, wantsServerHelp(nil))
+	assert.False(t, wantsServerHelp([]string{"admin"}))
+}
+
+func TestRunAdmin_Help(t *testing.T) {
+	t.Parallel()
+
+	err := runAdmin([]string{"--help"})
+	require.ErrorIs(t, err, flag.ErrHelp)
 }

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -6,6 +6,8 @@ import (
 	"database/sql"
 	"fmt"
 	"net/url"
+	"os"
+	"path/filepath"
 	"time"
 )
 
@@ -27,6 +29,9 @@ const (
 func OpenSQLite(path string, mode string, maxOpen int) (*sql.DB, error) {
 	if mode != "read" && mode != "write" {
 		return nil, fmt.Errorf("invalid SQLite mode %q: must be \"read\" or \"write\"", mode)
+	}
+	if err := ensureSQLiteParentDir(path); err != nil {
+		return nil, err
 	}
 
 	dsn := buildDSN(path, mode)
@@ -93,4 +98,15 @@ func buildDSN(path string, mode string) string {
 	}
 
 	return path + "?" + params.Encode()
+}
+
+func ensureSQLiteParentDir(path string) error {
+	parent := filepath.Dir(path)
+	if parent == "." || parent == "" {
+		return nil
+	}
+	if err := os.MkdirAll(parent, 0o750); err != nil {
+		return fmt.Errorf("create sqlite parent dir %q: %w", parent, err)
+	}
+	return nil
 }

--- a/internal/db/sqlite_test.go
+++ b/internal/db/sqlite_test.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"database/sql"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -170,15 +171,26 @@ func TestOpenSQLite_ForeignKeysEnabled(t *testing.T) {
 }
 
 func TestOpenSQLite_InvalidPath(t *testing.T) {
-	_, err := OpenSQLite("/nonexistent/dir/test.db", "write", 0)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "ping sqlite")
+	path := filepath.Join(t.TempDir(), "nested", "dir", "test.db")
+	db, err := OpenSQLite(path, "write", 0)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	_, statErr := os.Stat(filepath.Dir(path))
+	require.NoError(t, statErr)
 }
 
 func TestOpenSQLitePair_WriteFailClosesNothing(t *testing.T) {
-	// If the write pool fails to open, readDB should not be attempted
-	_, _, err := OpenSQLitePair("/nonexistent/dir/test.db", 4)
-	require.Error(t, err)
+	path := filepath.Join(t.TempDir(), "nested", "pair", "test.db")
+	writeDB, readDB, err := OpenSQLitePair(path, 4)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = writeDB.Close()
+		_ = readDB.Close()
+	})
+
+	_, statErr := os.Stat(filepath.Dir(path))
+	require.NoError(t, statErr)
 }
 
 // TestOpenSQLite_BusyTimeoutPreventsErrors verifies that the busy_timeout


### PR DESCRIPTION
## Summary
- make `server --help` and `server admin --help` print usage and exit without side effects
- create missing parent directories for `META_DB_PATH` before opening SQLite
- add focused regression tests for the server help/runtime paths and SQLite parent-dir creation

## Verification
- `go test ./cmd/server ./internal/db`
- direct runtime checks:
  - `./bin/server --help`
  - `./bin/server admin --help`
  - start server with `META_DB_PATH` pointing at a file under a missing parent directory
- `task check`

## Issue status
- closes #255
- closes #263
- closes #274

Stale issues closed separately during this sweep after direct verification on current `main`:
- #216
- #231
- #267
