### PR TITLE
test: cover remaining fixed issue regressions

### DIFF
--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -32,6 +32,7 @@ import (
 	"duck-demo/internal/service/governance"
 	"duck-demo/internal/service/query"
 	"duck-demo/internal/service/security"
+	"duck-demo/internal/service/storage"
 )
 
 // ctx is a package-level background context used by setup helpers.
@@ -153,8 +154,9 @@ func setupTestServer(t *testing.T, principalName string) *httptest.Server {
 	searchSvc := catalog.NewSearchService(repository.NewSearchRepo(metaDB, metaDB), nil)
 	tagSvc := governance.NewTagService(repository.NewTagRepo(metaDB), auditRepo)
 	viewSvc := catalog.NewViewService(repository.NewViewRepo(metaDB), catalogRepoFactory, cat, auditRepo)
+	volumeSvc := storage.NewVolumeService(repository.NewVolumeRepo(metaDB), cat, auditRepo)
 
-	handler := NewHandler(querySvc, principalSvc, groupSvc, grantSvc, rowFilterSvc, columnMaskSvc, auditSvc, nil, catalogSvc, nil, queryHistorySvc, lineageSvc, searchSvc, tagSvc, viewSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	handler := NewHandler(querySvc, principalSvc, groupSvc, grantSvc, rowFilterSvc, columnMaskSvc, auditSvc, nil, catalogSvc, nil, queryHistorySvc, lineageSvc, searchSvc, tagSvc, viewSvc, nil, nil, nil, volumeSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	strictHandler := NewStrictHandler(handler, nil)
 
 	// Lookup principal to get admin status for context injection
@@ -435,8 +437,9 @@ func setupCatalogTestServer(t *testing.T, principalName string, mockRepo *mockCa
 	searchSvc := catalog.NewSearchService(repository.NewSearchRepo(metaDB, metaDB), nil)
 	tagSvc := governance.NewTagService(repository.NewTagRepo(metaDB), auditRepo)
 	viewSvc := catalog.NewViewService(repository.NewViewRepo(metaDB), mockFactory, cat, auditRepo)
+	volumeSvc := storage.NewVolumeService(repository.NewVolumeRepo(metaDB), cat, auditRepo)
 
-	handler := NewHandler(querySvc, principalSvc, groupSvc, grantSvc, rowFilterSvc, columnMaskSvc, auditSvc, nil, catalogSvc, nil, queryHistorySvc, lineageSvc, searchSvc, tagSvc, viewSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	handler := NewHandler(querySvc, principalSvc, groupSvc, grantSvc, rowFilterSvc, columnMaskSvc, auditSvc, nil, catalogSvc, nil, queryHistorySvc, lineageSvc, searchSvc, tagSvc, viewSvc, nil, nil, nil, volumeSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	strictHandler := NewStrictHandler(handler, nil)
 
 	// Lookup principal to get admin status for context injection
@@ -1470,6 +1473,9 @@ func TestAPI_APIKey_CRUD(t *testing.T) {
 	item := (*listResp.Data)[0]
 	require.NotNil(t, item.Name)
 	require.Equal(t, "test-key", *item.Name)
+	require.NotNil(t, keyResp.KeyPrefix)
+	require.NotNil(t, item.KeyPrefix)
+	require.Equal(t, *keyResp.KeyPrefix, *item.KeyPrefix)
 
 	// Delete API key.
 	deleteURL := fmt.Sprintf("%s/api-keys/%s", srv.URL, *keyResp.Id)
@@ -1483,6 +1489,74 @@ func TestAPI_APIKey_CRUD(t *testing.T) {
 	if listResp2.Data != nil {
 		require.Empty(t, *listResp2.Data)
 	}
+}
+
+func TestAPI_ViewCreatePersists(t *testing.T) {
+	mock := newMockCatalogRepo()
+	mock.addSchema("main")
+	srv := setupCatalogTestServer(t, "admin_user", mock)
+	defer srv.Close()
+
+	resp := doRequest(t, http.MethodPost, srv.URL+"/catalogs/lake/schemas/main/views", `{"name":"active_passengers","view_definition":"SELECT * FROM titanic LIMIT 1"}`)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	created := decodeJSON[ViewDetail](t, resp)
+	require.NotNil(t, created.Name)
+	require.Equal(t, "active_passengers", *created.Name)
+
+	getResp := doRequest(t, http.MethodGet, srv.URL+"/catalogs/lake/schemas/main/views/active_passengers", "")
+	require.Equal(t, http.StatusOK, getResp.StatusCode)
+	got := decodeJSON[ViewDetail](t, getResp)
+	require.NotNil(t, got.Name)
+	require.Equal(t, "active_passengers", *got.Name)
+
+	listResp := doRequest(t, http.MethodGet, srv.URL+"/catalogs/lake/schemas/main/views", "")
+	require.Equal(t, http.StatusOK, listResp.StatusCode)
+	views := decodeJSON[PaginatedViewDetails](t, listResp)
+	require.NotNil(t, views.Data)
+	require.NotEmpty(t, *views.Data)
+
+	found := false
+	for _, view := range *views.Data {
+		if view.Name != nil && *view.Name == "active_passengers" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "created view should be returned by list")
+}
+
+func TestAPI_VolumeCreatePersists(t *testing.T) {
+	mock := newMockCatalogRepo()
+	mock.addSchema("main")
+	srv := setupCatalogTestServer(t, "admin_user", mock)
+	defer srv.Close()
+
+	resp := doRequest(t, http.MethodPost, srv.URL+"/catalogs/lake/schemas/main/volumes", `{"name":"landing_zone","volume_type":"EXTERNAL","storage_location":"s3://bucket/landing_zone/"}`)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	created := decodeJSON[VolumeDetail](t, resp)
+	require.NotNil(t, created.Name)
+	require.Equal(t, "landing_zone", *created.Name)
+
+	getResp := doRequest(t, http.MethodGet, srv.URL+"/catalogs/lake/schemas/main/volumes/landing_zone", "")
+	require.Equal(t, http.StatusOK, getResp.StatusCode)
+	got := decodeJSON[VolumeDetail](t, getResp)
+	require.NotNil(t, got.Name)
+	require.Equal(t, "landing_zone", *got.Name)
+
+	listResp := doRequest(t, http.MethodGet, srv.URL+"/catalogs/lake/schemas/main/volumes", "")
+	require.Equal(t, http.StatusOK, listResp.StatusCode)
+	volumes := decodeJSON[PaginatedVolumes](t, listResp)
+	require.NotNil(t, volumes.Data)
+	require.NotEmpty(t, *volumes.Data)
+
+	found := false
+	for _, volume := range *volumes.Data {
+		if volume.Name != nil && *volume.Name == "landing_zone" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "created volume should be returned by list")
 }
 
 func TestAPI_ReadEndpoints_NonAdminAccess(t *testing.T) {

--- a/internal/declarative/exporter_test.go
+++ b/internal/declarative/exporter_test.go
@@ -137,6 +137,18 @@ func TestExporter_EmptyState(t *testing.T) {
 	assert.Empty(t, entries, "empty state should produce no files")
 }
 
+func TestExporter_CreatesMissingOutputDirectory(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "nested", "duck-config")
+
+	err := ExportDirectory(dir, &DesiredState{
+		Principals: []PrincipalSpec{{Name: "user1", Type: "user"}},
+	}, false)
+	require.NoError(t, err)
+
+	assertFileExists(t, filepath.Join(dir, "security", "principals.yaml"))
+}
+
 func TestExporter_OverwriteProtection(t *testing.T) {
 	dir := t.TempDir()
 	// Write something first

--- a/pkg/cli/api_cmd_test.go
+++ b/pkg/cli/api_cmd_test.go
@@ -203,6 +203,39 @@ func TestAPI_Curl_WithAPIKeyAuth(t *testing.T) {
 		"curl should include X-API-Key auth header")
 }
 
+func TestAPI_Curl_ProfileTokenOverriddenByExplicitAPIKey(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	require.NoError(t, SaveUserConfig(&UserConfig{
+		CurrentProfile: "default",
+		Profiles: map[string]Profile{
+			"default": {
+				Host:  "http://localhost:8080",
+				Token: "stale-profile-token",
+			},
+		},
+	}))
+
+	rootCmd := newRootCmd()
+	rootCmd.SetArgs([]string{
+		"--output", "json",
+		"--api-key", "fresh-api-key",
+		"api", "curl", "listSchemas",
+		"--param", "catalogName=main",
+	})
+
+	old := captureStdout(t)
+	err := rootCmd.Execute()
+	output := old()
+	require.NoError(t, err)
+
+	var result map[string]string
+	require.NoError(t, json.Unmarshal([]byte(output), &result))
+	assert.Contains(t, result["curl"], "X-API-Key: fresh-api-key")
+	assert.NotContains(t, result["curl"], "Authorization: Bearer stale-profile-token")
+}
+
 func TestAPI_Curl_WithBodyParams(t *testing.T) {
 	// createSchema has path param catalogName and body fields (name, comment, etc.)
 	dir := t.TempDir()

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -696,6 +696,42 @@ func TestCLI_ProfileAPIKeyOverridesStaleProfileToken(t *testing.T) {
 	assert.Empty(t, captured.Headers.Get("Authorization"))
 }
 
+func TestCLI_ModelCommandsRejectMalformedConfigJSON(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "models create",
+			args: []string{"models", "models", "create", "--project-name", "cfg-proj", "--name", "cfg-model", "--sql", "SELECT 1", "--config", "{target_catalog:main}"},
+		},
+		{
+			name: "models tests create",
+			args: []string{"models", "tests", "create", "cfg-proj", "cfg-model", "--name", "cfg-test", "--test-type", "not_null", "--column", "id", "--config", "{strict:true}"},
+		},
+		{
+			name: "models update",
+			args: []string{"models", "models", "update", "cfg-proj", "cfg-model", "--config", "{owner:ops}"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := &requestRecorder{}
+			srv := httptest.NewServer(jsonHandler(rec, 200, `{}`))
+			defer srv.Close()
+
+			rootCmd := newTestRootCmd(t, srv)
+			rootCmd.SetArgs(append([]string{"--host", srv.URL}, tt.args...))
+
+			err := rootCmd.Execute()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "parse --config as JSON object")
+			assert.Empty(t, rec.requests, "malformed config should fail before issuing an HTTP request")
+		})
+	}
+}
+
 func TestCLI_ZeroArgCommandsRejectUnexpectedArgs(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)


### PR DESCRIPTION
## Summary
- add regression coverage for export creating missing output directories
- add CLI coverage for explicit api-key precedence in `api curl` and malformed model `--config` rejection
- add integration coverage for API key prefix consistency and view/volume create persistence

## Testing
- `go test ./pkg/cli ./internal/declarative`
- `go test -tags=integration ./internal/api -run 'TestAPI_APIKey_CRUD|TestAPI_ViewCreatePersists|TestAPI_VolumeCreatePersists'`

This PR verifies the behavior behind #154, #156, #157, #191, and #236 on current `main` so those issues can be closed with concrete regression coverage.