### PR TITLE
fix: tighten API validation and status mapping

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -238,6 +238,7 @@ func run() error {
 		RequestsPerSecond: cfg.RateLimitRPS,
 		Burst:             cfg.RateLimitBurst,
 	}))
+	r.Use(api.RequestValidationMiddleware)
 
 	// Consistent JSON error responses for unknown routes and wrong methods
 	r.NotFound(func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/api/handler_apikeys.go
+++ b/internal/api/handler_apikeys.go
@@ -30,6 +30,8 @@ func (h *APIHandler) CreateAPIKey(ctx context.Context, req CreateAPIKeyRequestOb
 			return CreateAPIKey400JSONResponse{BadRequestJSONResponse{Body: Error{Code: 400, Message: err.Error()}, Headers: BadRequestResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
 		case errors.As(err, new(*domain.AccessDeniedError)):
 			return CreateAPIKey403JSONResponse{ForbiddenJSONResponse{Body: Error{Code: 403, Message: err.Error()}, Headers: ForbiddenResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		case errors.As(err, new(*domain.NotFoundError)):
+			return CreateAPIKey400JSONResponse{BadRequestJSONResponse{Body: Error{Code: 400, Message: err.Error()}, Headers: BadRequestResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
 		default:
 			return nil, err
 		}

--- a/internal/api/handler_apikeys_test.go
+++ b/internal/api/handler_apikeys_test.go
@@ -1,0 +1,84 @@
+package api
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"duck-demo/internal/domain"
+)
+
+type mockAPIKeyService struct {
+	createFn func(ctx context.Context, req domain.CreateAPIKeyRequest) (string, *domain.APIKey, error)
+}
+
+func (m *mockAPIKeyService) Create(ctx context.Context, req domain.CreateAPIKeyRequest) (string, *domain.APIKey, error) {
+	if m.createFn == nil {
+		panic("mockAPIKeyService.Create called but not configured")
+	}
+	return m.createFn(ctx, req)
+}
+
+func (m *mockAPIKeyService) List(context.Context, *string, domain.PageRequest) ([]domain.APIKey, int64, error) {
+	panic("not implemented")
+}
+
+func (m *mockAPIKeyService) Delete(context.Context, string) error {
+	panic("not implemented")
+}
+
+func (m *mockAPIKeyService) CleanupExpired(context.Context) (int64, error) {
+	panic("not implemented")
+}
+
+func TestHandler_CreateAPIKey_UnknownPrincipalReturns400(t *testing.T) {
+	t.Parallel()
+
+	handler := &APIHandler{apiKeys: &mockAPIKeyService{
+		createFn: func(_ context.Context, _ domain.CreateAPIKeyRequest) (string, *domain.APIKey, error) {
+			return "", nil, domain.ErrNotFound("principal not found")
+		},
+	}}
+
+	body := CreateAPIKeyJSONRequestBody{
+		PrincipalId: "00000000-0000-0000-0000-000000000000",
+		Name:        "example",
+	}
+	resp, err := handler.CreateAPIKey(secTestCtx(), CreateAPIKeyRequestObject{Body: &body})
+	require.NoError(t, err)
+
+	badReq, ok := resp.(CreateAPIKey400JSONResponse)
+	require.True(t, ok, "expected 400 response, got %T", resp)
+	assert.Equal(t, int32(400), badReq.Body.Code)
+}
+
+func TestHandler_CreateAPIKey_CreatesResponse(t *testing.T) {
+	t.Parallel()
+
+	createdAt := time.Date(2026, 3, 8, 10, 0, 0, 0, time.UTC)
+	handler := &APIHandler{apiKeys: &mockAPIKeyService{
+		createFn: func(_ context.Context, _ domain.CreateAPIKeyRequest) (string, *domain.APIKey, error) {
+			return "raw-secret", &domain.APIKey{
+				ID:        "key-1",
+				Name:      "example",
+				KeyPrefix: "raw-secr",
+				CreatedAt: createdAt,
+			}, nil
+		},
+	}}
+
+	body := CreateAPIKeyJSONRequestBody{
+		PrincipalId: "00000000-0000-0000-0000-000000000001",
+		Name:        "example",
+	}
+	resp, err := handler.CreateAPIKey(secTestCtx(), CreateAPIKeyRequestObject{Body: &body})
+	require.NoError(t, err)
+
+	created, ok := resp.(CreateAPIKey201JSONResponse)
+	require.True(t, ok, "expected 201 response, got %T", resp)
+	assert.Equal(t, "raw-secret", *created.Body.Key)
+	assert.Equal(t, "key-1", *created.Body.Id)
+}

--- a/internal/api/handler_models_test.go
+++ b/internal/api/handler_models_test.go
@@ -14,7 +14,10 @@ import (
 
 type mockModelService struct {
 	triggerRunFn           func(ctx context.Context, principal string, req domain.TriggerModelRunRequest) (*domain.ModelRun, error)
+	getRunFn               func(ctx context.Context, runID string) (*domain.ModelRun, error)
 	listRunsFn             func(ctx context.Context, filter domain.ModelRunFilter) ([]domain.ModelRun, int64, error)
+	listRunStepsFn         func(ctx context.Context, runID string) ([]domain.ModelRunStep, error)
+	listTestResultsFn      func(ctx context.Context, runID, stepID string) ([]domain.ModelTestResult, error)
 	checkSourceFreshnessFn func(ctx context.Context, principal, sourceSchema, sourceTable, timestampColumn string, maxLagSeconds int64) (*domain.SourceFreshnessStatus, error)
 }
 
@@ -42,8 +45,11 @@ func (m *mockModelService) TriggerRun(ctx context.Context, principal string, req
 	}
 	return m.triggerRunFn(ctx, principal, req)
 }
-func (m *mockModelService) GetRun(context.Context, string) (*domain.ModelRun, error) {
-	panic("not implemented")
+func (m *mockModelService) GetRun(ctx context.Context, runID string) (*domain.ModelRun, error) {
+	if m.getRunFn == nil {
+		panic("not implemented")
+	}
+	return m.getRunFn(ctx, runID)
 }
 func (m *mockModelService) ListRuns(ctx context.Context, filter domain.ModelRunFilter) ([]domain.ModelRun, int64, error) {
 	if m.listRunsFn == nil {
@@ -51,8 +57,11 @@ func (m *mockModelService) ListRuns(ctx context.Context, filter domain.ModelRunF
 	}
 	return m.listRunsFn(ctx, filter)
 }
-func (m *mockModelService) ListRunSteps(context.Context, string) ([]domain.ModelRunStep, error) {
-	panic("not implemented")
+func (m *mockModelService) ListRunSteps(ctx context.Context, runID string) ([]domain.ModelRunStep, error) {
+	if m.listRunStepsFn == nil {
+		panic("not implemented")
+	}
+	return m.listRunStepsFn(ctx, runID)
 }
 func (m *mockModelService) CancelRun(context.Context, string, string) error {
 	panic("not implemented")
@@ -66,8 +75,11 @@ func (m *mockModelService) ListTests(context.Context, string, string) ([]domain.
 func (m *mockModelService) DeleteTest(context.Context, string, string, string, string) error {
 	panic("not implemented")
 }
-func (m *mockModelService) ListTestResults(context.Context, string, string) ([]domain.ModelTestResult, error) {
-	panic("not implemented")
+func (m *mockModelService) ListTestResults(ctx context.Context, runID, stepID string) ([]domain.ModelTestResult, error) {
+	if m.listTestResultsFn == nil {
+		panic("not implemented")
+	}
+	return m.listTestResultsFn(ctx, runID, stepID)
 }
 func (m *mockModelService) CheckFreshness(context.Context, string, string) (*domain.FreshnessStatus, error) {
 	panic("not implemented")
@@ -243,6 +255,47 @@ func TestHandler_ListModelRuns_IncludesModelNamesAndProject(t *testing.T) {
 	assert.Equal(t, "analytics", *run.ProjectName)
 	require.NotNil(t, run.ModelNames)
 	assert.Equal(t, []string{"stg_orders", "fct_orders"}, *run.ModelNames)
+}
+
+func TestHandler_ListModelRunSteps_MissingRunReturns404(t *testing.T) {
+	t.Parallel()
+
+	h := &APIHandler{
+		models: &mockModelService{
+			listRunStepsFn: func(_ context.Context, _ string) ([]domain.ModelRunStep, error) {
+				return nil, domain.ErrNotFound("run not found")
+			},
+		},
+	}
+
+	resp, err := h.ListModelRunSteps(context.Background(), ListModelRunStepsRequestObject{RunId: "00000000-0000-0000-0000-000000000000"})
+	require.NoError(t, err)
+
+	notFound, ok := resp.(ListModelRunSteps404JSONResponse)
+	require.True(t, ok, "expected 404 response, got %T", resp)
+	assert.Equal(t, int32(404), notFound.Body.Code)
+}
+
+func TestHandler_ListModelTestResults_MissingRunReturns404(t *testing.T) {
+	t.Parallel()
+
+	h := &APIHandler{
+		models: &mockModelService{
+			listTestResultsFn: func(_ context.Context, _, _ string) ([]domain.ModelTestResult, error) {
+				return nil, domain.ErrNotFound("run not found")
+			},
+		},
+	}
+
+	resp, err := h.ListModelTestResults(context.Background(), ListModelTestResultsRequestObject{
+		RunId:  "00000000-0000-0000-0000-000000000000",
+		StepId: "00000000-0000-0000-0000-000000000001",
+	})
+	require.NoError(t, err)
+
+	notFound, ok := resp.(ListModelTestResults404JSONResponse)
+	require.True(t, ok, "expected 404 response, got %T", resp)
+	assert.Equal(t, int32(404), notFound.Body.Code)
 }
 
 func boolPtr(v bool) *bool { return &v }

--- a/internal/api/handler_security.go
+++ b/internal/api/handler_security.go
@@ -194,6 +194,10 @@ func (h *APIHandler) CreateGroup(ctx context.Context, req CreateGroupRequestObje
 		switch {
 		case errors.As(err, new(*domain.AccessDeniedError)):
 			return CreateGroup403JSONResponse{ForbiddenJSONResponse{Body: Error{Code: 403, Message: err.Error()}, Headers: ForbiddenResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		case errors.As(err, new(*domain.ValidationError)):
+			return CreateGroup400JSONResponse{BadRequestJSONResponse{Body: Error{Code: 400, Message: err.Error()}, Headers: BadRequestResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		case errors.As(err, new(*domain.ConflictError)):
+			return CreateGroup409JSONResponse{ConflictJSONResponse{Body: Error{Code: 409, Message: err.Error()}, Headers: ConflictResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
 		default:
 			return nil, err
 		}
@@ -240,8 +244,12 @@ func (h *APIHandler) ListGroupMembers(ctx context.Context, req ListGroupMembersR
 	ms, total, err := h.groups.ListMembers(ctx, req.GroupId, page)
 	if err != nil {
 		switch {
+		case errors.As(err, new(*domain.ValidationError)):
+			return ListGroupMembers400JSONResponse{BadRequestJSONResponse{Body: Error{Code: 400, Message: err.Error()}, Headers: BadRequestResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
 		case errors.As(err, new(*domain.AccessDeniedError)):
 			return ListGroupMembers403JSONResponse{ForbiddenJSONResponse{Body: Error{Code: 403, Message: err.Error()}, Headers: ForbiddenResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		case errors.As(err, new(*domain.NotFoundError)):
+			return ListGroupMembers404JSONResponse{NotFoundJSONResponse{Body: Error{Code: 404, Message: err.Error()}, Headers: NotFoundResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
 		default:
 			return nil, err
 		}
@@ -265,8 +273,12 @@ func (h *APIHandler) CreateGroupMember(ctx context.Context, req CreateGroupMembe
 		MemberID:   req.Body.MemberId,
 	}); err != nil {
 		switch {
+		case errors.As(err, new(*domain.ValidationError)):
+			return CreateGroupMember400JSONResponse{BadRequestJSONResponse{Body: Error{Code: 400, Message: err.Error()}, Headers: BadRequestResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
 		case errors.As(err, new(*domain.AccessDeniedError)):
 			return CreateGroupMember403JSONResponse{ForbiddenJSONResponse{Body: Error{Code: 403, Message: err.Error()}, Headers: ForbiddenResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		case errors.As(err, new(*domain.NotFoundError)):
+			return CreateGroupMember404JSONResponse{NotFoundJSONResponse{Body: Error{Code: 404, Message: err.Error()}, Headers: NotFoundResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
 		default:
 			return nil, err
 		}
@@ -282,8 +294,12 @@ func (h *APIHandler) DeleteGroupMember(ctx context.Context, req DeleteGroupMembe
 		MemberID:   req.Params.MemberId,
 	}); err != nil {
 		switch {
+		case errors.As(err, new(*domain.ValidationError)):
+			return DeleteGroupMember400JSONResponse{BadRequestJSONResponse{Body: Error{Code: 400, Message: err.Error()}, Headers: BadRequestResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
 		case errors.As(err, new(*domain.AccessDeniedError)):
 			return DeleteGroupMember403JSONResponse{ForbiddenJSONResponse{Body: Error{Code: 403, Message: err.Error()}, Headers: ForbiddenResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		case errors.As(err, new(*domain.NotFoundError)):
+			return DeleteGroupMember404JSONResponse{NotFoundJSONResponse{Body: Error{Code: 404, Message: err.Error()}, Headers: NotFoundResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
 		default:
 			return nil, err
 		}

--- a/internal/api/handler_security_test.go
+++ b/internal/api/handler_security_test.go
@@ -373,6 +373,24 @@ func TestHandler_GetGroup(t *testing.T) {
 	}
 }
 
+func TestHandler_CreateGroup_ConflictReturns409(t *testing.T) {
+	t.Parallel()
+
+	handler := &APIHandler{groups: &mockGroupService{
+		createFn: func(_ context.Context, _ domain.CreateGroupRequest) (*domain.Group, error) {
+			return nil, domain.ErrConflict("group already exists")
+		},
+	}}
+
+	body := CreateGroupJSONRequestBody{Name: "engineers"}
+	resp, err := handler.CreateGroup(secTestCtx(), CreateGroupRequestObject{Body: &body})
+	require.NoError(t, err)
+
+	conflict, ok := resp.(CreateGroup409JSONResponse)
+	require.True(t, ok, "expected 409 response, got %T", resp)
+	assert.Equal(t, int32(409), conflict.Body.Code)
+}
+
 func TestHandler_ListGroupMembers(t *testing.T) {
 	t.Parallel()
 
@@ -407,6 +425,19 @@ func TestHandler_ListGroupMembers(t *testing.T) {
 				forbidden, ok := resp.(ListGroupMembers403JSONResponse)
 				require.True(t, ok, "expected 403 response, got %T", resp)
 				assert.Equal(t, int32(403), forbidden.Body.Code)
+			},
+		},
+		{
+			name: "missing group returns 404",
+			svcFn: func(_ context.Context, _ string, _ domain.PageRequest) ([]domain.GroupMember, int64, error) {
+				return nil, 0, domain.ErrNotFound("group not found")
+			},
+			assertFn: func(t *testing.T, resp ListGroupMembersResponseObject, err error) {
+				t.Helper()
+				require.NoError(t, err)
+				notFound, ok := resp.(ListGroupMembers404JSONResponse)
+				require.True(t, ok, "expected 404 response, got %T", resp)
+				assert.Equal(t, int32(404), notFound.Body.Code)
 			},
 		},
 	}
@@ -456,6 +487,32 @@ func TestHandler_CreateGroupMember(t *testing.T) {
 				forbidden, ok := resp.(CreateGroupMember403JSONResponse)
 				require.True(t, ok, "expected 403 response, got %T", resp)
 				assert.Equal(t, int32(403), forbidden.Body.Code)
+			},
+		},
+		{
+			name: "missing group returns 404",
+			svcFn: func(_ context.Context, _ domain.AddGroupMemberRequest) error {
+				return domain.ErrNotFound("group not found")
+			},
+			assertFn: func(t *testing.T, resp CreateGroupMemberResponseObject, err error) {
+				t.Helper()
+				require.NoError(t, err)
+				notFound, ok := resp.(CreateGroupMember404JSONResponse)
+				require.True(t, ok, "expected 404 response, got %T", resp)
+				assert.Equal(t, int32(404), notFound.Body.Code)
+			},
+		},
+		{
+			name: "validation returns 400",
+			svcFn: func(_ context.Context, _ domain.AddGroupMemberRequest) error {
+				return domain.ErrValidation("group cannot be a member of itself")
+			},
+			assertFn: func(t *testing.T, resp CreateGroupMemberResponseObject, err error) {
+				t.Helper()
+				require.NoError(t, err)
+				badReq, ok := resp.(CreateGroupMember400JSONResponse)
+				require.True(t, ok, "expected 400 response, got %T", resp)
+				assert.Equal(t, int32(400), badReq.Body.Code)
 			},
 		},
 	}

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -137,7 +137,7 @@ func setupTestServer(t *testing.T, principalName string) *httptest.Server {
 	lineageRepo := repository.NewLineageRepo(metaDB)
 	querySvc := query.NewQueryService(eng, auditRepo, lineageRepo)
 	principalSvc := security.NewPrincipalService(principalRepo, auditRepo)
-	groupSvc := security.NewGroupService(groupRepo, auditRepo)
+	groupSvc := security.NewGroupService(groupRepo, principalRepo, auditRepo)
 	grantSvc := security.NewGrantService(grantRepo, auditRepo)
 	rowFilterSvc := security.NewRowFilterService(rowFilterRepo, auditRepo)
 	columnMaskSvc := security.NewColumnMaskService(columnMaskRepo, auditRepo)
@@ -419,7 +419,7 @@ func setupCatalogTestServer(t *testing.T, principalName string, mockRepo *mockCa
 	lineageRepo2 := repository.NewLineageRepo(metaDB)
 	querySvc := query.NewQueryService(eng, auditRepo, lineageRepo2)
 	principalSvc := security.NewPrincipalService(principalRepo, auditRepo)
-	groupSvc := security.NewGroupService(groupRepo, auditRepo)
+	groupSvc := security.NewGroupService(groupRepo, principalRepo, auditRepo)
 	grantSvc := security.NewGrantService(grantRepo, auditRepo)
 	rowFilterSvc := security.NewRowFilterService(rowFilterRepo, auditRepo)
 	columnMaskSvc := security.NewColumnMaskService(columnMaskRepo, auditRepo)
@@ -1306,12 +1306,12 @@ func setupSecurityTestServer(t *testing.T, principalName string, isAdmin bool) *
 	apiKeyRepo := repository.NewAPIKeyRepo(metaDB)
 
 	principalSvc := security.NewPrincipalService(principalRepo, auditRepo)
-	groupSvc := security.NewGroupService(groupRepo, auditRepo)
+	groupSvc := security.NewGroupService(groupRepo, principalRepo, auditRepo)
 	grantSvc := security.NewGrantService(grantRepo, auditRepo)
 	rowFilterSvc := security.NewRowFilterService(rowFilterRepo, auditRepo)
 	columnMaskSvc := security.NewColumnMaskService(columnMaskRepo, auditRepo)
 	auditSvc := governance.NewAuditService(auditRepo)
-	apiKeySvc := security.NewAPIKeyService(apiKeyRepo, auditRepo)
+	apiKeySvc := security.NewAPIKeyService(apiKeyRepo, principalRepo, auditRepo)
 
 	handler := NewHandler(
 		nil, // querySvc (not needed for security tests)

--- a/internal/api/request_validation.go
+++ b/internal/api/request_validation.go
@@ -1,0 +1,248 @@
+package api
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+
+	"duck-demo/internal/domain"
+)
+
+var uuidPathPattern = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+
+type bodyValidationTarget int
+
+const (
+	bodyValidationNone bodyValidationTarget = iota
+	bodyValidationCreatePrincipal
+	bodyValidationCreateNotebook
+	bodyValidationCreateAPIKey
+)
+
+// RequestValidationMiddleware enforces HTTP contract validation that the
+// generated strict handler does not currently apply itself.
+func RequestValidationMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := validatePaginationParams(r); err != nil {
+			writeBadRequest(w, err)
+			return
+		}
+		if err := validateUUIDPathParams(r); err != nil {
+			writeBadRequest(w, err)
+			return
+		}
+
+		if err := normalizeAndValidateJSONBody(r); err != nil {
+			writeBadRequest(w, err)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+func validatePaginationParams(r *http.Request) error {
+	qs := r.URL.Query()
+
+	if raw := qs.Get("max_results"); raw != "" {
+		value, err := strconv.Atoi(raw)
+		if err != nil || value < 1 || value > domain.MaxMaxResults {
+			return domain.ErrValidation("max_results must be between 1 and %d", domain.MaxMaxResults)
+		}
+	}
+
+	if raw := qs.Get("page_token"); raw != "" {
+		if _, err := decodePageToken(raw); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func decodePageToken(token string) (int, error) {
+	decoded, err := base64.StdEncoding.DecodeString(token)
+	if err != nil {
+		return 0, domain.ErrValidation("page_token must be a valid cursor")
+	}
+	offset, err := strconv.Atoi(string(decoded))
+	if err != nil || offset < 0 {
+		return 0, domain.ErrValidation("page_token must be a valid cursor")
+	}
+	return offset, nil
+}
+
+func validateUUIDPathParams(r *http.Request) error {
+	for _, spec := range uuidRouteSpecs {
+		pathParts := normalizedPathParts(r.URL.Path)
+		if !spec.matches(r.Method, pathParts) {
+			continue
+		}
+		for _, param := range spec.params {
+			value := chi.URLParam(r, param.name)
+			if value == "" {
+				value = routeParamFromPath(pathParts, param.segmentIndex)
+			}
+			if value == "" {
+				continue
+			}
+			if !uuidPathPattern.MatchString(value) {
+				return domain.ErrValidation("%s must be a valid UUID", param.name)
+			}
+		}
+	}
+
+	return nil
+}
+
+type uuidRouteSpec struct {
+	method  string
+	pattern []string
+	params  []uuidRouteParam
+}
+
+type uuidRouteParam struct {
+	name         string
+	segmentIndex int
+}
+
+var uuidRouteSpecs = []uuidRouteSpec{
+	{method: http.MethodGet, pattern: []string{"principals", "*"}, params: []uuidRouteParam{{name: "principalId", segmentIndex: 1}}},
+	{method: http.MethodDelete, pattern: []string{"principals", "*"}, params: []uuidRouteParam{{name: "principalId", segmentIndex: 1}}},
+	{method: http.MethodPatch, pattern: []string{"principals", "*"}, params: []uuidRouteParam{{name: "principalId", segmentIndex: 1}}},
+	{method: http.MethodGet, pattern: []string{"groups", "*"}, params: []uuidRouteParam{{name: "groupId", segmentIndex: 1}}},
+	{method: http.MethodDelete, pattern: []string{"groups", "*"}, params: []uuidRouteParam{{name: "groupId", segmentIndex: 1}}},
+	{method: http.MethodGet, pattern: []string{"groups", "*", "members"}, params: []uuidRouteParam{{name: "groupId", segmentIndex: 1}}},
+	{method: http.MethodPost, pattern: []string{"groups", "*", "members"}, params: []uuidRouteParam{{name: "groupId", segmentIndex: 1}}},
+	{method: http.MethodDelete, pattern: []string{"groups", "*", "members"}, params: []uuidRouteParam{{name: "groupId", segmentIndex: 1}}},
+	{method: http.MethodDelete, pattern: []string{"grants", "*"}, params: []uuidRouteParam{{name: "grantId", segmentIndex: 1}}},
+	{method: http.MethodDelete, pattern: []string{"row-filters", "*"}, params: []uuidRouteParam{{name: "rowFilterId", segmentIndex: 1}}},
+	{method: http.MethodDelete, pattern: []string{"column-masks", "*"}, params: []uuidRouteParam{{name: "columnMaskId", segmentIndex: 1}}},
+	{method: http.MethodDelete, pattern: []string{"api-keys", "*"}, params: []uuidRouteParam{{name: "apiKeyId", segmentIndex: 1}}},
+	{method: http.MethodDelete, pattern: []string{"tags", "*"}, params: []uuidRouteParam{{name: "tagId", segmentIndex: 1}}},
+	{method: http.MethodDelete, pattern: []string{"lineage", "edges", "*"}, params: []uuidRouteParam{{name: "edgeId", segmentIndex: 2}}},
+	{method: http.MethodGet, pattern: []string{"model-runs", "*"}, params: []uuidRouteParam{{name: "runId", segmentIndex: 1}}},
+	{method: http.MethodGet, pattern: []string{"model-runs", "*", "steps"}, params: []uuidRouteParam{{name: "runId", segmentIndex: 1}}},
+	{method: http.MethodGet, pattern: []string{"model-runs", "*", "steps", "*", "test-results"}, params: []uuidRouteParam{{name: "runId", segmentIndex: 1}, {name: "stepId", segmentIndex: 3}}},
+	{method: http.MethodPost, pattern: []string{"model-runs", "*", "cancel"}, params: []uuidRouteParam{{name: "runId", segmentIndex: 1}}},
+}
+
+func (s uuidRouteSpec) matches(method string, pathParts []string) bool {
+	if s.method != method {
+		return false
+	}
+	if len(pathParts) != len(s.pattern) {
+		return false
+	}
+	for i, part := range s.pattern {
+		if part == "*" {
+			continue
+		}
+		if pathParts[i] != part {
+			return false
+		}
+	}
+	return true
+}
+
+func normalizedPathParts(path string) []string {
+	parts := strings.Split(strings.Trim(path, "/"), "/")
+	if len(parts) > 0 && parts[0] == "v1" {
+		return parts[1:]
+	}
+	return parts
+}
+
+func routeParamFromPath(parts []string, index int) string {
+	if index >= len(parts) {
+		return ""
+	}
+	return parts[index]
+}
+
+func normalizeAndValidateJSONBody(r *http.Request) error {
+	if r.Body == nil || !strings.Contains(r.Header.Get("Content-Type"), "application/json") {
+		return nil
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return domain.ErrValidation("read request body: %v", err)
+	}
+
+	if isSetDefaultCatalogRoute(r.Method, r.URL.Path) && len(bytes.TrimSpace(body)) == 0 {
+		body = []byte("{}")
+	}
+
+	target := bodyValidationForRoute(r.Method, r.URL.Path)
+	if target != bodyValidationNone && len(bytes.TrimSpace(body)) > 0 {
+		if err := validateJSONBody(body, target); err != nil {
+			return err
+		}
+	}
+
+	r.Body = io.NopCloser(bytes.NewReader(body))
+	return nil
+}
+
+func isSetDefaultCatalogRoute(method, path string) bool {
+	return method == http.MethodPost && uuidRouteSpec{method: http.MethodPost, pattern: []string{"catalogs", "*", "set-default"}}.matches(method, normalizedPathParts(path))
+}
+
+func bodyValidationForRoute(method, path string) bodyValidationTarget {
+	if method != http.MethodPost {
+		return bodyValidationNone
+	}
+	switch path {
+	case "/principals", "/v1/principals":
+		return bodyValidationCreatePrincipal
+	case "/notebooks", "/v1/notebooks":
+		return bodyValidationCreateNotebook
+	case "/api-keys", "/v1/api-keys":
+		return bodyValidationCreateAPIKey
+	default:
+		return bodyValidationNone
+	}
+}
+
+func validateJSONBody(body []byte, target bodyValidationTarget) error {
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.DisallowUnknownFields()
+
+	switch target {
+	case bodyValidationCreatePrincipal:
+		var req CreatePrincipalJSONRequestBody
+		if err := decoder.Decode(&req); err != nil {
+			return domain.ErrValidation("invalid JSON body: %v", err)
+		}
+	case bodyValidationCreateNotebook:
+		var req CreateNotebookJSONRequestBody
+		if err := decoder.Decode(&req); err != nil {
+			return domain.ErrValidation("invalid JSON body: %v", err)
+		}
+	case bodyValidationCreateAPIKey:
+		var req CreateAPIKeyJSONRequestBody
+		if err := decoder.Decode(&req); err != nil {
+			return domain.ErrValidation("invalid JSON body: %v", err)
+		}
+	}
+
+	if decoder.More() {
+		return domain.ErrValidation("invalid JSON body: unexpected trailing content")
+	}
+
+	return nil
+}
+
+func writeBadRequest(w http.ResponseWriter, err error) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusBadRequest)
+	_ = json.NewEncoder(w).Encode(Error{Code: 400, Message: err.Error()})
+}

--- a/internal/api/request_validation_test.go
+++ b/internal/api/request_validation_test.go
@@ -1,0 +1,101 @@
+package api
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequestValidationMiddleware_RejectsInvalidPagination(t *testing.T) {
+	t.Parallel()
+
+	for _, target := range []string{
+		"/v1/principals?max_results=0",
+		"/v1/principals?max_results=2001",
+		"/v1/principals?page_token=garbage",
+	} {
+		t.Run(target, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest(http.MethodGet, target, nil)
+			rec := httptest.NewRecorder()
+
+			RequestValidationMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusNoContent)
+			})).ServeHTTP(rec, req)
+
+			require.Equal(t, http.StatusBadRequest, rec.Code)
+			assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+		})
+	}
+}
+
+func TestRequestValidationMiddleware_RejectsMalformedUUIDPath(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/principals/not-a-uuid", nil)
+	rec := httptest.NewRecorder()
+
+	RequestValidationMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})).ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "principalId")
+}
+
+func TestRequestValidationMiddleware_RejectsUnknownJSONFields(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		path string
+		body string
+	}{
+		{name: "principal", path: "/v1/principals", body: `{"name":"alice","type":"user","unexpected":"x"}`},
+		{name: "notebook", path: "/v1/notebooks", body: `{"name":"nb","owner_id":"x"}`},
+		{name: "api key", path: "/v1/api-keys", body: `{"name":"key","principal_id":"00000000-0000-0000-0000-000000000000","unexpected":true}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest(http.MethodPost, tt.path, strings.NewReader(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+
+			RequestValidationMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusCreated)
+			})).ServeHTTP(rec, req)
+
+			require.Equal(t, http.StatusBadRequest, rec.Code)
+			assert.Contains(t, rec.Body.String(), "invalid JSON body")
+		})
+	}
+}
+
+func TestRequestValidationMiddleware_AllowsEmptySetDefaultBody(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/catalogs/demo/set-default", http.NoBody)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	called := false
+	RequestValidationMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		body, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		assert.JSONEq(t, `{}`, string(body))
+		w.WriteHeader(http.StatusOK)
+	})).ServeHTTP(rec, req)
+
+	require.True(t, called)
+	require.Equal(t, http.StatusOK, rec.Code)
+}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -235,7 +235,7 @@ func New(ctx context.Context, deps Deps) (*App, error) {
 	principalSvc.SetAuthIdentityRepository(authIdentityRepo)
 	authService := authsvc.NewService(principalRepo, localCredentialRepo, authLoginAttemptRepo, setupStateRepo, authProviderRepo, auditRepo, cfg.Auth.JWTSecret)
 	webSessionAuth := authsvc.NewSessionService(principalRepo, webSessionRepo, auditRepo, cfg.Auth.WebSessionIdleTTL, cfg.Auth.WebSessionAbsoluteTTL)
-	groupSvc := security.NewGroupService(groupRepo, auditRepo)
+	groupSvc := security.NewGroupService(groupRepo, principalRepo, auditRepo)
 	grantSvc := security.NewGrantService(grantRepo, auditRepo, authSvc)
 	rowFilterSvc := security.NewRowFilterService(rowFilterRepo, auditRepo)
 	columnMaskSvc := security.NewColumnMaskService(columnMaskRepo, auditRepo)
@@ -367,7 +367,7 @@ func New(ctx context.Context, deps Deps) (*App, error) {
 
 	// === API Key ===
 	apiKeyRepo := repository.NewAPIKeyRepo(deps.ReadDB)
-	apiKeySvc := security.NewAPIKeyService(apiKeyRepo, auditRepo)
+	apiKeySvc := security.NewAPIKeyService(apiKeyRepo, principalRepo, auditRepo)
 
 	return &App{
 		Services: Services{

--- a/internal/db/repository/api_key.go
+++ b/internal/db/repository/api_key.go
@@ -13,12 +13,13 @@ import (
 
 // APIKeyRepo implements both domain.APIKeyRepository and middleware.APIKeyLookup using sqlc queries.
 type APIKeyRepo struct {
-	q *dbstore.Queries
+	q  *dbstore.Queries
+	db *sql.DB
 }
 
 // NewAPIKeyRepo creates a new APIKeyRepo.
 func NewAPIKeyRepo(db *sql.DB) *APIKeyRepo {
-	return &APIKeyRepo{q: dbstore.New(db)}
+	return &APIKeyRepo{q: dbstore.New(db), db: db}
 }
 
 // Compile-time check that APIKeyRepo implements domain.APIKeyRepository.
@@ -123,7 +124,18 @@ func (r *APIKeyRepo) GetByID(ctx context.Context, id string) (*domain.APIKey, er
 
 // Delete removes an API key by ID.
 func (r *APIKeyRepo) Delete(ctx context.Context, id string) error {
-	return r.q.DeleteAPIKey(ctx, id)
+	result, err := r.db.ExecContext(ctx, "DELETE FROM api_keys WHERE id = ?", id)
+	if err != nil {
+		return mapDBError(err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return domain.ErrNotFound("api key %s not found", id)
+	}
+	return nil
 }
 
 // DeleteExpired removes all expired API keys and returns the count deleted.

--- a/internal/db/repository/grant.go
+++ b/internal/db/repository/grant.go
@@ -13,12 +13,13 @@ var _ domain.GrantRepository = (*GrantRepo)(nil)
 
 // GrantRepo implements domain.GrantRepository using SQLite.
 type GrantRepo struct {
-	q *dbstore.Queries
+	q  *dbstore.Queries
+	db *sql.DB
 }
 
 // NewGrantRepo creates a new GrantRepo.
 func NewGrantRepo(db *sql.DB) *GrantRepo {
-	return &GrantRepo{q: dbstore.New(db)}
+	return &GrantRepo{q: dbstore.New(db), db: db}
 }
 
 // Grant creates a new privilege grant.
@@ -55,7 +56,18 @@ func (r *GrantRepo) Revoke(ctx context.Context, g *domain.PrivilegeGrant) error 
 
 // RevokeByID removes a privilege grant by its ID.
 func (r *GrantRepo) RevokeByID(ctx context.Context, id string) error {
-	return r.q.RevokePrivilegeByID(ctx, id)
+	result, err := r.db.ExecContext(ctx, "DELETE FROM privilege_grants WHERE id = ?", id)
+	if err != nil {
+		return mapDBError(err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return domain.ErrNotFound("grant %s not found", id)
+	}
+	return nil
 }
 
 // ListAll returns a paginated list of all grants.

--- a/internal/db/repository/lineage.go
+++ b/internal/db/repository/lineage.go
@@ -12,12 +12,13 @@ import (
 
 // LineageRepo implements domain.LineageRepository using SQLite.
 type LineageRepo struct {
-	q *dbstore.Queries
+	q  *dbstore.Queries
+	db *sql.DB
 }
 
 // NewLineageRepo creates a new LineageRepo.
 func NewLineageRepo(db *sql.DB) *LineageRepo {
-	return &LineageRepo{q: dbstore.New(db)}
+	return &LineageRepo{q: dbstore.New(db), db: db}
 }
 
 // InsertEdge records a new lineage edge between tables.
@@ -88,8 +89,18 @@ func (r *LineageRepo) GetDownstream(ctx context.Context, tableName string, page 
 
 // DeleteEdge removes a lineage edge by ID.
 func (r *LineageRepo) DeleteEdge(ctx context.Context, id string) error {
-	// sqlc DeleteLineageEdge doesn't return rows affected, so we need to check existence
-	return r.q.DeleteLineageEdge(ctx, id)
+	result, err := r.db.ExecContext(ctx, "DELETE FROM lineage_edges WHERE id = ?", id)
+	if err != nil {
+		return mapDBError(err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return domain.ErrNotFound("lineage edge %s not found", id)
+	}
+	return nil
 }
 
 // PurgeOlderThan removes lineage edges created before the given time.

--- a/internal/service/model/service.go
+++ b/internal/service/model/service.go
@@ -419,6 +419,9 @@ func (s *Service) ListRuns(ctx context.Context, filter domain.ModelRunFilter) ([
 
 // ListRunSteps returns the steps for a model run.
 func (s *Service) ListRunSteps(ctx context.Context, runID string) ([]domain.ModelRunStep, error) {
+	if _, err := s.runs.GetRunByID(ctx, runID); err != nil {
+		return nil, err
+	}
 	return s.runs.ListStepsByRun(ctx, runID)
 }
 
@@ -515,7 +518,10 @@ func (s *Service) DeleteTest(ctx context.Context, principal, projectName, modelN
 }
 
 // ListTestResults returns all test results for a model run step.
-func (s *Service) ListTestResults(ctx context.Context, _, stepID string) ([]domain.ModelTestResult, error) {
+func (s *Service) ListTestResults(ctx context.Context, runID, stepID string) ([]domain.ModelTestResult, error) {
+	if _, err := s.runs.GetRunByID(ctx, runID); err != nil {
+		return nil, err
+	}
 	return s.testResults.ListByStep(ctx, stepID)
 }
 

--- a/internal/service/query/query.go
+++ b/internal/service/query/query.go
@@ -3,6 +3,7 @@ package query
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -73,7 +74,7 @@ func (s *QueryService) Execute(ctx context.Context, principalName, sqlQuery stri
 	if err != nil {
 		// Log failed query
 		s.logAudit(ctx, principalName, "QUERY", &sqlQuery, nil, nil, "DENIED", err.Error(), duration, nil)
-		return nil, err
+		return nil, normalizeQueryError(err)
 	}
 	defer rows.Close() //nolint:errcheck
 
@@ -247,4 +248,24 @@ func (s *QueryService) logAudit(ctx context.Context, principal, action string, o
 // TablesAccessedStr returns a comma-separated list of tables for display.
 func TablesAccessedStr(tables []string) string {
 	return strings.Join(tables, ",")
+}
+
+func normalizeQueryError(err error) error {
+	var accessDenied *domain.AccessDeniedError
+	var validation *domain.ValidationError
+	if errors.As(err, &accessDenied) || errors.As(err, &validation) {
+		return err
+	}
+
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "classify statement:"),
+		strings.Contains(msg, "parse SQL:"),
+		strings.Contains(msg, "DDL statements are not allowed through the query engine"),
+		strings.Contains(msg, "unsupported statement type"),
+		strings.Contains(msg, "catalog lookup for") && strings.Contains(msg, "no such table"):
+		return domain.ErrValidation("%s", msg)
+	default:
+		return err
+	}
 }

--- a/internal/service/security/api_key.go
+++ b/internal/service/security/api_key.go
@@ -13,13 +13,14 @@ import (
 
 // APIKeyService provides API key management operations.
 type APIKeyService struct {
-	repo  domain.APIKeyRepository
-	audit domain.AuditRepository
+	repo       domain.APIKeyRepository
+	principals domain.PrincipalRepository
+	audit      domain.AuditRepository
 }
 
 // NewAPIKeyService creates a new APIKeyService.
-func NewAPIKeyService(repo domain.APIKeyRepository, audit domain.AuditRepository) *APIKeyService {
-	return &APIKeyService{repo: repo, audit: audit}
+func NewAPIKeyService(repo domain.APIKeyRepository, principals domain.PrincipalRepository, audit domain.AuditRepository) *APIKeyService {
+	return &APIKeyService{repo: repo, principals: principals, audit: audit}
 }
 
 // Create generates a new API key for the given principal.
@@ -38,6 +39,9 @@ func (s *APIKeyService) Create(ctx context.Context, req domain.CreateAPIKeyReque
 	// Non-admin users can only create keys for themselves.
 	if !caller.IsAdmin && caller.ID != req.PrincipalID {
 		return "", nil, domain.ErrAccessDenied("non-admin users can only create API keys for themselves")
+	}
+	if _, err := s.principals.GetByID(ctx, req.PrincipalID); err != nil {
+		return "", nil, err
 	}
 
 	// Generate a cryptographically secure random key.

--- a/internal/service/security/api_key_test.go
+++ b/internal/service/security/api_key_test.go
@@ -21,7 +21,7 @@ func setupAPIKeyService(t *testing.T) (*APIKeyService, *PrincipalService) {
 	apiKeyRepo := repository.NewAPIKeyRepo(db)
 	principalRepo := repository.NewPrincipalRepo(db)
 	auditRepo := repository.NewAuditRepo(db)
-	return NewAPIKeyService(apiKeyRepo, auditRepo), NewPrincipalService(principalRepo, auditRepo)
+	return NewAPIKeyService(apiKeyRepo, principalRepo, auditRepo), NewPrincipalService(principalRepo, auditRepo)
 }
 
 func TestAPIKeyService_Create(t *testing.T) {
@@ -58,6 +58,18 @@ func TestAPIKeyService_Create_EmptyName(t *testing.T) {
 	require.Error(t, err)
 	var validationErr *domain.ValidationError
 	assert.ErrorAs(t, err, &validationErr)
+}
+
+func TestAPIKeyService_Create_UnknownPrincipal(t *testing.T) {
+	svc, _ := setupAPIKeyService(t)
+
+	_, _, err := svc.Create(adminCtx(), domain.CreateAPIKeyRequest{
+		PrincipalID: "00000000-0000-0000-0000-000000000000",
+		Name:        "missing-owner",
+	})
+	require.Error(t, err)
+	var notFound *domain.NotFoundError
+	assert.ErrorAs(t, err, &notFound)
 }
 
 func TestAPIKeyService_Create_Unauthenticated(t *testing.T) {

--- a/internal/service/security/group.go
+++ b/internal/service/security/group.go
@@ -9,13 +9,14 @@ import (
 
 // GroupService provides group management operations.
 type GroupService struct {
-	repo  domain.GroupRepository
-	audit domain.AuditRepository
+	repo       domain.GroupRepository
+	principals domain.PrincipalRepository
+	audit      domain.AuditRepository
 }
 
 // NewGroupService creates a new GroupService.
-func NewGroupService(repo domain.GroupRepository, audit domain.AuditRepository) *GroupService {
-	return &GroupService{repo: repo, audit: audit}
+func NewGroupService(repo domain.GroupRepository, principals domain.PrincipalRepository, audit domain.AuditRepository) *GroupService {
+	return &GroupService{repo: repo, principals: principals, audit: audit}
 }
 
 // Create validates and persists a new group. Requires admin privileges.
@@ -71,6 +72,21 @@ func (s *GroupService) AddMember(ctx context.Context, req domain.AddGroupMemberR
 	if err := req.Validate(); err != nil {
 		return err
 	}
+	if _, err := s.repo.GetByID(ctx, req.GroupID); err != nil {
+		return err
+	}
+	if req.MemberType == "group" {
+		if req.MemberID == req.GroupID {
+			return domain.ErrValidation("group cannot be a member of itself")
+		}
+		if _, err := s.repo.GetByID(ctx, req.MemberID); err != nil {
+			return err
+		}
+	} else {
+		if _, err := s.principals.GetByID(ctx, req.MemberID); err != nil {
+			return err
+		}
+	}
 	m := &domain.GroupMember{
 		GroupID:    req.GroupID,
 		MemberType: req.MemberType,
@@ -91,6 +107,9 @@ func (s *GroupService) RemoveMember(ctx context.Context, req domain.RemoveGroupM
 	if err := req.Validate(); err != nil {
 		return err
 	}
+	if _, err := s.repo.GetByID(ctx, req.GroupID); err != nil {
+		return err
+	}
 	m := &domain.GroupMember{
 		GroupID:    req.GroupID,
 		MemberType: req.MemberType,
@@ -106,6 +125,9 @@ func (s *GroupService) RemoveMember(ctx context.Context, req domain.RemoveGroupM
 // ListMembers returns a paginated list of members in a group. Requires admin privileges.
 func (s *GroupService) ListMembers(ctx context.Context, groupID string, page domain.PageRequest) ([]domain.GroupMember, int64, error) {
 	if err := requireAdmin(ctx); err != nil {
+		return nil, 0, err
+	}
+	if _, err := s.repo.GetByID(ctx, groupID); err != nil {
 		return nil, 0, err
 	}
 	return s.repo.ListMembers(ctx, groupID, page)

--- a/internal/service/security/group_test.go
+++ b/internal/service/security/group_test.go
@@ -20,7 +20,7 @@ func setupGroupService(t *testing.T) (*GroupService, *PrincipalService) {
 	groupRepo := repository.NewGroupRepo(db)
 	principalRepo := repository.NewPrincipalRepo(db)
 	auditRepo := repository.NewAuditRepo(db)
-	return NewGroupService(groupRepo, auditRepo), NewPrincipalService(principalRepo, auditRepo)
+	return NewGroupService(groupRepo, principalRepo, auditRepo), NewPrincipalService(principalRepo, auditRepo)
 }
 
 func TestGroupService_Create_AdminRequired(t *testing.T) {
@@ -108,6 +108,38 @@ func TestGroupService_AddMember_AdminAllowed(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestGroupService_AddMember_RejectsMissingMember(t *testing.T) {
+	svc, _ := setupGroupService(t)
+
+	g, err := svc.Create(adminCtx(), domain.CreateGroupRequest{Name: "team"})
+	require.NoError(t, err)
+
+	err = svc.AddMember(adminCtx(), domain.AddGroupMemberRequest{
+		GroupID:    g.ID,
+		MemberID:   "00000000-0000-0000-0000-000000000000",
+		MemberType: "user",
+	})
+	require.Error(t, err)
+	var notFound *domain.NotFoundError
+	assert.ErrorAs(t, err, &notFound)
+}
+
+func TestGroupService_AddMember_RejectsSelfCycle(t *testing.T) {
+	svc, _ := setupGroupService(t)
+
+	g, err := svc.Create(adminCtx(), domain.CreateGroupRequest{Name: "team"})
+	require.NoError(t, err)
+
+	err = svc.AddMember(adminCtx(), domain.AddGroupMemberRequest{
+		GroupID:    g.ID,
+		MemberID:   g.ID,
+		MemberType: "group",
+	})
+	require.Error(t, err)
+	var validationErr *domain.ValidationError
+	assert.ErrorAs(t, err, &validationErr)
+}
+
 func TestGroupService_RemoveMember_AdminRequired(t *testing.T) {
 	svc, principalSvc := setupGroupService(t)
 
@@ -159,6 +191,15 @@ func TestGroupService_ListMembers_AdminAllowed(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), total)
 	assert.Empty(t, members)
+}
+
+func TestGroupService_ListMembers_MissingGroup(t *testing.T) {
+	svc, _ := setupGroupService(t)
+
+	_, _, err := svc.ListMembers(adminCtx(), "00000000-0000-0000-0000-000000000000", domain.PageRequest{})
+	require.Error(t, err)
+	var notFound *domain.NotFoundError
+	assert.ErrorAs(t, err, &notFound)
 }
 
 func TestGroupService_List_RequiresAdmin(t *testing.T) {

--- a/internal/ui/handlers_security_test.go
+++ b/internal/ui/handlers_security_test.go
@@ -152,9 +152,9 @@ func newUISecurityTestEnv(t *testing.T) uiSecurityTestEnv {
 	webSessionService := authsvc.NewSessionService(principalRepo, webSessionRepo, auditRepo, 30*time.Minute, 24*time.Hour)
 	h := NewHandler(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, authService, webSessionService, nil, config.AuthConfig{WebSessionCookieName: "ui_session"}, false)
 	h.Principal = securitysvc.NewPrincipalService(principalRepo, auditRepo)
-	h.Group = securitysvc.NewGroupService(groupRepo, auditRepo)
+	h.Group = securitysvc.NewGroupService(groupRepo, principalRepo, auditRepo)
 	h.Grant = securitysvc.NewGrantService(grantRepo, auditRepo)
-	h.APIKey = securitysvc.NewAPIKeyService(apiKeyRepo, auditRepo)
+	h.APIKey = securitysvc.NewAPIKeyService(apiKeyRepo, principalRepo, auditRepo)
 
 	router := chi.NewRouter()
 	router.Route("/ui", func(r chi.Router) {

--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -679,7 +679,7 @@ func setupIntegrationServer(t *testing.T) *testEnv {
 	// Remaining services (querySvc gets nil engine — we never hit /v1/query)
 	querySvc := query.NewQueryService(nil, auditRepo, nil)
 	principalSvc := security.NewPrincipalService(principalRepo, auditRepo)
-	groupSvc := security.NewGroupService(groupRepo, auditRepo)
+	groupSvc := security.NewGroupService(groupRepo, principalRepo, auditRepo)
 	grantSvc := security.NewGrantService(grantRepo, auditRepo)
 	rowFilterSvc := security.NewRowFilterService(rowFilterRepo, auditRepo)
 	columnMaskSvc := security.NewColumnMaskService(columnMaskRepo, auditRepo)
@@ -816,7 +816,7 @@ func setupLocalExtensionServer(t *testing.T) *testEnv {
 	// Remaining services (querySvc gets nil engine — we never hit /v1/query)
 	querySvc := query.NewQueryService(nil, auditRepo, nil)
 	principalSvc := security.NewPrincipalService(principalRepo, auditRepo)
-	groupSvc := security.NewGroupService(groupRepo, auditRepo)
+	groupSvc := security.NewGroupService(groupRepo, principalRepo, auditRepo)
 	grantSvc := security.NewGrantService(grantRepo, auditRepo)
 	rowFilterSvc := security.NewRowFilterService(rowFilterRepo, auditRepo)
 	columnMaskSvc := security.NewColumnMaskService(columnMaskRepo, auditRepo)
@@ -1225,7 +1225,7 @@ func setupHTTPServer(t *testing.T, opts httpTestOpts) *httpTestEnv {
 
 	// Build services
 	principalSvc := security.NewPrincipalService(principalRepo, auditRepo)
-	groupSvc := security.NewGroupService(groupRepo, auditRepo)
+	groupSvc := security.NewGroupService(groupRepo, principalRepo, auditRepo)
 	grantSvc := security.NewGrantService(grantRepo, auditRepo)
 	rowFilterSvc := security.NewRowFilterService(rowFilterRepo, auditRepo)
 	columnMaskSvc := security.NewColumnMaskService(columnMaskRepo, auditRepo)
@@ -1297,7 +1297,7 @@ func setupHTTPServer(t *testing.T, opts httpTestOpts) *httpTestEnv {
 			nil,
 		)
 		principalSvc = security.NewPrincipalService(principalRepo, auditRepo)
-		groupSvc = security.NewGroupService(groupRepo, auditRepo)
+		groupSvc = security.NewGroupService(groupRepo, principalRepo, auditRepo)
 		grantSvc = security.NewGrantService(grantRepo, auditRepo)
 		rowFilterSvc = security.NewRowFilterService(rowFilterRepo, auditRepo)
 		columnMaskSvc = security.NewColumnMaskService(columnMaskRepo, auditRepo)
@@ -1454,7 +1454,7 @@ func setupHTTPServer(t *testing.T, opts httpTestOpts) *httpTestEnv {
 
 	// Wire APIKeyService by default so API key endpoints are always available
 	// in integration test servers.
-	apiKeySvc := security.NewAPIKeyService(apiKeyRepo, auditRepo)
+	apiKeySvc := security.NewAPIKeyService(apiKeyRepo, principalRepo, auditRepo)
 	authService := authsvc.NewService(principalRepo, localCredentialRepo, authLoginAttemptRepo, setupStateRepo, authProviderRepo, auditRepo, string(jwtSecret))
 	webSessionAuth := authsvc.NewSessionService(principalRepo, webSessionRepo, auditRepo, 30*time.Minute, 24*time.Hour)
 	authHandler := api.NewAuthHTTPHandler(authService, webSessionAuth)
@@ -2253,7 +2253,7 @@ func setupMultiTableLocalServer(t *testing.T) *multiTableTestEnv {
 
 	querySvc := query.NewQueryService(nil, auditRepo, nil)
 	principalSvc := security.NewPrincipalService(principalRepo, auditRepo)
-	groupSvc := security.NewGroupService(groupRepo, auditRepo)
+	groupSvc := security.NewGroupService(groupRepo, principalRepo, auditRepo)
 	grantSvc := security.NewGrantService(grantRepo, auditRepo)
 	rowFilterSvc := security.NewRowFilterService(rowFilterRepo, auditRepo)
 	columnMaskSvc := security.NewColumnMaskService(columnMaskRepo, auditRepo)

--- a/test/integration/lineage_http_test.go
+++ b/test/integration/lineage_http_test.go
@@ -208,13 +208,11 @@ func TestHTTP_DeleteLineageEdge(t *testing.T) {
 			}
 		}},
 
-		{"delete_nonexistent_204_idempotent", func(t *testing.T) {
-			// Deleting a nonexistent edge returns 204 (idempotent — the SQL
-			// DELETE succeeds with 0 rows affected and no error).
+		{"delete_nonexistent_404", func(t *testing.T) {
 			resp := doRequest(t, "DELETE",
 				fmt.Sprintf("%s/v1/lineage/edges/%s", env.Server.URL, "nonexistent-id"),
 				env.Keys.Admin, nil)
-			assert.Equal(t, 204, resp.StatusCode)
+			assert.Equal(t, 404, resp.StatusCode)
 			_ = resp.Body.Close()
 		}},
 	}

--- a/test/integration/models_http_test.go
+++ b/test/integration/models_http_test.go
@@ -1463,16 +1463,11 @@ func TestHTTP_ModelRunEndpoints(t *testing.T) {
 		require.Equal(t, 404, resp.StatusCode)
 	})
 
-	t.Run("list_run_steps_empty_for_nonexistent_run", func(t *testing.T) {
+	t.Run("list_run_steps_not_found_for_nonexistent_run", func(t *testing.T) {
 		resp := doRequest(t, "GET",
 			env.Server.URL+"/v1/model-runs/00000000-0000-0000-0000-000000000000/steps",
 			env.Keys.Admin, nil)
-		require.Equal(t, 200, resp.StatusCode)
-
-		var result map[string]interface{}
-		decodeJSON(t, resp, &result)
-		data := result["data"].([]interface{})
-		assert.Equal(t, 0, len(data), "steps should be empty for nonexistent run")
+		require.Equal(t, 404, resp.StatusCode)
 	})
 }
 


### PR DESCRIPTION
## Summary
- enforce API contract validation at the HTTP edge for malformed UUIDs, invalid pagination cursors, unexpected JSON fields, and empty set-default bodies
- map remaining group/API-key/query/model-run error cases to stable 4xx responses and enforce missing-parent/membership invariants
- make delete semantics for grants, API keys, and lineage edges return 404 when the resource is missing, and update integration coverage to the new contract

## Testing
- task check

Closes #251
Closes #252
Closes #253
Closes #258
Closes #259
Closes #264
Closes #270
Closes #261
Closes #233
Closes #234
Closes #235