### PR TITLE
fix: fail fast on unsupported group updates

### DIFF
--- a/internal/service/model/executor_test.go
+++ b/internal/service/model/executor_test.go
@@ -3,6 +3,7 @@ package model
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"log/slog"
 	"sort"
 	"testing"
@@ -22,6 +23,26 @@ func (passthroughSessionEngine) Query(ctx context.Context, _ string, sqlQuery st
 }
 
 func (passthroughSessionEngine) QueryOnConn(ctx context.Context, conn *sql.Conn, _ string, sqlQuery string) (*sql.Rows, error) {
+	return conn.QueryContext(ctx, sqlQuery)
+}
+
+type ddlRejectingSessionEngine struct {
+	queries []string
+}
+
+func (*ddlRejectingSessionEngine) Query(context.Context, string, string) (*sql.Rows, error) {
+	panic("unexpected Query call in executor tests")
+}
+
+func (e *ddlRejectingSessionEngine) QueryOnConn(ctx context.Context, conn *sql.Conn, _ string, sqlQuery string) (*sql.Rows, error) {
+	e.queries = append(e.queries, sqlQuery)
+	stmtType, err := sqlrewrite.ClassifyStatement(sqlQuery)
+	if err != nil {
+		return nil, err
+	}
+	if stmtType == sqlrewrite.StmtDDL {
+		return nil, fmt.Errorf("DDL statements are not allowed through the query engine")
+	}
 	return conn.QueryContext(ctx, sqlQuery)
 }
 
@@ -63,6 +84,61 @@ func TestCanDirectExecOnConn(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := canDirectExecOnConn(tt.stmtType, tt.query)
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestExecuteSingleModel_DDLBypassesQueryEngine(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name            string
+		materialization string
+		wantQueryCount  int
+	}{
+		{name: "view", materialization: domain.MaterializationView, wantQueryCount: 0},
+		{name: "table", materialization: domain.MaterializationTable, wantQueryCount: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			engine := &ddlRejectingSessionEngine{}
+			db, err := sql.Open("duckdb", "")
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = db.Close() })
+
+			_, err = db.ExecContext(context.Background(), "CREATE SCHEMA analytics")
+			require.NoError(t, err)
+
+			svc := &Service{
+				engine: engine,
+				duckDB: db,
+				logger: slog.New(slog.DiscardHandler),
+			}
+
+			rowsAffected, err := svc.executeSingleModel(
+				context.Background(),
+				&domain.Model{
+					ProjectName:     "analytics",
+					Name:            "orders",
+					SQL:             "SELECT 1 AS id",
+					Materialization: tc.materialization,
+				},
+				ExecutionConfig{TargetSchema: "analytics"},
+				"admin",
+				slog.New(slog.DiscardHandler),
+			)
+			require.NoError(t, err)
+
+			if tc.materialization == domain.MaterializationTable {
+				require.NotNil(t, rowsAffected)
+				assert.EqualValues(t, 1, *rowsAffected)
+			} else {
+				assert.Nil(t, rowsAffected)
+			}
+
+			require.Len(t, engine.queries, tc.wantQueryCount)
+			for _, query := range engine.queries {
+				assert.NotContains(t, query, "CREATE OR REPLACE")
+			}
 		})
 	}
 }

--- a/pkg/cli/declarative_capabilities.go
+++ b/pkg/cli/declarative_capabilities.go
@@ -97,6 +97,12 @@ func (c *APIStateClient) probeEndpoint(ctx context.Context, path string) error {
 // ValidateApplyCapabilities validates that optional model/macro endpoints
 // required by the current plan are available before execution starts.
 func (c *APIStateClient) ValidateApplyCapabilities(ctx context.Context, actions []declarative.Action) error {
+	for _, action := range actions {
+		if action.ResourceKind == declarative.KindGroup && action.Operation == declarative.OpUpdate {
+			return fmt.Errorf("group updates are not supported by the API; delete and recreate group %q or remove the description drift", action.ResourceName)
+		}
+	}
+
 	if endpointRequiredByPlan(actions, declarative.KindModel) {
 		if err := c.probeEndpoint(ctx, "/models"); err != nil {
 			if c.isOptionalReadError(err) {

--- a/pkg/cli/declarative_client_test.go
+++ b/pkg/cli/declarative_client_test.go
@@ -1784,6 +1784,20 @@ func TestValidateApplyCapabilities_AssetEndpointRequired(t *testing.T) {
 	assert.Contains(t, err.Error(), "/assets endpoint is unavailable")
 }
 
+func TestValidateApplyCapabilities_GroupUpdateUnsupported(t *testing.T) {
+	t.Parallel()
+
+	sc := setupReadStateClient(t, http.NewServeMux())
+	err := sc.ValidateApplyCapabilities(context.Background(), []declarative.Action{{
+		Operation:    declarative.OpUpdate,
+		ResourceKind: declarative.KindGroup,
+		ResourceName: "viewers",
+	}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "group updates are not supported by the API")
+	assert.Contains(t, err.Error(), "viewers")
+}
+
 // === ReadState helper ===
 
 // setupReadStateClient creates an APIStateClient backed by a test server with the given mux.


### PR DESCRIPTION
## Summary
- fail declarative apply before execution when a plan contains an unsupported group update
- add regression coverage for the new group-update preflight
- add model executor coverage proving materialization DDL bypasses the secured query engine

## Testing
- `go test ./pkg/cli ./internal/service/model -run 'TestValidateApplyCapabilities|TestValidateNoSelfAPIKeyDeletion|TestCanDirectExecOnConn|TestExecuteSingleModel_DDLBypassesQueryEngine'`

Closes #249