### PR TITLE
refactor: make model service dependencies explicit

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -93,7 +93,7 @@ type App struct {
 // It also performs external-table view restoration.
 //
 // Construction order is designed so every dependency is available at the
-// time each constructor is called — no post-construction Set*() calls.
+// time each constructor is called, including feature-gated collaborators.
 func New(ctx context.Context, deps Deps) (*App, error) {
 	cfg := deps.Cfg
 
@@ -340,21 +340,24 @@ func New(ctx context.Context, deps Deps) (*App, error) {
 	modelRunRepo := repository.NewModelRunRepo(deps.WriteDB)
 	modelTestRepo := repository.NewModelTestRepo(deps.WriteDB)
 	modelTestResultRepo := repository.NewModelTestResultRepo(deps.WriteDB)
-	modelSvc := svcmodel.NewService(
-		modelRepo, modelRunRepo, modelTestRepo, modelTestResultRepo, auditRepo,
-		lineageRepo, colLineageRepo,
-		eng, deps.DuckDB,
-		deps.Logger.With("component", "model"),
-	)
-
 	// === Macro ===
 	macroRepo := repository.NewMacroRepo(deps.WriteDB)
 	macroSvc := macro.NewService(macroRepo, auditRepo)
-
-	// Wire optional dependencies into model service.
-	modelSvc.SetMacroRepo(macroRepo)
-	modelSvc.SetNotebookProvider(notebookProvider)
-	modelSvc.SetNotebookModelLinkRepo(notebookModelLinkRepo)
+	modelSvc := svcmodel.NewService(svcmodel.ServiceDeps{
+		Models:        modelRepo,
+		Runs:          modelRunRepo,
+		Tests:         modelTestRepo,
+		TestResults:   modelTestResultRepo,
+		Audit:         auditRepo,
+		Lineage:       lineageRepo,
+		ColumnLineage: colLineageRepo,
+		Macros:        macroRepo,
+		Notebooks:     notebookProvider,
+		NotebookLinks: notebookModelLinkRepo,
+		Engine:        eng,
+		DuckDB:        deps.DuckDB,
+		Logger:        deps.Logger.With("component", "model"),
+	})
 	notebookSvc.SetPublishRepositories(modelRepo, notebookModelLinkRepo)
 
 	// === Semantic ===

--- a/internal/service/model/service.go
+++ b/internal/service/model/service.go
@@ -35,30 +35,39 @@ type Service struct {
 	runCancels    sync.Map
 }
 
+// ServiceDeps defines the collaborators required to construct a model service.
+type ServiceDeps struct {
+	Models        domain.ModelRepository
+	Runs          domain.ModelRunRepository
+	Tests         domain.ModelTestRepository
+	TestResults   domain.ModelTestResultRepository
+	Audit         domain.AuditRepository
+	Lineage       domain.LineageRepository
+	ColumnLineage domain.ColumnLineageRepository
+	Macros        domain.MacroRepository
+	Notebooks     domain.NotebookProvider
+	NotebookLinks domain.NotebookModelLinkRepository
+	Engine        domain.SessionEngine
+	DuckDB        *sql.DB
+	Logger        *slog.Logger
+}
+
 // NewService creates a new model Service.
-func NewService(
-	models domain.ModelRepository,
-	runs domain.ModelRunRepository,
-	tests domain.ModelTestRepository,
-	testResults domain.ModelTestResultRepository,
-	audit domain.AuditRepository,
-	lineage domain.LineageRepository,
-	colLineage domain.ColumnLineageRepository,
-	engine domain.SessionEngine,
-	duckDB *sql.DB,
-	logger *slog.Logger,
-) *Service {
+func NewService(deps ServiceDeps) *Service {
 	return &Service{
-		models:      models,
-		runs:        runs,
-		tests:       tests,
-		testResults: testResults,
-		audit:       audit,
-		lineage:     lineage,
-		colLineage:  colLineage,
-		engine:      engine,
-		duckDB:      duckDB,
-		logger:      logger,
+		models:        deps.Models,
+		runs:          deps.Runs,
+		tests:         deps.Tests,
+		testResults:   deps.TestResults,
+		audit:         deps.Audit,
+		lineage:       deps.Lineage,
+		colLineage:    deps.ColumnLineage,
+		macros:        deps.Macros,
+		notebooks:     deps.Notebooks,
+		notebookLinks: deps.NotebookLinks,
+		engine:        deps.Engine,
+		duckDB:        deps.DuckDB,
+		logger:        deps.Logger,
 	}
 }
 
@@ -446,28 +455,6 @@ func (s *Service) CancelRun(ctx context.Context, principal, runID string) error 
 
 	s.logAudit(ctx, principal, "cancel_model_run", runID)
 	return nil
-}
-
-// SetTestRepos sets the test and test result repositories on the service.
-// This allows injecting these optional dependencies after construction.
-func (s *Service) SetTestRepos(tests domain.ModelTestRepository, testResults domain.ModelTestResultRepository) {
-	s.tests = tests
-	s.testResults = testResults
-}
-
-// SetMacroRepo sets the macro repository for loading macros during model runs.
-func (s *Service) SetMacroRepo(macros domain.MacroRepository) {
-	s.macros = macros
-}
-
-// SetNotebookProvider sets the notebook provider for notebook-to-model promotion.
-func (s *Service) SetNotebookProvider(notebooks domain.NotebookProvider) {
-	s.notebooks = notebooks
-}
-
-// SetNotebookModelLinkRepo configures notebook-model link persistence for notebook promotion.
-func (s *Service) SetNotebookModelLinkRepo(links domain.NotebookModelLinkRepository) {
-	s.notebookLinks = links
 }
 
 // CreateTest creates a new test assertion for a model.

--- a/internal/service/model/service_constructor_test.go
+++ b/internal/service/model/service_constructor_test.go
@@ -1,0 +1,93 @@
+package model
+
+import (
+	"context"
+	"database/sql"
+	"log/slog"
+	"testing"
+
+	"duck-demo/internal/domain"
+
+	_ "github.com/duckdb/duckdb-go/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type constructorMacroRepoStub struct{}
+
+func (constructorMacroRepoStub) Create(context.Context, *domain.Macro) (*domain.Macro, error) {
+	panic("unexpected call")
+}
+func (constructorMacroRepoStub) GetByName(context.Context, string) (*domain.Macro, error) {
+	panic("unexpected call")
+}
+func (constructorMacroRepoStub) List(context.Context, domain.PageRequest) ([]domain.Macro, int64, error) {
+	panic("unexpected call")
+}
+func (constructorMacroRepoStub) Update(context.Context, string, domain.UpdateMacroRequest) (*domain.Macro, error) {
+	panic("unexpected call")
+}
+func (constructorMacroRepoStub) Delete(context.Context, string) error { panic("unexpected call") }
+func (constructorMacroRepoStub) ListAll(context.Context) ([]domain.Macro, error) {
+	return []domain.Macro{}, nil
+}
+func (constructorMacroRepoStub) ListRevisions(context.Context, string) ([]domain.MacroRevision, error) {
+	panic("unexpected call")
+}
+func (constructorMacroRepoStub) GetRevisionByVersion(context.Context, string, int) (*domain.MacroRevision, error) {
+	panic("unexpected call")
+}
+
+func TestNewService_AssignsConstructorDependencies(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+	engine := passthroughSessionEngine{}
+	notebooks := promotionNotebookProviderStub{}
+	notebookLinks := promotionLinkRepoStub{}
+	macros := constructorMacroRepoStub{}
+
+	svc := NewService(ServiceDeps{
+		Macros:        macros,
+		Notebooks:     notebooks,
+		NotebookLinks: notebookLinks,
+		Engine:        engine,
+		Logger:        logger,
+	})
+
+	require.NotNil(t, svc)
+	assert.Same(t, logger, svc.logger)
+	assert.NotNil(t, svc.engine)
+	assert.NotNil(t, svc.macros)
+	assert.NotNil(t, svc.notebooks)
+	assert.NotNil(t, svc.notebookLinks)
+}
+
+func TestNewService_PromoteNotebookRequiresNotebookProvider(t *testing.T) {
+	svc := NewService(ServiceDeps{
+		Models: promotionModelRepoStub{},
+		Audit:  promotionAuditRepoStub{},
+		Logger: slog.New(slog.DiscardHandler),
+	})
+
+	_, err := svc.PromoteNotebook(context.Background(), "alice", domain.PromoteNotebookRequest{
+		NotebookID:      "nb-1",
+		OutputCellID:    "cell-out",
+		ProjectName:     "analytics",
+		Name:            "orders",
+		Materialization: domain.MaterializationTable,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "notebook provider not configured")
+}
+
+func TestNewService_VerifyMacrosLoadableWithoutMacroRepo(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	svc := NewService(ServiceDeps{
+		DuckDB: db,
+		Logger: slog.New(slog.DiscardHandler),
+	})
+
+	require.NoError(t, svc.verifyMacrosLoadable(context.Background(), "alice"))
+}

--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -1481,17 +1481,23 @@ func setupHTTPServer(t *testing.T, opts httpTestOpts) *httpTestEnv {
 		modelTestRepo := repository.NewModelTestRepo(metaDB)
 		modelTestResultRepo := repository.NewModelTestResultRepo(metaDB)
 		colLineageRepo := repository.NewColumnLineageRepo(metaDB)
-		modelSvc = svcmodel.NewService(
-			modelRepo, modelRunRepo, modelTestRepo, modelTestResultRepo, auditRepo,
-			lineageRepo, colLineageRepo,
-			integrationSessionEngine{}, duckDB,
-			slog.New(slog.NewTextHandler(io.Discard, nil)),
-		)
 		macroRepo := repository.NewMacroRepo(metaDB)
 		macroSvc = macro.NewService(macroRepo, auditRepo)
-		modelSvc.SetMacroRepo(macroRepo)
-		modelSvc.SetNotebookProvider(notebookProvider)
-		modelSvc.SetNotebookModelLinkRepo(notebookModelLinkRepo)
+		modelSvc = svcmodel.NewService(svcmodel.ServiceDeps{
+			Models:        modelRepo,
+			Runs:          modelRunRepo,
+			Tests:         modelTestRepo,
+			TestResults:   modelTestResultRepo,
+			Audit:         auditRepo,
+			Lineage:       lineageRepo,
+			ColumnLineage: colLineageRepo,
+			Macros:        macroRepo,
+			Notebooks:     notebookProvider,
+			NotebookLinks: notebookModelLinkRepo,
+			Engine:        integrationSessionEngine{},
+			DuckDB:        duckDB,
+			Logger:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		})
 		notebookSvc.SetPublishRepositories(modelRepo, notebookModelLinkRepo)
 	}
 


### PR DESCRIPTION
## Summary
- replace the positional model service constructor with an explicit `ServiceDeps` struct
- wire macro and notebook collaborators through construction in app and integration setup
- add focused constructor and feature-guard tests for the model service

## Testing
- `go test ./internal/service/model`

## Notes
- `internal/app` and broader unit runs are currently blocked by an existing generated DB code issue in `internal/db/dbstore` (`Queries` / `Principal` symbols missing), so this PR verifies the directly affected package only.