### PR TITLE
fix: normalize s3 endpoint handling in presigner

### DIFF
--- a/internal/service/query/presigner.go
+++ b/internal/service/query/presigner.go
@@ -40,7 +40,10 @@ func NewS3Presigner(cfg *config.Config) (*S3Presigner, error) {
 		return nil, fmt.Errorf("S3 config is incomplete")
 	}
 
-	endpoint := fmt.Sprintf("https://%s", *cfg.S3Endpoint)
+	endpoint, err := normalizeS3Endpoint(*cfg.S3Endpoint)
+	if err != nil {
+		return nil, err
+	}
 
 	s3Client := s3.New(s3.Options{
 		Region: *cfg.S3Region,
@@ -111,7 +114,10 @@ func NewS3PresignerFromCredential(cred *domain.StorageCredential, bucket string)
 		return nil, fmt.Errorf("credential is nil")
 	}
 
-	endpoint := fmt.Sprintf("https://%s", cred.Endpoint)
+	endpoint, err := normalizeS3Endpoint(cred.Endpoint)
+	if err != nil {
+		return nil, err
+	}
 	usePathStyle := cred.URLStyle != "vhost"
 
 	s3Client := s3.New(s3.Options{
@@ -127,6 +133,29 @@ func NewS3PresignerFromCredential(cred *domain.StorageCredential, bucket string)
 		presignClient: s3.NewPresignClient(s3Client),
 		bucket:        bucket,
 	}, nil
+}
+
+func normalizeS3Endpoint(endpoint string) (string, error) {
+	trimmed := strings.TrimSpace(endpoint)
+	if trimmed == "" {
+		return "", fmt.Errorf("S3 endpoint is required")
+	}
+
+	if !strings.Contains(trimmed, "://") {
+		return "https://" + strings.TrimRight(trimmed, "/"), nil
+	}
+
+	parsed, err := url.Parse(trimmed)
+	if err != nil {
+		return "", fmt.Errorf("parse S3 endpoint %q: %w", endpoint, err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return "", fmt.Errorf("unsupported S3 endpoint scheme %q", parsed.Scheme)
+	}
+	if parsed.Host == "" {
+		return "", fmt.Errorf("S3 endpoint %q must include a host", endpoint)
+	}
+	return strings.TrimRight(parsed.String(), "/"), nil
 }
 
 // ParseS3Path extracts bucket and key from an "s3://bucket/path/to/file" URI.

--- a/internal/service/query/presigner_test.go
+++ b/internal/service/query/presigner_test.go
@@ -9,6 +9,54 @@ import (
 	"duck-demo/internal/domain"
 )
 
+func TestNormalizeS3Endpoint(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		want     string
+		wantErr  string
+	}{
+		{
+			name:  "adds_https_to_bare_host",
+			input: "s3.example.com",
+			want:  "https://s3.example.com",
+		},
+		{
+			name:  "preserves_http_scheme",
+			input: "http://127.0.0.1:9000",
+			want:  "http://127.0.0.1:9000",
+		},
+		{
+			name:  "trims_trailing_slash",
+			input: "https://s3.example.com/",
+			want:  "https://s3.example.com",
+		},
+		{
+			name:    "rejects_unsupported_scheme",
+			input:   "ftp://s3.example.com",
+			wantErr: "unsupported S3 endpoint scheme",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := normalizeS3Endpoint(tt.input)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestParseS3Path(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -155,6 +203,22 @@ func TestParseGCSPath(t *testing.T) {
 			assert.Equal(t, tt.wantKey, key)
 		})
 	}
+}
+
+func TestNewS3PresignerFromCredential_AllowsSchemeInEndpoint(t *testing.T) {
+	t.Parallel()
+
+	presigner, err := NewS3PresignerFromCredential(&domain.StorageCredential{
+		CredentialType: domain.CredentialTypeS3,
+		KeyID:          "AKID",
+		Secret:         "secret",
+		Endpoint:       "http://127.0.0.1:9000",
+		Region:         "us-east-1",
+		URLStyle:       "path",
+	}, "demo-bucket")
+	require.NoError(t, err)
+	require.NotNil(t, presigner)
+	assert.Equal(t, "demo-bucket", presigner.Bucket())
 }
 
 // === Factory dispatch: NewPresignerFromCredential ===


### PR DESCRIPTION
## Summary
- sync the tracking branch with current `main`
- fix S3 endpoint normalization so explicit `http://` / `https://` endpoints do not become double-prefixed in presigned URLs
- add regression coverage for endpoint normalization and presigner construction from stored credentials

## Scope
This PR now reflects the live, still-reproducible bug from the original init-bootstrap track:
- #331 `init apply` double-prefixes storage endpoint schemes and generates invalid presigned URLs

The other original issues in the draft description were tied to the older showcase bootstrap / `init destroy` flow. After syncing this branch to current `main`, that flow is no longer present in [`pkg/cli/init_cmd.go`](/Users/yacobolo/.codex/worktrees/441a/main/pkg/cli/init_cmd.go), so they need re-triage against the current sample-data/bootstrap implementation instead of staying attached to this PR.

## Verification
- `go test ./internal/service/query/...`

## Notes
- `go test ./internal/sampledata/...` is currently blocked by an existing generated-code problem in `internal/db/dbstore` on this branch after sync (`Queries` / `Principal` symbols missing in `principals.sql.go`).
