### PR TITLE
fix: notebooks-declarative bug hunt track

### DIFF
--- a/internal/api/handler_notebooks.go
+++ b/internal/api/handler_notebooks.go
@@ -274,6 +274,8 @@ func (h *APIHandler) DeleteCell(ctx context.Context, req GenDeleteCellRequest) (
 			return DeleteCell403JSONResponse{ForbiddenJSONResponse{Body: Error{Code: 403, Message: err.Error()}, Headers: ForbiddenResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
 		case errors.As(err, new(*domain.NotFoundError)):
 			return DeleteCell404JSONResponse{NotFoundJSONResponse{Body: Error{Code: 404, Message: err.Error()}, Headers: NotFoundResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
+		case errors.As(err, new(*domain.ValidationError)):
+			return DeleteCell400JSONResponse{BadRequestJSONResponse{Body: Error{Code: 400, Message: err.Error()}, Headers: BadRequestResponseHeaders{XRateLimitLimit: defaultRateLimitLimit, XRateLimitRemaining: defaultRateLimitRemaining, XRateLimitReset: defaultRateLimitReset}}}, nil
 		default:
 			return nil, err
 		}

--- a/internal/api/handler_notebooks_test.go
+++ b/internal/api/handler_notebooks_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -253,6 +254,14 @@ func nbDecodeJSON[T any](t *testing.T, resp *http.Response) T {
 	return result
 }
 
+func nbReadBody(t *testing.T, resp *http.Response) string {
+	t.Helper()
+	defer resp.Body.Close() //nolint:errcheck
+	data, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return string(data)
+}
+
 // === Shared test fixtures ===
 
 var (
@@ -492,6 +501,19 @@ func TestAPI_CellCRUD(t *testing.T) {
 		resp := nbDoRequest(t, http.MethodDelete, srv.URL+"/notebooks/"+nbID+"/cells/"+cellID, "")
 		defer resp.Body.Close() //nolint:errcheck
 		require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	})
+
+	t.Run("delete cell validation error", func(t *testing.T) {
+		notebookSvc.deleteCellFn = func(_ context.Context, _ string, _ bool, _ string) error {
+			return domain.ErrValidation("cannot delete published output cell")
+		}
+		resp := nbDoRequest(t, http.MethodDelete, srv.URL+"/notebooks/"+nbID+"/cells/"+cellID, "")
+		defer resp.Body.Close() //nolint:errcheck
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		assert.Contains(t, nbReadBody(t, resp), "cannot delete published output cell")
+		notebookSvc.deleteCellFn = func(_ context.Context, _ string, _ bool, _ string) error {
+			return nil
+		}
 	})
 }
 

--- a/internal/db/repository/notebooks.go
+++ b/internal/db/repository/notebooks.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"duck-demo/internal/db/dbstore"
 	"duck-demo/internal/db/mapper"
@@ -15,12 +16,13 @@ var _ domain.NotebookRepository = (*NotebookRepo)(nil)
 
 // NotebookRepo implements domain.NotebookRepository using sqlc-generated queries.
 type NotebookRepo struct {
-	q *dbstore.Queries
+	db *sql.DB
+	q  *dbstore.Queries
 }
 
 // NewNotebookRepo creates a new NotebookRepo.
 func NewNotebookRepo(db *sql.DB) *NotebookRepo {
-	return &NotebookRepo{q: dbstore.New(db)}
+	return &NotebookRepo{db: db, q: dbstore.New(db)}
 }
 
 // CreateNotebook inserts a new notebook.
@@ -102,15 +104,6 @@ func (r *NotebookRepo) DeleteNotebook(ctx context.Context, id string) error {
 // A position of -1 means "auto-assign to end". Any other value (including 0)
 // is treated as an explicit position.
 func (r *NotebookRepo) CreateCell(ctx context.Context, cell *domain.Cell) (*domain.Cell, error) {
-	position := int64(cell.Position)
-	if cell.Position < 0 {
-		maxPos, err := r.GetMaxPosition(ctx, cell.NotebookID)
-		if err != nil {
-			return nil, fmt.Errorf("get max position: %w", err)
-		}
-		position = int64(maxPos + 1)
-	}
-
 	role := cell.Role
 	if role == "" {
 		if cell.CellType == domain.CellTypeMarkdown {
@@ -128,7 +121,27 @@ func (r *NotebookRepo) CreateCell(ctx context.Context, cell *domain.Cell) (*doma
 		testCfg = string(b)
 	}
 
-	row, err := r.q.CreateCell(ctx, dbstore.CreateCellParams{
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	qtx := r.q.WithTx(tx)
+	position := int64(cell.Position)
+	if cell.Position < 0 {
+		maxPos, err := r.getMaxPositionWithQuerier(ctx, qtx, cell.NotebookID)
+		if err != nil {
+			return nil, fmt.Errorf("get max position: %w", err)
+		}
+		position = int64(maxPos + 1)
+	} else {
+		if err := shiftPositionsForInsert(ctx, tx, cell.NotebookID, position); err != nil {
+			return nil, err
+		}
+	}
+
+	row, err := qtx.CreateCell(ctx, dbstore.CreateCellParams{
 		ID:         domain.NewID(),
 		NotebookID: cell.NotebookID,
 		CellType:   string(cell.CellType),
@@ -141,6 +154,9 @@ func (r *NotebookRepo) CreateCell(ctx context.Context, cell *domain.Cell) (*doma
 	})
 	if err != nil {
 		return nil, mapDBError(err)
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit create cell: %w", err)
 	}
 	return mapper.CellFromDB(row), nil
 }
@@ -165,7 +181,14 @@ func (r *NotebookRepo) ListCells(ctx context.Context, notebookID string) ([]doma
 
 // UpdateCell applies partial updates to an existing cell.
 func (r *NotebookRepo) UpdateCell(ctx context.Context, id string, req domain.UpdateCellRequest) (*domain.Cell, error) {
-	existing, err := r.q.GetCell(ctx, id)
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	qtx := r.q.WithTx(tx)
+	existing, err := qtx.GetCell(ctx, id)
 	if err != nil {
 		return nil, mapDBError(err)
 	}
@@ -203,10 +226,16 @@ func (r *NotebookRepo) UpdateCell(ctx context.Context, id string, req domain.Upd
 
 	position := existing.Position
 	if req.Position != nil {
-		position = int64(*req.Position)
+		nextPosition := int64(*req.Position)
+		if nextPosition != existing.Position {
+			if err := shiftPositionsForMove(ctx, tx, existing.NotebookID, existing.ID, existing.Position, nextPosition); err != nil {
+				return nil, err
+			}
+			position = nextPosition
+		}
 	}
 
-	row, err := r.q.UpdateCell(ctx, dbstore.UpdateCellParams{
+	row, err := qtx.UpdateCell(ctx, dbstore.UpdateCellParams{
 		Name:       name,
 		Role:       role,
 		Disabled:   disabled,
@@ -218,12 +247,52 @@ func (r *NotebookRepo) UpdateCell(ctx context.Context, id string, req domain.Upd
 	if err != nil {
 		return nil, mapDBError(err)
 	}
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit update cell: %w", err)
+	}
 	return mapper.CellFromDB(row), nil
 }
 
 // DeleteCell removes a cell by ID.
 func (r *NotebookRepo) DeleteCell(ctx context.Context, id string) error {
-	return r.q.DeleteCell(ctx, id)
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	qtx := r.q.WithTx(tx)
+	cell, err := qtx.GetCell(ctx, id)
+	if err != nil {
+		return mapDBError(err)
+	}
+	if linked, err := isProtectedNotebookOutputCell(ctx, tx, id); err != nil {
+		return err
+	} else if linked {
+		return domain.ErrValidation("cannot delete notebook output cell %q while it is published to a model", id)
+	}
+
+	result, err := tx.ExecContext(ctx, "DELETE FROM cells WHERE id = ?", id)
+	if err != nil {
+		if strings.Contains(err.Error(), "FOREIGN KEY constraint failed") {
+			return domain.ErrValidation("cannot delete notebook cell %q because it is still referenced", id)
+		}
+		return err
+	}
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("delete cell rows affected: %w", err)
+	}
+	if rowsAffected == 0 {
+		return domain.ErrNotFound("cell %s not found", id)
+	}
+	if _, err := tx.ExecContext(ctx, "UPDATE cells SET position = position - 1, updated_at = datetime('now') WHERE notebook_id = ? AND position > ?", cell.NotebookID, cell.Position); err != nil {
+		return fmt.Errorf("normalize positions after delete: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit delete cell: %w", err)
+	}
+	return nil
 }
 
 // UpdateCellResult updates the last_result field of a cell.
@@ -269,7 +338,11 @@ func (r *NotebookRepo) ReorderCells(ctx context.Context, notebookID string, cell
 // GetMaxPosition returns the maximum cell position in a notebook.
 // Returns -1 if the notebook has no cells.
 func (r *NotebookRepo) GetMaxPosition(ctx context.Context, notebookID string) (int, error) {
-	result, err := r.q.GetMaxCellPosition(ctx, notebookID)
+	return r.getMaxPositionWithQuerier(ctx, r.q, notebookID)
+}
+
+func (r *NotebookRepo) getMaxPositionWithQuerier(ctx context.Context, q maxCellPositionQuerier, notebookID string) (int, error) {
+	result, err := q.GetMaxCellPosition(ctx, notebookID)
 	if err != nil {
 		return 0, err
 	}
@@ -282,4 +355,37 @@ func (r *NotebookRepo) GetMaxPosition(ctx context.Context, notebookID string) (i
 	default:
 		return -1, nil
 	}
+}
+
+type maxCellPositionQuerier interface {
+	GetMaxCellPosition(ctx context.Context, notebookID string) (interface{}, error)
+}
+
+func shiftPositionsForInsert(ctx context.Context, tx *sql.Tx, notebookID string, position int64) error {
+	if _, err := tx.ExecContext(ctx, "UPDATE cells SET position = position + 1, updated_at = datetime('now') WHERE notebook_id = ? AND position >= ?", notebookID, position); err != nil {
+		return fmt.Errorf("shift positions for insert: %w", err)
+	}
+	return nil
+}
+
+func shiftPositionsForMove(ctx context.Context, tx *sql.Tx, notebookID, cellID string, fromPosition, toPosition int64) error {
+	if toPosition < fromPosition {
+		if _, err := tx.ExecContext(ctx, "UPDATE cells SET position = position + 1, updated_at = datetime('now') WHERE notebook_id = ? AND id <> ? AND position >= ? AND position < ?", notebookID, cellID, toPosition, fromPosition); err != nil {
+			return fmt.Errorf("shift positions up for move: %w", err)
+		}
+		return nil
+	}
+	if _, err := tx.ExecContext(ctx, "UPDATE cells SET position = position - 1, updated_at = datetime('now') WHERE notebook_id = ? AND id <> ? AND position > ? AND position <= ?", notebookID, cellID, fromPosition, toPosition); err != nil {
+		return fmt.Errorf("shift positions down for move: %w", err)
+	}
+	return nil
+}
+
+func isProtectedNotebookOutputCell(ctx context.Context, tx *sql.Tx, cellID string) (bool, error) {
+	row := tx.QueryRowContext(ctx, "SELECT EXISTS(SELECT 1 FROM notebook_model_links WHERE output_cell_id = ?)", cellID)
+	var exists bool
+	if err := row.Scan(&exists); err != nil {
+		return false, fmt.Errorf("check notebook output links: %w", err)
+	}
+	return exists, nil
 }

--- a/internal/db/repository/notebooks_test.go
+++ b/internal/db/repository/notebooks_test.go
@@ -387,3 +387,76 @@ func TestNotebookRepo_GetMaxPosition(t *testing.T) {
 		assert.Equal(t, 5, maxPos)
 	})
 }
+
+func TestNotebookRepo_CreateCell_ShiftsExistingPositions(t *testing.T) {
+	repo := setupNotebookRepo(t)
+	ctx := context.Background()
+
+	nb, err := repo.CreateNotebook(ctx, &domain.Notebook{Name: "ShiftInsertNB", Owner: "alice"})
+	require.NoError(t, err)
+
+	first, err := repo.CreateCell(ctx, &domain.Cell{NotebookID: nb.ID, CellType: domain.CellTypeSQL, Content: "SELECT 1", Position: 0})
+	require.NoError(t, err)
+	second, err := repo.CreateCell(ctx, &domain.Cell{NotebookID: nb.ID, CellType: domain.CellTypeSQL, Content: "SELECT 2", Position: 1})
+	require.NoError(t, err)
+
+	inserted, err := repo.CreateCell(ctx, &domain.Cell{NotebookID: nb.ID, CellType: domain.CellTypeSQL, Content: "SELECT 1.5", Position: 1})
+	require.NoError(t, err)
+	assert.Equal(t, 1, inserted.Position)
+
+	cells, err := repo.ListCells(ctx, nb.ID)
+	require.NoError(t, err)
+	require.Len(t, cells, 3)
+	assert.Equal(t, first.ID, cells[0].ID)
+	assert.Equal(t, inserted.ID, cells[1].ID)
+	assert.Equal(t, second.ID, cells[2].ID)
+	assert.Equal(t, 2, cells[2].Position)
+}
+
+func TestNotebookRepo_DeleteCell_ProtectsPublishedOutputAndNormalizesPositions(t *testing.T) {
+	repo := setupNotebookRepo(t)
+	ctx := context.Background()
+
+	nb, err := repo.CreateNotebook(ctx, &domain.Notebook{Name: "DeleteNB", Owner: "alice"})
+	require.NoError(t, err)
+	first, err := repo.CreateCell(ctx, &domain.Cell{NotebookID: nb.ID, CellType: domain.CellTypeSQL, Content: "SELECT 1", Position: 0})
+	require.NoError(t, err)
+	outputName := "published_output"
+	output, err := repo.CreateCell(ctx, &domain.Cell{
+		NotebookID: nb.ID,
+		CellType:   domain.CellTypeSQL,
+		Name:       &outputName,
+		Role:       domain.CellRoleOutput,
+		Content:    "SELECT 2",
+		Position:   1,
+	})
+	require.NoError(t, err)
+	tail, err := repo.CreateCell(ctx, &domain.Cell{NotebookID: nb.ID, CellType: domain.CellTypeSQL, Content: "SELECT 3", Position: 2})
+	require.NoError(t, err)
+
+	_, err = repo.db.ExecContext(ctx, "INSERT INTO models (id, project_name, name, sql_body, materialization) VALUES (?, ?, ?, ?, ?)", "model-1", "analytics", "published", "SELECT 2", "VIEW")
+	require.NoError(t, err)
+	_, err = repo.db.ExecContext(ctx, "INSERT INTO notebook_model_links (id, notebook_id, model_id, output_cell_id) VALUES (?, ?, ?, ?)", "link-1", nb.ID, "model-1", output.ID)
+	require.NoError(t, err)
+
+	err = repo.DeleteCell(ctx, output.ID)
+	require.Error(t, err)
+	var validationErr *domain.ValidationError
+	require.ErrorAs(t, err, &validationErr)
+
+	err = repo.DeleteCell(ctx, first.ID)
+	require.NoError(t, err)
+
+	cells, err := repo.ListCells(ctx, nb.ID)
+	require.NoError(t, err)
+	require.Len(t, cells, 2)
+	assert.Equal(t, output.ID, cells[0].ID)
+	assert.Equal(t, 0, cells[0].Position)
+	assert.Equal(t, tail.ID, cells[1].ID)
+	assert.Equal(t, 1, cells[1].Position)
+
+	_, err = repo.db.ExecContext(ctx, "DELETE FROM notebook_model_links WHERE id = ?", "link-1")
+	require.NoError(t, err)
+	err = repo.DeleteCell(ctx, output.ID)
+	require.NoError(t, err)
+}

--- a/internal/service/notebook/notebook.go
+++ b/internal/service/notebook/notebook.go
@@ -42,20 +42,6 @@ func (s *Service) CreateNotebook(ctx context.Context, principal string, req doma
 	if err != nil {
 		return nil, fmt.Errorf("create notebook: %w", err)
 	}
-	if req.Source != nil && *req.Source != "" {
-		cell := &domain.Cell{
-			ID:         domain.NewID(),
-			NotebookID: result.ID,
-			CellType:   domain.CellTypeSQL,
-			Role:       domain.CellRoleTransform,
-			Content:    *req.Source,
-			Position:   0,
-		}
-		if _, err := s.repo.CreateCell(ctx, cell); err != nil {
-			_ = s.repo.DeleteNotebook(ctx, result.ID)
-			return nil, fmt.Errorf("create initial notebook cell: %w", err)
-		}
-	}
 	_ = s.audit.Insert(ctx, &domain.AuditEntry{
 		PrincipalName: principal,
 		Action:        "CREATE_NOTEBOOK",

--- a/internal/service/notebook/notebook_test.go
+++ b/internal/service/notebook/notebook_test.go
@@ -51,6 +51,23 @@ func TestNotebookService_CreateNotebook(t *testing.T) {
 		var validationErr *domain.ValidationError
 		assert.ErrorAs(t, err, &validationErr)
 	})
+
+	t.Run("source does not create synthetic initial cell", func(t *testing.T) {
+		svc, repo, _ := setupNotebookService(t)
+		ctx := context.Background()
+		source := "sql"
+
+		repo.CreateNotebookFn = func(_ context.Context, nb *domain.Notebook) (*domain.Notebook, error) {
+			return &domain.Notebook{ID: "nb-2", Name: nb.Name, Owner: nb.Owner}, nil
+		}
+		repo.CreateCellFn = func(_ context.Context, _ *domain.Cell) (*domain.Cell, error) {
+			t.Fatal("CreateCell should not be called for notebook source metadata")
+			return nil, nil
+		}
+
+		_, err := svc.CreateNotebook(ctx, "alice", domain.CreateNotebookRequest{Name: "No Seed", Source: &source})
+		require.NoError(t, err)
+	})
 }
 
 // === GetNotebook ===

--- a/internal/service/notebook/session.go
+++ b/internal/service/notebook/session.go
@@ -470,10 +470,33 @@ func (m *SessionManager) RunAllAsync(ctx context.Context, sessionID string, prin
 			return
 		}
 		resultStr := string(resultJSON)
+		if runAllResultHasErrors(result) {
+			errStr := firstRunAllError(result)
+			_ = m.jobRepo.UpdateJobState(context.Background(), job.ID, domain.JobStateFailed, &resultStr, &errStr)
+			return
+		}
 		_ = m.jobRepo.UpdateJobState(context.Background(), job.ID, domain.JobStateComplete, &resultStr, nil)
 	}()
 
 	return job, nil
+}
+
+func runAllResultHasErrors(result *domain.RunAllResult) bool {
+	for i := range result.Results {
+		if result.Results[i].Error != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func firstRunAllError(result *domain.RunAllResult) string {
+	for i := range result.Results {
+		if result.Results[i].Error != nil {
+			return *result.Results[i].Error
+		}
+	}
+	return "notebook execution failed"
 }
 
 // GetJob returns a notebook job by ID.

--- a/internal/service/notebook/session_test.go
+++ b/internal/service/notebook/session_test.go
@@ -380,6 +380,55 @@ func TestSessionManager_RunAll(t *testing.T) {
 		var notFound *domain.NotFoundError
 		assert.ErrorAs(t, err, &notFound)
 	})
+
+	t.Run("marks job failed when execution result contains cell errors", func(t *testing.T) {
+		sm, repo, jobRepo, engine, _ := setupSessionManager(t)
+		ctx := context.Background()
+
+		repo.GetNotebookFn = func(_ context.Context, id string) (*domain.Notebook, error) {
+			return &domain.Notebook{ID: id, Name: "NB", Owner: "alice"}, nil
+		}
+		repo.ListCellsFn = func(_ context.Context, _ string) ([]domain.Cell, error) {
+			return []domain.Cell{
+				{ID: "cell-1", NotebookID: "nb-1", CellType: domain.CellTypeSQL, Content: "SELECT broken"},
+			}, nil
+		}
+		repo.GetCellFn = func(_ context.Context, _ string) (*domain.Cell, error) {
+			return &domain.Cell{ID: "cell-1", NotebookID: "nb-1", CellType: domain.CellTypeSQL, Content: "SELECT broken"}, nil
+		}
+		engine.queryOnConnFn = func(context.Context, *sql.Conn, string, string) (*sql.Rows, error) {
+			return nil, fmt.Errorf("syntax error")
+		}
+		jobRepo.CreateJobFn = func(_ context.Context, job *domain.NotebookJob) (*domain.NotebookJob, error) {
+			job.CreatedAt = time.Now()
+			return job, nil
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		var finalState domain.JobState
+		var finalError string
+		jobRepo.UpdateJobStateFn = func(_ context.Context, _ string, state domain.JobState, result *string, errMsg *string) error {
+			if state == domain.JobStateFailed || state == domain.JobStateComplete {
+				finalState = state
+				if errMsg != nil {
+					finalError = *errMsg
+				}
+				wg.Done()
+			}
+			return nil
+		}
+
+		sess, err := sm.CreateSession(ctx, "nb-1", "alice")
+		require.NoError(t, err)
+
+		_, err = sm.RunAllAsync(ctx, sess.ID)
+		require.NoError(t, err)
+
+		wg.Wait()
+		assert.Equal(t, domain.JobStateFailed, finalState)
+		assert.Contains(t, finalError, "syntax error")
+	})
 }
 
 // === RunAllAsync ===

--- a/pkg/cli/declarative_client.go
+++ b/pkg/cli/declarative_client.go
@@ -51,6 +51,7 @@ func normalizeCompatibilityMode(mode CapabilityCompatibilityMode) CapabilityComp
 type resourceIndex struct {
 	principalIDByName     map[string]string // "alice" → UUID
 	groupIDByName         map[string]string // "admins" → UUID
+	grantIDByIdentity     map[string]string // effective grant identity → UUID
 	catalogIDByName       map[string]string // "demo" → UUID
 	semanticModelIDByPath map[string]string // "project.model" → UUID
 	schemaIDByPath        map[string]string // "catalog.schema" → UUID
@@ -69,6 +70,7 @@ func newResourceIndex() *resourceIndex {
 	return &resourceIndex{
 		principalIDByName:     make(map[string]string),
 		groupIDByName:         make(map[string]string),
+		grantIDByIdentity:     make(map[string]string),
 		catalogIDByName:       make(map[string]string),
 		semanticModelIDByPath: make(map[string]string),
 		schemaIDByPath:        make(map[string]string),
@@ -348,6 +350,7 @@ func (c *APIStateClient) readGroups(ctx context.Context, state *declarative.Desi
 }
 
 type apiGrant struct {
+	ID            string `json:"id"`
 	PrincipalID   string `json:"principal_id"`
 	PrincipalType string `json:"principal_type"`
 	SecurableType string `json:"securable_type"`
@@ -395,6 +398,15 @@ func (c *APIStateClient) readGrants(ctx context.Context, state *declarative.Desi
 			Securable:     securablePath,
 			Privilege:     g.Privilege,
 		})
+		if g.ID != "" && c.index != nil {
+			c.index.grantIDByIdentity[grantIdentity(declarative.GrantSpec{
+				Principal:     principalName,
+				PrincipalType: g.PrincipalType,
+				SecurableType: g.SecurableType,
+				Securable:     securablePath,
+				Privilege:     g.Privilege,
+			})] = g.ID
+		}
 	}
 
 	_ = unresolved
@@ -697,6 +709,9 @@ type apiStorageCredential struct {
 	Name           string `json:"name"`
 	CredentialType string `json:"credential_type"`
 	Comment        string `json:"comment"`
+	Endpoint       string `json:"endpoint"`
+	Region         string `json:"region"`
+	URLStyle       string `json:"url_style"`
 }
 
 func (c *APIStateClient) readStorageCredentials(ctx context.Context, state *declarative.DesiredState) error {
@@ -714,11 +729,30 @@ func (c *APIStateClient) readStorageCredentials(ctx context.Context, state *decl
 	}
 
 	for _, sc := range items {
-		state.StorageCredentials = append(state.StorageCredentials, declarative.StorageCredentialSpec{
+		spec := declarative.StorageCredentialSpec{
 			Name:           sc.Name,
 			CredentialType: sc.CredentialType,
 			Comment:        sc.Comment,
-		})
+		}
+		switch sc.CredentialType {
+		case "S3":
+			spec.S3 = &declarative.S3CredentialSpec{
+				KeyIDFromEnv:  "REPLACE_ME",
+				SecretFromEnv: "REPLACE_ME",
+				Endpoint:      sc.Endpoint,
+				Region:        sc.Region,
+				URLStyle:      sc.URLStyle,
+			}
+		case "AZURE":
+			spec.Azure = &declarative.AzureCredentialSpec{
+				AccountNameFromEnv: "REPLACE_ME",
+			}
+		case "GCS":
+			spec.GCS = &declarative.GCSCredentialSpec{
+				KeyFilePath: "REPLACE_ME",
+			}
+		}
+		state.StorageCredentials = append(state.StorageCredentials, spec)
 		if sc.ID != "" && c.index != nil {
 			c.index.credentialIDByName[sc.Name] = sc.ID
 		}
@@ -885,15 +919,31 @@ type apiNotebook struct {
 }
 
 type apiNotebookCell struct {
-	ID       string `json:"id"`
-	CellType string `json:"cell_type"`
-	Content  string `json:"content"`
-	Position int    `json:"position"`
+	ID       string               `json:"id"`
+	CellType string               `json:"cell_type"`
+	Name     string               `json:"name"`
+	Role     string               `json:"role"`
+	Disabled bool                 `json:"disabled"`
+	Test     *apiNotebookCellTest `json:"test"`
+	Content  string               `json:"content"`
+	Position int                  `json:"position"`
+}
+
+type apiNotebookCellTest struct {
+	Severity string `json:"severity"`
+}
+
+type apiNotebookPublishModel struct {
+	ProjectName     string `json:"project_name"`
+	Name            string `json:"name"`
+	Materialization string `json:"materialization"`
+	OutputCellID    string `json:"output_cell_id"`
 }
 
 type apiNotebookDetail struct {
-	Notebook apiNotebook       `json:"notebook"`
-	Cells    []apiNotebookCell `json:"cells"`
+	Notebook     apiNotebook              `json:"notebook"`
+	Cells        []apiNotebookCell        `json:"cells"`
+	PublishModel *apiNotebookPublishModel `json:"publish_model"`
 }
 
 type apiAsset struct {
@@ -948,12 +998,40 @@ func (c *APIStateClient) readNotebooks(ctx context.Context, state *declarative.D
 				return detail.Cells[i].Position < detail.Cells[j].Position
 			})
 			cells = make([]declarative.CellSpec, 0, len(detail.Cells))
+			publish := buildNotebookPublishSpec(detail.PublishModel, detail.Cells)
 			for _, cell := range detail.Cells {
-				cells = append(cells, declarative.CellSpec{
+				name := cell.Name
+				if publish != nil && publish.Model != nil && publish.Model.OutputCell == cell.ID && name == "" {
+					name = cell.ID
+				}
+				spec := declarative.CellSpec{
 					Type:    cell.CellType,
 					Content: cell.Content,
-				})
+				}
+				if name != "" {
+					spec.Name = name
+				}
+				if cell.Role != "" && cell.Role != defaultNotebookCellRole(cell.CellType) {
+					spec.Role = cell.Role
+				}
+				if cell.Disabled {
+					spec.Disabled = true
+				}
+				if cell.Test != nil {
+					spec.Test = toDeclarativeNotebookTest(cell.Test)
+				}
+				cells = append(cells, spec)
 			}
+			state.Notebooks = append(state.Notebooks, declarative.NotebookResource{
+				Name: nb.Name,
+				Spec: declarative.NotebookSpec{
+					Description: nb.Description,
+					Owner:       nb.Owner,
+					Cells:       cells,
+					Publish:     publish,
+				},
+			})
+			continue
 		}
 
 		state.Notebooks = append(state.Notebooks, declarative.NotebookResource{
@@ -1286,6 +1364,44 @@ func toDeclarativeFreshness(freshness *apiModelFreshness) *declarative.Freshness
 	}
 }
 
+func toDeclarativeNotebookTest(test *apiNotebookCellTest) *declarative.NotebookTestSpec {
+	if test == nil {
+		return nil
+	}
+	return &declarative.NotebookTestSpec{Severity: test.Severity}
+}
+
+func buildNotebookPublishSpec(model *apiNotebookPublishModel, cells []apiNotebookCell) *declarative.NotebookPublishSpec {
+	if model == nil {
+		return nil
+	}
+	outputCellRef := model.OutputCellID
+	for _, cell := range cells {
+		if cell.ID != model.OutputCellID {
+			continue
+		}
+		if cell.Name != "" {
+			outputCellRef = cell.Name
+		}
+		break
+	}
+	return &declarative.NotebookPublishSpec{
+		Model: &declarative.NotebookPublishModelSpec{
+			Project:         model.ProjectName,
+			Name:            model.Name,
+			Materialization: model.Materialization,
+			OutputCell:      outputCellRef,
+		},
+	}
+}
+
+func defaultNotebookCellRole(cellType string) string {
+	if cellType == "markdown" {
+		return "markdown"
+	}
+	return "transform"
+}
+
 func (c *APIStateClient) readModels(ctx context.Context, state *declarative.DesiredState) error {
 	pages, err := c.fetchAllPages(ctx, "/models")
 	if err != nil {
@@ -1300,7 +1416,18 @@ func (c *APIStateClient) readModels(ctx context.Context, state *declarative.Desi
 		return err
 	}
 
+	publishedNotebookModels := make(map[string]struct{}, len(state.Notebooks))
+	for _, notebook := range state.Notebooks {
+		if notebook.Spec.Publish == nil || notebook.Spec.Publish.Model == nil {
+			continue
+		}
+		publishedNotebookModels[modelPath(notebook.Spec.Publish.Model.Project, notebook.Spec.Publish.Model.Name)] = struct{}{}
+	}
+
 	for _, m := range items {
+		if _, published := publishedNotebookModels[modelPath(m.ProjectName, m.Name)]; published {
+			continue
+		}
 		tests, _, err := c.listModelTests(ctx, m.ProjectName, m.Name)
 		if err != nil {
 			return fmt.Errorf("list tests for model %s.%s: %w", m.ProjectName, m.Name, err)
@@ -1581,6 +1708,53 @@ func (c *APIStateClient) resolvePrincipalID(name, principalType string) (string,
 	return id, nil
 }
 
+func grantIdentity(grant declarative.GrantSpec) string {
+	return strings.Join([]string{
+		grant.Principal,
+		grant.PrincipalType,
+		grant.SecurableType,
+		grant.Securable,
+		grant.Privilege,
+	}, "|")
+}
+
+func (c *APIStateClient) resolveGrantID(ctx context.Context, grant declarative.GrantSpec) (string, error) {
+	if c.index != nil {
+		if id, ok := c.index.grantIDByIdentity[grantIdentity(grant)]; ok {
+			return id, nil
+		}
+	}
+	principalID, err := c.resolvePrincipalID(grant.Principal, grant.PrincipalType)
+	if err != nil {
+		return "", err
+	}
+	securableID, err := c.resolveSecurableID(ctx, grant.SecurableType, grant.Securable)
+	if err != nil {
+		return "", err
+	}
+	pages, err := c.fetchAllPages(ctx, "/grants?principal_id="+url.QueryEscape(principalID)+"&principal_type="+url.QueryEscape(grant.PrincipalType))
+	if err != nil {
+		return "", err
+	}
+	var items []apiGrant
+	if err := mergePages(pages, &items); err != nil {
+		return "", err
+	}
+	for _, item := range items {
+		if item.SecurableType != grant.SecurableType || item.SecurableID != securableID || item.Privilege != grant.Privilege {
+			continue
+		}
+		if item.ID == "" {
+			continue
+		}
+		if c.index != nil {
+			c.index.grantIDByIdentity[grantIdentity(grant)] = item.ID
+		}
+		return item.ID, nil
+	}
+	return "", fmt.Errorf("grant %q not found", grantIdentity(grant))
+}
+
 // resolveSecurableID looks up a securable UUID by type and dot-path.
 // It falls back to direct API lookups for schemas/tables when missing in the index.
 func (c *APIStateClient) resolveSecurableID(ctx context.Context, securableType, path string) (string, error) {
@@ -1859,6 +2033,10 @@ func (c *APIStateClient) Execute(ctx context.Context, action declarative.Action)
 }
 
 func semanticModelPath(projectName, modelName string) string {
+	return projectName + "." + modelName
+}
+
+func modelPath(projectName, modelName string) string {
 	return projectName + "." + modelName
 }
 
@@ -2259,7 +2437,10 @@ func (c *APIStateClient) executeNotebook(ctx context.Context, action declarative
 		if c.index != nil {
 			c.index.notebookIDByName[nb.Name] = notebookID
 		}
-		return c.syncNotebookCells(ctx, notebookID, nb.Spec.Cells)
+		if err := c.syncNotebookCells(ctx, notebookID, nb.Spec.Cells); err != nil {
+			return err
+		}
+		return c.reconcileNotebookPublish(ctx, notebookID, nb.Spec)
 
 	case declarative.OpUpdate:
 		nb := action.Desired.(declarative.NotebookResource)
@@ -2278,7 +2459,10 @@ func (c *APIStateClient) executeNotebook(ctx context.Context, action declarative
 		if err := apiruntime.CheckError(resp); err != nil {
 			return err
 		}
-		return c.syncNotebookCells(ctx, notebookID, nb.Spec.Cells)
+		if err := c.syncNotebookCells(ctx, notebookID, nb.Spec.Cells); err != nil {
+			return err
+		}
+		return c.reconcileNotebookPublish(ctx, notebookID, nb.Spec)
 
 	case declarative.OpDelete:
 		notebookName := action.ResourceName
@@ -2386,8 +2570,53 @@ func (c *APIStateClient) syncNotebookCells(ctx context.Context, notebookID strin
 	if err != nil {
 		return err
 	}
+	sort.Slice(detail.Cells, func(i, j int) bool {
+		return detail.Cells[i].Position < detail.Cells[j].Position
+	})
+	protectedOutputCellID := ""
+	if detail.PublishModel != nil {
+		protectedOutputCellID = detail.PublishModel.OutputCellID
+	}
 
-	for _, cell := range detail.Cells {
+	for i, existing := range detail.Cells {
+		if i >= len(desired) {
+			if existing.ID == protectedOutputCellID {
+				return fmt.Errorf("cannot delete published output cell %q from notebook %q during declarative sync", existing.ID, notebookID)
+			}
+			continue
+		}
+		if existing.CellType != desired[i].Type && existing.ID == protectedOutputCellID {
+			return fmt.Errorf("cannot replace published output cell %q in notebook %q because cell_type changed", existing.ID, notebookID)
+		}
+	}
+
+	for i := 0; i < len(detail.Cells) && i < len(desired); i++ {
+		existing := detail.Cells[i]
+		cell := desired[i]
+		if existing.CellType != cell.Type {
+			continue
+		}
+		resp, err := c.client.Do(http.MethodPatch, "/notebooks/"+notebookID+"/cells/"+existing.ID, nil, notebookCellBody(cell, i, false))
+		if err != nil {
+			return err
+		}
+		if err := apiruntime.CheckError(resp); err != nil {
+			return err
+		}
+	}
+
+	for i := len(detail.Cells); i < len(desired); i++ {
+		resp, err := c.client.Do(http.MethodPost, "/notebooks/"+notebookID+"/cells", nil, notebookCellBody(desired[i], i, true))
+		if err != nil {
+			return err
+		}
+		if err := apiruntime.CheckError(resp); err != nil {
+			return err
+		}
+	}
+
+	for i := len(detail.Cells) - 1; i >= len(desired); i-- {
+		cell := detail.Cells[i]
 		resp, err := c.client.Do(http.MethodDelete, "/notebooks/"+notebookID+"/cells/"+cell.ID, nil, nil)
 		if err != nil {
 			return err
@@ -2397,15 +2626,20 @@ func (c *APIStateClient) syncNotebookCells(ctx context.Context, notebookID strin
 		}
 	}
 
-	for i, cell := range desired {
-		body := map[string]interface{}{
-			"cell_type": cell.Type,
-			"position":  i,
+	for i := 0; i < len(detail.Cells) && i < len(desired); i++ {
+		existing := detail.Cells[i]
+		cell := desired[i]
+		if existing.CellType == cell.Type {
+			continue
 		}
-		if cell.Content != "" {
-			body["content"] = cell.Content
+		resp, err := c.client.Do(http.MethodDelete, "/notebooks/"+notebookID+"/cells/"+existing.ID, nil, nil)
+		if err != nil {
+			return err
 		}
-		resp, err := c.client.Do(http.MethodPost, "/notebooks/"+notebookID+"/cells", nil, body)
+		if err := apiruntime.CheckError(resp); err != nil {
+			return err
+		}
+		resp, err = c.client.Do(http.MethodPost, "/notebooks/"+notebookID+"/cells", nil, notebookCellBody(cell, i, true))
 		if err != nil {
 			return err
 		}
@@ -2415,6 +2649,61 @@ func (c *APIStateClient) syncNotebookCells(ctx context.Context, notebookID strin
 	}
 
 	return nil
+}
+
+func notebookCellBody(cell declarative.CellSpec, position int, includeCellType bool) map[string]interface{} {
+	body := map[string]interface{}{
+		"content":  cell.Content,
+		"position": position,
+	}
+	if includeCellType {
+		body["cell_type"] = cell.Type
+	}
+	if cell.Name != "" {
+		body["name"] = cell.Name
+	}
+	if cell.Role != "" {
+		body["role"] = cell.Role
+	}
+	if cell.Disabled {
+		body["disabled"] = true
+	}
+	if cell.Test != nil {
+		body["test"] = map[string]interface{}{
+			"severity": cell.Test.Severity,
+		}
+	}
+	return body
+}
+
+func (c *APIStateClient) reconcileNotebookPublish(_ context.Context, notebookID string, spec declarative.NotebookSpec) error {
+	if spec.Publish == nil || spec.Publish.Model == nil {
+		return nil
+	}
+	outputIndex := -1
+	for i, cell := range spec.Cells {
+		if cell.Name == spec.Publish.Model.OutputCell {
+			outputIndex = i
+			break
+		}
+	}
+	if outputIndex < 0 {
+		return fmt.Errorf("published output cell %q not found in notebook %q", spec.Publish.Model.OutputCell, notebookID)
+	}
+	body := map[string]interface{}{
+		"notebook_id":  notebookID,
+		"cell_index":   outputIndex,
+		"project_name": spec.Publish.Model.Project,
+		"name":         spec.Publish.Model.Name,
+	}
+	if spec.Publish.Model.Materialization != "" {
+		body["materialization"] = spec.Publish.Model.Materialization
+	}
+	resp, err := c.client.Do(http.MethodPost, "/models/from-notebook", nil, body)
+	if err != nil {
+		return err
+	}
+	return apiruntime.CheckError(resp)
 }
 
 func (c *APIStateClient) resolveNotebookID(ctx context.Context, notebookName string) (string, error) {
@@ -3005,7 +3294,15 @@ func (c *APIStateClient) executeGroup(_ context.Context, action declarative.Acti
 		return apiruntime.CheckError(resp)
 
 	case declarative.OpDelete:
-		resp, err := c.client.Do(http.MethodDelete, "/groups/"+action.ResourceName, nil, nil)
+		groupName := action.ResourceName
+		if actual, ok := action.Actual.(declarative.GroupSpec); ok && actual.Name != "" {
+			groupName = actual.Name
+		}
+		groupID, err := c.resolvePrincipalID(groupName, "group")
+		if err != nil {
+			return fmt.Errorf("resolve group for delete: %w", err)
+		}
+		resp, err := c.client.Do(http.MethodDelete, "/groups/"+groupID, nil, nil)
 		if err != nil {
 			return err
 		}
@@ -3043,22 +3340,11 @@ func (c *APIStateClient) executeGrant(ctx context.Context, action declarative.Ac
 
 	case declarative.OpDelete:
 		grant := action.Actual.(declarative.GrantSpec)
-		principalID, err := c.resolvePrincipalID(grant.Principal, grant.PrincipalType)
+		grantID, err := c.resolveGrantID(ctx, grant)
 		if err != nil {
-			return fmt.Errorf("resolve principal for grant delete: %w", err)
+			return fmt.Errorf("resolve grant for delete: %w", err)
 		}
-		securableID, err := c.resolveSecurableID(ctx, grant.SecurableType, grant.Securable)
-		if err != nil {
-			return fmt.Errorf("resolve securable for grant delete: %w", err)
-		}
-		body := map[string]interface{}{
-			"principal_id":   principalID,
-			"principal_type": grant.PrincipalType,
-			"securable_id":   securableID,
-			"securable_type": grant.SecurableType,
-			"privilege":      grant.Privilege,
-		}
-		resp, err := c.client.Do(http.MethodDelete, "/grants", nil, body)
+		resp, err := c.client.Do(http.MethodDelete, "/grants/"+grantID, nil, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/cli/declarative_client_test.go
+++ b/pkg/cli/declarative_client_test.go
@@ -63,6 +63,13 @@ func withTestIndex(sc *APIStateClient) *APIStateClient {
 	sc.index.principalIDByName["bob"] = "principal-id-bob"
 	sc.index.groupIDByName["admins"] = "group-id-admins"
 	sc.index.groupIDByName["analysts"] = "group-id-analysts"
+	sc.index.grantIDByIdentity[grantIdentity(declarative.GrantSpec{
+		Principal:     "admins",
+		PrincipalType: "group",
+		SecurableType: "schema",
+		Securable:     "demo.titanic",
+		Privilege:     "ALL_PRIVILEGES",
+	})] = "grant-id-admins-schema"
 	sc.index.catalogIDByName["demo"] = "catalog-id-demo"
 	sc.index.schemaIDByPath["demo.titanic"] = "schema-id-titanic"
 	sc.index.tableIDByPath["demo.titanic.passengers"] = "table-id-passengers"
@@ -214,7 +221,7 @@ func TestExecuteGrant_Delete(t *testing.T) {
 
 	req := captured[0]
 	assert.Equal(t, http.MethodDelete, req.Method)
-	assert.Equal(t, "group-id-admins", bodyStr(req, "principal_id"))
+	assert.Equal(t, "/v1/grants/grant-id-admins-schema", req.Path)
 }
 
 // === Group membership execution tests (#128) ===
@@ -2076,7 +2083,7 @@ func TestReadState_StorageCredentials(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		resp := map[string]interface{}{
 			"data": []map[string]interface{}{
-				{"name": "aws-creds", "credential_type": "S3", "comment": "AWS access"},
+				{"name": "aws-creds", "credential_type": "S3", "comment": "AWS access", "endpoint": "s3.example.com", "region": "ap-southeast-2", "url_style": "path"},
 			},
 		}
 		_ = json.NewEncoder(w).Encode(resp)
@@ -2091,6 +2098,9 @@ func TestReadState_StorageCredentials(t *testing.T) {
 	assert.Equal(t, "aws-creds", state.StorageCredentials[0].Name)
 	assert.Equal(t, "S3", state.StorageCredentials[0].CredentialType)
 	assert.Equal(t, "AWS access", state.StorageCredentials[0].Comment)
+	require.NotNil(t, state.StorageCredentials[0].S3)
+	assert.Equal(t, "REPLACE_ME", state.StorageCredentials[0].S3.KeyIDFromEnv)
+	assert.Equal(t, "s3.example.com", state.StorageCredentials[0].S3.Endpoint)
 }
 
 func TestReadState_ExternalLocations(t *testing.T) {
@@ -2197,8 +2207,14 @@ func TestReadState_Notebooks(t *testing.T) {
 				"owner":       "alice",
 			},
 			"cells": []map[string]interface{}{
-				{"id": "cell-1", "cell_type": "markdown", "content": "# Intro", "position": 0},
-				{"id": "cell-2", "cell_type": "sql", "content": "SELECT 1", "position": 1},
+				{"id": "cell-1", "cell_type": "markdown", "name": "intro", "role": "markdown", "content": "# Intro", "position": 0},
+				{"id": "cell-2", "cell_type": "sql", "name": "published_output", "role": "output", "content": "SELECT 1", "position": 1},
+			},
+			"publish_model": map[string]interface{}{
+				"project_name":    "analytics",
+				"name":            "fct_revenue",
+				"materialization": "VIEW",
+				"output_cell_id":  "cell-2",
 			},
 		}
 		_ = json.NewEncoder(w).Encode(resp)
@@ -2216,7 +2232,14 @@ func TestReadState_Notebooks(t *testing.T) {
 	assert.Equal(t, "alice", state.Notebooks[0].Spec.Owner)
 	require.Len(t, state.Notebooks[0].Spec.Cells, 2)
 	assert.Equal(t, "markdown", state.Notebooks[0].Spec.Cells[0].Type)
+	assert.Equal(t, "intro", state.Notebooks[0].Spec.Cells[0].Name)
+	assert.Equal(t, "published_output", state.Notebooks[0].Spec.Cells[1].Name)
+	assert.Equal(t, "output", state.Notebooks[0].Spec.Cells[1].Role)
 	assert.Equal(t, "SELECT 1", state.Notebooks[0].Spec.Cells[1].Content)
+	require.NotNil(t, state.Notebooks[0].Spec.Publish)
+	require.NotNil(t, state.Notebooks[0].Spec.Publish.Model)
+	assert.Equal(t, "analytics", state.Notebooks[0].Spec.Publish.Model.Project)
+	assert.Equal(t, "published_output", state.Notebooks[0].Spec.Publish.Model.OutputCell)
 }
 
 func TestReadState_APIKeys(t *testing.T) {
@@ -2666,7 +2689,7 @@ func TestExecuteGroup_Delete(t *testing.T) {
 	t.Parallel()
 
 	var captured []execCapture
-	sc := newTestExecuteClient(t, &captured)
+	sc := withTestIndex(newTestExecuteClient(t, &captured))
 
 	action := declarative.Action{
 		Operation:    declarative.OpDelete,
@@ -2680,7 +2703,7 @@ func TestExecuteGroup_Delete(t *testing.T) {
 
 	req := captured[0]
 	assert.Equal(t, http.MethodDelete, req.Method)
-	assert.Contains(t, req.Path, "/groups/analysts")
+	assert.Contains(t, req.Path, "/groups/group-id-analysts")
 }
 
 func TestExecuteTable_Create(t *testing.T) {


### PR DESCRIPTION
## Summary
This PR closes the `notebooks-declarative` execution track from [#361](https://github.com/Yacobolo/ducklake-dataplatform/issues/361).

It fixes notebook CRUD/execution correctness and the declarative export/apply bugs that were leaving notebook or security state inconsistent.

## Issues Fixed
- #321 Creating a SQL notebook no longer seeds an invalid default cell
- #320 Notebook insertion now keeps cell positions deterministic and unique
- #338 Notebook cell deletion is transactional, normalizes positions, and returns validation errors for published output cells
- #340 Async notebook jobs now fail consistently when executed cells fail
- #339 Declarative notebook reconciliation no longer blindly deletes all cells before reapplying state
- #330 `duck export` now emits self-consistent notebook/model and storage credential config
- #334 Declarative apply now revokes grants through the correct grant-id delete path
- #360 Declarative apply now deletes groups using UUIDs instead of names

## Verification
- `go test ./internal/service/notebook ./internal/db/repository ./internal/api ./pkg/cli`
- `task test:integration`
- `task check`

## Progress Checklist
- [x] #321 fixed and covered by tests
- [x] #320 fixed and covered by tests
- [x] #338 fixed and covered by tests
- [x] #340 fixed and covered by tests
- [x] #339 fixed and covered by tests
- [x] #330 fixed and covered by tests
- [x] #334 fixed and covered by tests
- [x] #360 fixed and covered by tests
