### PR TITLE
docs: improve OpenAPI contract metadata

### DIFF
--- a/api/gen/openapi.yaml
+++ b/api/gen/openapi.yaml
@@ -1,14 +1,44 @@
 openapi: 3.0.0
 info:
   title: Duck Data Platform API
-  description: Secure SQL query layer over DuckDB with RBAC, row-level security, and column masking, backed by SQLite metadata.
-  version: 0.0.0
+  version: 0.1.0
+  description: Duck Data Platform exposes a secure SQL query layer over DuckDB together with metadata management, RBAC, row-level security, column masking, lineage, orchestration, and semantic modeling APIs backed by SQLite metadata.
 tags:
-  - name: Duck
+  - name: Semantic Layer
+    description: Semantic models, metrics, relationships, and metric query execution.
+  - name: Models
+    description: Model, macro, and model run management for transformation workflows.
+  - name: Pipelines
+    description: Pipeline definitions, jobs, runs, and orchestration controls.
+  - name: Integrations
+    description: Git repository and external integration lifecycle operations.
+  - name: Notebooks
+    description: Notebook authoring, sessions, cells, and job execution endpoints.
+  - name: Compute
+    description: Compute endpoint lifecycle, assignments, and health checks.
+  - name: Storage
+    description: Storage credentials and external location configuration for object storage access.
+  - name: Lineage
+    description: Table and column lineage inspection together with lineage maintenance operations.
+  - name: Queries
+    description: Synchronous and asynchronous SQL query execution, search, and query history endpoints.
+  - name: Assets
+    description: Data asset definitions, runs, checks, partitions, and materialization workflows.
+  - name: Catalogs
+    description: Catalog, schema, table, view, volume, and ingestion management APIs.
+  - name: Governance
+    description: Privileges, tags, classifications, row filters, and column masking controls.
+  - name: Identity
+    description: Principals, groups, and API key management for authenticated access.
+  - name: Auth
+    description: Authentication bootstrap, login, OIDC configuration, and web session administration.
+  - name: Health
+    description: Operational readiness and service health endpoints.
 paths:
   /api-keys:
     get:
       operationId: listAPIKeys
+      summary: List API keys
       parameters:
         - name: principal_id
           in: query
@@ -55,9 +85,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Identity
     post:
       operationId: createAPIKey
+      summary: Create API key
       parameters: []
       responses:
         '201':
@@ -91,7 +122,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Identity
       requestBody:
         required: true
         content:
@@ -101,6 +132,7 @@ paths:
   /api-keys/cleanup:
     post:
       operationId: cleanupExpiredAPIKeys
+      summary: Clean up expired API keys
       parameters: []
       responses:
         '200':
@@ -134,10 +166,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Identity
   /api-keys/{apiKeyId}:
     delete:
       operationId: deleteAPIKey
+      summary: Delete API key
       parameters:
         - name: apiKeyId
           in: path
@@ -172,10 +205,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Identity
   /assets:
     get:
       operationId: listAssets
+      summary: List assets
       parameters:
         - name: max_results
           in: query
@@ -216,9 +250,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Assets
     post:
       operationId: createAsset
+      summary: Create asset
+      description: Creates a managed asset definition together with its ownership, checks, tags, and upstream lineage metadata.
       parameters: []
       responses:
         '201':
@@ -258,7 +294,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Assets
       requestBody:
         required: true
         content:
@@ -274,6 +310,7 @@ paths:
   /assets/{assetKey}:
     get:
       operationId: getAsset
+      summary: Get asset
       parameters:
         - name: assetKey
           in: path
@@ -318,9 +355,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Assets
     put:
       operationId: updateAsset
+      summary: Update asset
       parameters:
         - name: assetKey
           in: path
@@ -365,7 +403,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Assets
       requestBody:
         required: true
         content:
@@ -380,6 +418,7 @@ paths:
             securable_id_source: catalog_sentinel
     delete:
       operationId: deleteAsset
+      summary: Delete asset
       parameters:
         - name: assetKey
           in: path
@@ -420,7 +459,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Assets
       x-authz:
         mode: privilege
         checks:
@@ -430,6 +469,7 @@ paths:
   /assets/{assetKey}/backfills:
     get:
       operationId: listAssetBackfills
+      summary: List asset backfills
       parameters:
         - name: assetKey
           in: path
@@ -493,9 +533,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Assets
     post:
       operationId: createAssetBackfill
+      summary: Create asset backfill
       parameters:
         - name: assetKey
           in: path
@@ -540,7 +581,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Assets
       requestBody:
         required: true
         content:
@@ -556,6 +597,7 @@ paths:
   /assets/{assetKey}/backfills/{backfillId}:
     get:
       operationId: getAssetBackfill
+      summary: Get asset backfill
       parameters:
         - name: assetKey
           in: path
@@ -605,10 +647,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Assets
   /assets/{assetKey}/check-results:
     get:
       operationId: listAssetCheckResults
+      summary: List asset check results
       parameters:
         - name: assetKey
           in: path
@@ -666,10 +709,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Assets
   /assets/{assetKey}/checks:
     get:
       operationId: listAssetChecks
+      summary: List asset checks
       parameters:
         - name: assetKey
           in: path
@@ -714,10 +758,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Assets
   /assets/{assetKey}/graph:
     get:
       operationId: getAssetGraph
+      summary: Get asset graph
       parameters:
         - name: assetKey
           in: path
@@ -762,10 +807,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Assets
   /assets/{assetKey}/materializations:
     get:
       operationId: listAssetMaterializations
+      summary: List asset materializations
       parameters:
         - name: assetKey
           in: path
@@ -823,10 +869,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Assets
   /assets/{assetKey}/materialize:
     post:
       operationId: triggerAssetMaterialization
+      summary: Trigger asset materialization
+      description: Starts a materialization run for the specified asset and returns the queued execution metadata.
       parameters:
         - name: assetKey
           in: path
@@ -871,7 +919,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Assets
       requestBody:
         required: false
         content:
@@ -887,6 +935,7 @@ paths:
   /assets/{assetKey}/partitions:
     get:
       operationId: listAssetPartitions
+      summary: List asset partitions
       parameters:
         - name: assetKey
           in: path
@@ -944,10 +993,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Assets
   /assets/{assetKey}/runs:
     get:
       operationId: listAssetRuns
+      summary: List asset runs
       parameters:
         - name: assetKey
           in: path
@@ -1011,10 +1061,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Assets
   /audit-logs:
     get:
       operationId: listAuditLogs
+      summary: List audit logs
       parameters:
         - name: principal_name
           in: query
@@ -1073,10 +1124,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Queries
   /auth/bootstrap/complete:
     post:
       operationId: bootstrapComplete
+      summary: Bootstrap complete
       parameters: []
       responses:
         '201':
@@ -1122,7 +1174,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Auth
       requestBody:
         required: true
         content:
@@ -1137,6 +1189,7 @@ paths:
   /auth/bootstrap/tokens:
     post:
       operationId: createBootstrapToken
+      summary: Create bootstrap token
       parameters: []
       responses:
         '201':
@@ -1176,7 +1229,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Auth
       requestBody:
         required: true
         content:
@@ -1189,6 +1242,8 @@ paths:
   /auth/local/login:
     post:
       operationId: localLogin
+      summary: Local login
+      description: Authenticates a local user with username and password and returns a bearer token for subsequent API calls.
       parameters: []
       responses:
         '201':
@@ -1228,7 +1283,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Auth
       requestBody:
         required: true
         content:
@@ -1243,6 +1298,7 @@ paths:
   /auth/provider/oidc:
     get:
       operationId: getOIDCProvider
+      summary: Get OIDC provider
       parameters: []
       responses:
         '200':
@@ -1276,12 +1332,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Auth
       x-authz:
         mode: admin_only
       x-apigen-manual: true
     put:
       operationId: upsertOIDCProvider
+      summary: Upsert OIDC provider
       parameters: []
       responses:
         '204':
@@ -1317,7 +1374,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Auth
       requestBody:
         required: true
         content:
@@ -1330,6 +1387,7 @@ paths:
   /auth/sessions/revoke-all:
     post:
       operationId: revokeAllWebSessions
+      summary: Revoke all web sessions
       parameters: []
       responses:
         '204':
@@ -1371,7 +1429,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Auth
       requestBody:
         required: true
         content:
@@ -1384,6 +1442,7 @@ paths:
   /auth/sessions/stats:
     get:
       operationId: getWebSessionStats
+      summary: Get web session stats
       parameters: []
       responses:
         '200':
@@ -1423,13 +1482,14 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Auth
       x-authz:
         mode: admin_only
       x-apigen-manual: true
   /catalogs:
     post:
       operationId: registerCatalog
+      summary: Register catalog
       parameters: []
       responses:
         '201':
@@ -1463,7 +1523,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Catalogs
       requestBody:
         required: true
         content:
@@ -1472,6 +1532,8 @@ paths:
               $ref: '#/components/schemas/CreateCatalogRequest'
     get:
       operationId: listCatalogs
+      summary: List catalogs
+      description: Lists registered catalogs and returns a paginated catalog registration view for management clients.
       parameters:
         - name: max_results
           in: query
@@ -1512,10 +1574,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Catalogs
   /catalogs/{catalogName}:
     get:
       operationId: getCatalogRegistration
+      summary: Get catalog registration
       parameters:
         - name: catalogName
           in: path
@@ -1560,9 +1623,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Catalogs
     patch:
       operationId: updateCatalogRegistration
+      summary: Update catalog registration
       parameters:
         - name: catalogName
           in: path
@@ -1601,7 +1665,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Catalogs
       requestBody:
         required: true
         content:
@@ -1610,6 +1674,7 @@ paths:
               $ref: '#/components/schemas/UpdateCatalogRegistrationRequest'
     delete:
       operationId: deleteCatalogRegistration
+      summary: Delete catalog registration
       parameters:
         - name: catalogName
           in: path
@@ -1644,10 +1709,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Catalogs
   /catalogs/{catalogName}/history:
     get:
       operationId: listCatalogHistory
+      summary: List catalog history
       parameters:
         - name: catalogName
           in: path
@@ -1717,10 +1783,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Catalogs
   /catalogs/{catalogName}/info:
     get:
       operationId: getCatalog
+      summary: Get catalog
+      description: Returns runtime catalog information, including metastore details and status for the named catalog.
       parameters:
         - name: catalogName
           in: path
@@ -1765,10 +1833,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Catalogs
   /catalogs/{catalogName}/metastore/summary:
     get:
       operationId: getMetastoreSummary
+      summary: Get metastore summary
       parameters:
         - name: catalogName
           in: path
@@ -1813,10 +1882,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Catalogs
   /catalogs/{catalogName}/schemas:
     get:
       operationId: listSchemas
+      summary: List schemas
       parameters:
         - name: catalogName
           in: path
@@ -1874,9 +1944,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Catalogs
     post:
       operationId: createSchema
+      summary: Create schema
       parameters:
         - name: catalogName
           in: path
@@ -1915,7 +1986,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Catalogs
       requestBody:
         required: true
         content:
@@ -1931,6 +2002,7 @@ paths:
   /catalogs/{catalogName}/schemas/{schemaName}:
     get:
       operationId: getSchema
+      summary: Get schema
       parameters:
         - name: catalogName
           in: path
@@ -1980,9 +2052,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Catalogs
     patch:
       operationId: updateSchema
+      summary: Update schema
       parameters:
         - name: catalogName
           in: path
@@ -2026,7 +2099,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Catalogs
       requestBody:
         required: true
         content:
@@ -2041,6 +2114,7 @@ paths:
             securable_id_source: runtime_resolved_object_id
     delete:
       operationId: deleteSchema
+      summary: Delete schema
       parameters:
         - name: catalogName
           in: path
@@ -2086,7 +2160,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Catalogs
       x-authz:
         mode: privilege
         checks:
@@ -2096,6 +2170,7 @@ paths:
   /catalogs/{catalogName}/schemas/{schemaName}/tables:
     get:
       operationId: listTables
+      summary: List tables
       parameters:
         - name: catalogName
           in: path
@@ -2158,9 +2233,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Catalogs
     post:
       operationId: createTable
+      summary: Create table
       parameters:
         - name: catalogName
           in: path
@@ -2204,7 +2280,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Catalogs
       requestBody:
         required: true
         content:
@@ -2220,6 +2296,7 @@ paths:
   /catalogs/{catalogName}/schemas/{schemaName}/tables/{tableName}:
     get:
       operationId: getTable
+      summary: Get table
       parameters:
         - name: catalogName
           in: path
@@ -2274,9 +2351,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Catalogs
     patch:
       operationId: updateTable
+      summary: Update table
       parameters:
         - name: catalogName
           in: path
@@ -2325,7 +2403,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Catalogs
       requestBody:
         required: true
         content:
@@ -2340,6 +2418,7 @@ paths:
             securable_id_source: runtime_resolved_object_id
     delete:
       operationId: deleteTable
+      summary: Delete table
       parameters:
         - name: catalogName
           in: path
@@ -2384,7 +2463,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Catalogs
       x-authz:
         mode: privilege
         checks:
@@ -2394,6 +2473,7 @@ paths:
   /catalogs/{catalogName}/schemas/{schemaName}/tables/{tableName}/columns:
     get:
       operationId: listTableColumns
+      summary: List table columns
       parameters:
         - name: catalogName
           in: path
@@ -2461,10 +2541,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Catalogs
   /catalogs/{catalogName}/schemas/{schemaName}/tables/{tableName}/columns/{columnName}:
     patch:
       operationId: updateColumn
+      summary: Update column
       parameters:
         - name: catalogName
           in: path
@@ -2518,7 +2599,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Catalogs
       requestBody:
         required: true
         content:
@@ -2534,6 +2615,7 @@ paths:
   /catalogs/{catalogName}/schemas/{schemaName}/tables/{tableName}/ingestion/commit:
     post:
       operationId: commitTableIngestion
+      summary: Commit table ingestion
       parameters:
         - name: catalogName
           in: path
@@ -2582,7 +2664,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Catalogs
       requestBody:
         required: true
         content:
@@ -2598,6 +2680,7 @@ paths:
   /catalogs/{catalogName}/schemas/{schemaName}/tables/{tableName}/ingestion/load:
     post:
       operationId: loadTableExternalFiles
+      summary: Load table external files
       parameters:
         - name: catalogName
           in: path
@@ -2646,7 +2729,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Catalogs
       requestBody:
         required: true
         content:
@@ -2662,6 +2745,7 @@ paths:
   /catalogs/{catalogName}/schemas/{schemaName}/tables/{tableName}/ingestion/upload-url:
     post:
       operationId: createUploadUrl
+      summary: Create upload URL
       parameters:
         - name: catalogName
           in: path
@@ -2710,7 +2794,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Catalogs
       requestBody:
         required: true
         content:
@@ -2726,6 +2810,7 @@ paths:
   /catalogs/{catalogName}/schemas/{schemaName}/tables/{tableName}/profile:
     post:
       operationId: profileTable
+      summary: Profile table
       parameters:
         - name: catalogName
           in: path
@@ -2774,10 +2859,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Catalogs
   /catalogs/{catalogName}/schemas/{schemaName}/views:
     get:
       operationId: listViews
+      summary: List views
       parameters:
         - name: catalogName
           in: path
@@ -2840,9 +2926,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Catalogs
     post:
       operationId: createView
+      summary: Create view
       parameters:
         - name: catalogName
           in: path
@@ -2886,7 +2973,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Catalogs
       requestBody:
         required: true
         content:
@@ -2902,6 +2989,7 @@ paths:
   /catalogs/{catalogName}/schemas/{schemaName}/views/{viewName}:
     get:
       operationId: getView
+      summary: Get view
       parameters:
         - name: catalogName
           in: path
@@ -2956,9 +3044,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Catalogs
     patch:
       operationId: updateView
+      summary: Update view
       parameters:
         - name: catalogName
           in: path
@@ -3007,7 +3096,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Catalogs
       requestBody:
         required: true
         content:
@@ -3022,6 +3111,7 @@ paths:
             securable_id_source: runtime_resolved_object_id
     delete:
       operationId: deleteView
+      summary: Delete view
       parameters:
         - name: catalogName
           in: path
@@ -3066,7 +3156,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Catalogs
       x-authz:
         mode: privilege
         checks:
@@ -3076,6 +3166,7 @@ paths:
   /catalogs/{catalogName}/schemas/{schemaName}/volumes:
     get:
       operationId: listVolumes
+      summary: List volumes
       parameters:
         - name: catalogName
           in: path
@@ -3138,9 +3229,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Catalogs
     post:
       operationId: createVolume
+      summary: Create volume
       parameters:
         - name: catalogName
           in: path
@@ -3184,7 +3276,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Catalogs
       requestBody:
         required: true
         content:
@@ -3200,6 +3292,7 @@ paths:
   /catalogs/{catalogName}/schemas/{schemaName}/volumes/{volumeName}:
     get:
       operationId: getVolume
+      summary: Get volume
       parameters:
         - name: catalogName
           in: path
@@ -3254,9 +3347,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Catalogs
     patch:
       operationId: updateVolume
+      summary: Update volume
       parameters:
         - name: catalogName
           in: path
@@ -3305,7 +3399,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Catalogs
       requestBody:
         required: true
         content:
@@ -3320,6 +3414,7 @@ paths:
             securable_id_source: runtime_resolved_object_id
     delete:
       operationId: deleteVolume
+      summary: Delete volume
       parameters:
         - name: catalogName
           in: path
@@ -3364,7 +3459,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Catalogs
       x-authz:
         mode: privilege
         checks:
@@ -3374,6 +3469,7 @@ paths:
   /catalogs/{catalogName}/set-default:
     post:
       operationId: setDefaultCatalog
+      summary: Set default catalog
       parameters:
         - name: catalogName
           in: path
@@ -3412,7 +3508,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Catalogs
       requestBody:
         required: true
         content:
@@ -3422,6 +3518,7 @@ paths:
   /catalogs/{catalogName}/version-summary:
     get:
       operationId: getCatalogVersionSummary
+      summary: Get catalog version summary
       parameters:
         - name: catalogName
           in: path
@@ -3466,10 +3563,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Catalogs
   /classifications:
     get:
       operationId: listClassifications
+      summary: List classifications
       parameters:
         - name: max_results
           in: query
@@ -3510,10 +3608,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Governance
   /column-masks/{columnMaskId}:
     delete:
       operationId: deleteColumnMask
+      summary: Delete column mask
       parameters:
         - name: columnMaskId
           in: path
@@ -3548,10 +3647,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Governance
   /column-masks/{columnMaskId}/bindings:
     get:
       operationId: listColumnMaskBindings
+      summary: List column mask bindings
       parameters:
         - name: columnMaskId
           in: path
@@ -3609,9 +3709,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Governance
     post:
       operationId: bindColumnMask
+      summary: Bind column mask
       parameters:
         - name: columnMaskId
           in: path
@@ -3646,7 +3747,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Governance
       requestBody:
         required: true
         content:
@@ -3655,6 +3756,7 @@ paths:
               $ref: '#/components/schemas/ColumnMaskBindingRequest'
     delete:
       operationId: unbindColumnMask
+      summary: Unbind column mask
       parameters:
         - name: columnMaskId
           in: path
@@ -3701,10 +3803,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Governance
   /compute-endpoints:
     get:
       operationId: listComputeEndpoints
+      summary: List compute endpoints
       parameters:
         - name: max_results
           in: query
@@ -3745,9 +3848,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Compute
     post:
       operationId: createComputeEndpoint
+      summary: Create compute endpoint
+      description: Registers a compute endpoint that can execute remote workloads and accept assignment-based routing.
       parameters: []
       responses:
         '201':
@@ -3781,7 +3886,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Compute
       requestBody:
         required: true
         content:
@@ -3797,6 +3902,7 @@ paths:
   /compute-endpoints/{endpointName}:
     get:
       operationId: getComputeEndpoint
+      summary: Get compute endpoint
       parameters:
         - name: endpointName
           in: path
@@ -3841,9 +3947,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Compute
     patch:
       operationId: updateComputeEndpoint
+      summary: Update compute endpoint
       parameters:
         - name: endpointName
           in: path
@@ -3882,7 +3989,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Compute
       requestBody:
         required: true
         content:
@@ -3897,6 +4004,7 @@ paths:
             securable_id_source: runtime_resolved_object_id
     delete:
       operationId: deleteComputeEndpoint
+      summary: Delete compute endpoint
       parameters:
         - name: endpointName
           in: path
@@ -3931,7 +4039,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Compute
       x-authz:
         mode: privilege
         checks:
@@ -3941,6 +4049,7 @@ paths:
   /compute-endpoints/{endpointName}/assignments:
     get:
       operationId: listComputeAssignments
+      summary: List compute assignments
       parameters:
         - name: endpointName
           in: path
@@ -3998,9 +4107,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Compute
     post:
       operationId: createComputeAssignment
+      summary: Create compute assignment
       parameters:
         - name: endpointName
           in: path
@@ -4039,7 +4149,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Compute
       requestBody:
         required: true
         content:
@@ -4055,6 +4165,7 @@ paths:
   /compute-endpoints/{endpointName}/assignments/{assignmentId}:
     delete:
       operationId: deleteComputeAssignment
+      summary: Delete compute assignment
       parameters:
         - name: endpointName
           in: path
@@ -4094,7 +4205,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Compute
       x-authz:
         mode: privilege
         checks:
@@ -4104,6 +4215,7 @@ paths:
   /compute-endpoints/{endpointName}/health:
     get:
       operationId: getComputeEndpointHealth
+      summary: Get compute endpoint health
       parameters:
         - name: endpointName
           in: path
@@ -4160,10 +4272,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Compute
   /external-locations:
     get:
       operationId: listExternalLocations
+      summary: List external locations
       parameters:
         - name: max_results
           in: query
@@ -4204,9 +4317,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Storage
     post:
       operationId: createExternalLocation
+      summary: Create external location
       description: Creates a new external location and configures DuckDB with the associated credential. Catalog registrations are managed separately; creating a location does not attach or create a DuckLake catalog.
       parameters: []
       responses:
@@ -4241,7 +4355,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Storage
       requestBody:
         required: true
         content:
@@ -4257,6 +4371,7 @@ paths:
   /external-locations/{locationName}:
     get:
       operationId: getExternalLocation
+      summary: Get external location
       parameters:
         - name: locationName
           in: path
@@ -4301,9 +4416,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Storage
     patch:
       operationId: updateExternalLocation
+      summary: Update external location
       parameters:
         - name: locationName
           in: path
@@ -4342,7 +4458,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Storage
       requestBody:
         required: true
         content:
@@ -4357,6 +4473,7 @@ paths:
             securable_id_source: runtime_resolved_object_id
     delete:
       operationId: deleteExternalLocation
+      summary: Delete external location
       parameters:
         - name: locationName
           in: path
@@ -4391,7 +4508,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Storage
       x-authz:
         mode: privilege
         checks:
@@ -4401,6 +4518,7 @@ paths:
   /git-repos:
     get:
       operationId: listGitRepos
+      summary: List git repos
       parameters:
         - name: max_results
           in: query
@@ -4441,9 +4559,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Integrations
     post:
       operationId: createGitRepo
+      summary: Create git repo
       parameters: []
       responses:
         '201':
@@ -4477,7 +4596,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Integrations
       requestBody:
         required: true
         content:
@@ -4487,6 +4606,7 @@ paths:
   /git-repos/{gitRepoId}:
     get:
       operationId: getGitRepo
+      summary: Get git repo
       parameters:
         - name: gitRepoId
           in: path
@@ -4531,9 +4651,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Integrations
     delete:
       operationId: deleteGitRepo
+      summary: Delete git repo
       parameters:
         - name: gitRepoId
           in: path
@@ -4568,10 +4689,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Integrations
   /git-repos/{gitRepoId}/sync:
     post:
       operationId: syncGitRepo
+      summary: Sync git repo
       parameters:
         - name: gitRepoId
           in: path
@@ -4610,10 +4732,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Integrations
   /grants:
     get:
       operationId: listGrants
+      summary: List grants
       parameters:
         - name: principal_id
           in: query
@@ -4678,9 +4801,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Governance
     post:
       operationId: createGrant
+      summary: Create grant
       parameters: []
       responses:
         '201':
@@ -4714,7 +4838,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Governance
       requestBody:
         required: true
         content:
@@ -4726,6 +4850,7 @@ paths:
   /grants/{grantId}:
     delete:
       operationId: deleteGrant
+      summary: Delete grant
       parameters:
         - name: grantId
           in: path
@@ -4760,12 +4885,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Governance
       x-authz:
         mode: admin_only
   /groups:
     get:
       operationId: listGroups
+      summary: List groups
       parameters:
         - name: max_results
           in: query
@@ -4806,9 +4932,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Identity
     post:
       operationId: createGroup
+      summary: Create group
       parameters: []
       responses:
         '201':
@@ -4842,7 +4969,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Identity
       requestBody:
         required: true
         content:
@@ -4852,6 +4979,7 @@ paths:
   /groups/{groupId}:
     get:
       operationId: getGroup
+      summary: Get group
       parameters:
         - name: groupId
           in: path
@@ -4896,9 +5024,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Identity
     delete:
       operationId: deleteGroup
+      summary: Delete group
       parameters:
         - name: groupId
           in: path
@@ -4933,10 +5062,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Identity
   /groups/{groupId}/members:
     get:
       operationId: listGroupMembers
+      summary: List group members
       parameters:
         - name: groupId
           in: path
@@ -4994,9 +5124,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Identity
     post:
       operationId: createGroupMember
+      summary: Create group member
       parameters:
         - name: groupId
           in: path
@@ -5031,7 +5162,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Identity
       requestBody:
         required: true
         content:
@@ -5040,6 +5171,7 @@ paths:
               $ref: '#/components/schemas/CreateGroupMemberRequest'
     delete:
       operationId: deleteGroupMember
+      summary: Delete group member
       parameters:
         - name: groupId
           in: path
@@ -5086,10 +5218,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Identity
   /healthz:
     get:
       operationId: getHealth
+      summary: Get health
       parameters: []
       responses:
         '200':
@@ -5117,10 +5250,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Health
+      security:
+        - {}
   /lineage/columns/{schemaName}/{tableName}:
     get:
       operationId: getColumnLineage
+      summary: Get column lineage
       parameters:
         - name: schemaName
           in: path
@@ -5183,10 +5319,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Lineage
   /lineage/columns/{schemaName}/{tableName}/{columnName}/impact:
     get:
       operationId: getColumnImpact
+      summary: Get column impact
       parameters:
         - name: schemaName
           in: path
@@ -5254,10 +5391,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Lineage
   /lineage/edges/{edgeId}:
     delete:
       operationId: deleteLineageEdge
+      summary: Delete lineage edge
       parameters:
         - name: edgeId
           in: path
@@ -5292,10 +5430,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Lineage
   /lineage/purge:
     post:
       operationId: purgeLineage
+      summary: Purge lineage
       parameters: []
       responses:
         '200':
@@ -5329,7 +5468,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Lineage
       requestBody:
         required: true
         content:
@@ -5339,6 +5478,7 @@ paths:
   /lineage/tables/{schemaName}/{tableName}:
     get:
       operationId: getTableLineage
+      summary: Get table lineage
       parameters:
         - name: schemaName
           in: path
@@ -5401,10 +5541,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Lineage
   /lineage/tables/{schemaName}/{tableName}/downstream:
     get:
       operationId: getDownstreamLineage
+      summary: Get downstream lineage
       parameters:
         - name: schemaName
           in: path
@@ -5467,10 +5608,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Lineage
   /lineage/tables/{schemaName}/{tableName}/upstream:
     get:
       operationId: getUpstreamLineage
+      summary: Get upstream lineage
       parameters:
         - name: schemaName
           in: path
@@ -5533,10 +5675,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Lineage
   /macros:
     get:
       operationId: listMacros
+      summary: List macros
       parameters:
         - name: max_results
           in: query
@@ -5577,9 +5720,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Models
     post:
       operationId: createMacro
+      summary: Create macro
       parameters: []
       responses:
         '201':
@@ -5613,7 +5757,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Models
       requestBody:
         required: true
         content:
@@ -5623,6 +5767,7 @@ paths:
   /macros/{macroName}:
     get:
       operationId: getMacro
+      summary: Get macro
       parameters:
         - name: macroName
           in: path
@@ -5667,9 +5812,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Models
     patch:
       operationId: updateMacro
+      summary: Update macro
       parameters:
         - name: macroName
           in: path
@@ -5708,7 +5854,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Models
       requestBody:
         required: true
         content:
@@ -5717,6 +5863,7 @@ paths:
               $ref: '#/components/schemas/UpdateMacroRequest'
     delete:
       operationId: deleteMacro
+      summary: Delete macro
       parameters:
         - name: macroName
           in: path
@@ -5751,10 +5898,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Models
   /macros/{macroName}/diff:
     get:
       operationId: diffMacroRevisions
+      summary: Diff macro revisions
       parameters:
         - name: macroName
           in: path
@@ -5813,10 +5961,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Models
   /macros/{macroName}/impact:
     get:
       operationId: getMacroImpact
+      summary: Get macro impact
       parameters:
         - name: macroName
           in: path
@@ -5874,10 +6023,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Models
   /macros/{macroName}/revisions:
     get:
       operationId: listMacroRevisions
+      summary: List macro revisions
       parameters:
         - name: macroName
           in: path
@@ -5922,10 +6072,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Models
   /manifest:
     post:
       operationId: createManifest
+      summary: Create manifest
       parameters: []
       responses:
         '200':
@@ -5959,7 +6110,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Catalogs
       requestBody:
         required: true
         content:
@@ -5969,6 +6120,7 @@ paths:
   /metric-queries:explain:
     post:
       operationId: explainMetricQuery
+      summary: Explain metric query
       parameters: []
       responses:
         '200':
@@ -6002,7 +6154,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Semantic Layer
       requestBody:
         required: true
         content:
@@ -6012,6 +6164,7 @@ paths:
   /metric-queries:run:
     post:
       operationId: runMetricQuery
+      summary: Run metric query
       parameters: []
       responses:
         '200':
@@ -6045,7 +6198,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Semantic Layer
       requestBody:
         required: true
         content:
@@ -6055,6 +6208,7 @@ paths:
   /metrics/{metricName}/freshness:
     get:
       operationId: checkMetricFreshness
+      summary: Check metric freshness
       parameters:
         - name: metricName
           in: path
@@ -6111,10 +6265,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Semantic Layer
   /model-runs:
     post:
       operationId: triggerModelRun
+      summary: Trigger model run
       parameters: []
       responses:
         '201':
@@ -6148,7 +6303,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Models
       requestBody:
         required: true
         content:
@@ -6157,6 +6312,7 @@ paths:
               $ref: '#/components/schemas/TriggerModelRunRequest'
     get:
       operationId: listModelRuns
+      summary: List model runs
       parameters:
         - name: status
           in: query
@@ -6203,10 +6359,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Models
   /model-runs/{runId}:
     get:
       operationId: getModelRun
+      summary: Get model run
       parameters:
         - name: runId
           in: path
@@ -6251,10 +6408,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Models
   /model-runs/{runId}/cancel:
     post:
       operationId: cancelModelRun
+      summary: Cancel model run
       parameters:
         - name: runId
           in: path
@@ -6293,10 +6451,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Models
   /model-runs/{runId}/steps:
     get:
       operationId: listModelRunSteps
+      summary: List model run steps
       parameters:
         - name: runId
           in: path
@@ -6341,10 +6500,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Models
   /model-runs/{runId}/steps/{stepId}/test-results:
     get:
       operationId: listModelTestResults
+      summary: List model test results
       parameters:
         - name: runId
           in: path
@@ -6394,10 +6554,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Models
   /models:
     get:
       operationId: listModels
+      summary: List models
       parameters:
         - name: project_name
           in: query
@@ -6444,9 +6605,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Models
     post:
       operationId: createModel
+      summary: Create model
       parameters: []
       responses:
         '201':
@@ -6480,7 +6642,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Models
       requestBody:
         required: true
         content:
@@ -6490,6 +6652,7 @@ paths:
   /models/dag:
     get:
       operationId: getModelDAG
+      summary: Get model DAG
       parameters:
         - name: project_name
           in: query
@@ -6523,10 +6686,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Models
   /models/from-notebook:
     post:
       operationId: promoteNotebookToModel
+      summary: Promote notebook to model
       parameters: []
       responses:
         '201':
@@ -6560,7 +6724,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Models
       requestBody:
         required: true
         content:
@@ -6570,6 +6734,7 @@ paths:
   /models/{projectName}/{modelName}:
     get:
       operationId: getModel
+      summary: Get model
       parameters:
         - name: projectName
           in: path
@@ -6619,9 +6784,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Models
     patch:
       operationId: updateModel
+      summary: Update model
       parameters:
         - name: projectName
           in: path
@@ -6665,7 +6831,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Models
       requestBody:
         required: true
         content:
@@ -6674,6 +6840,7 @@ paths:
               $ref: '#/components/schemas/UpdateModelRequest'
     delete:
       operationId: deleteModel
+      summary: Delete model
       parameters:
         - name: projectName
           in: path
@@ -6713,10 +6880,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Models
   /models/{projectName}/{modelName}/freshness:
     get:
       operationId: checkModelFreshness
+      summary: Check model freshness
       parameters:
         - name: projectName
           in: path
@@ -6766,10 +6934,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Models
   /models/{projectName}/{modelName}/tests:
     post:
       operationId: createModelTest
+      summary: Create model test
       parameters:
         - name: projectName
           in: path
@@ -6813,7 +6982,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Models
       requestBody:
         required: true
         content:
@@ -6822,6 +6991,7 @@ paths:
               $ref: '#/components/schemas/CreateModelTestRequest'
     get:
       operationId: listModelTests
+      summary: List model tests
       parameters:
         - name: projectName
           in: path
@@ -6871,10 +7041,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Models
   /models/{projectName}/{modelName}/tests/{testId}:
     delete:
       operationId: deleteModelTest
+      summary: Delete model test
       parameters:
         - name: projectName
           in: path
@@ -6919,10 +7090,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Models
   /notebooks:
     get:
       operationId: listNotebooks
+      summary: List notebooks
       parameters:
         - name: owner
           in: query
@@ -6969,9 +7141,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Notebooks
     post:
       operationId: createNotebook
+      summary: Create notebook
       parameters: []
       responses:
         '201':
@@ -7005,7 +7178,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Notebooks
       requestBody:
         required: true
         content:
@@ -7015,6 +7188,7 @@ paths:
   /notebooks/{notebookId}:
     get:
       operationId: getNotebook
+      summary: Get notebook
       parameters:
         - name: notebookId
           in: path
@@ -7059,9 +7233,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Notebooks
     patch:
       operationId: updateNotebook
+      summary: Update notebook
       parameters:
         - name: notebookId
           in: path
@@ -7100,7 +7275,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Notebooks
       requestBody:
         required: true
         content:
@@ -7109,6 +7284,7 @@ paths:
               $ref: '#/components/schemas/UpdateNotebookRequest'
     delete:
       operationId: deleteNotebook
+      summary: Delete notebook
       parameters:
         - name: notebookId
           in: path
@@ -7143,10 +7319,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Notebooks
   /notebooks/{notebookId}/cells:
     post:
       operationId: createCell
+      summary: Create cell
       parameters:
         - name: notebookId
           in: path
@@ -7185,7 +7362,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Notebooks
       requestBody:
         required: true
         content:
@@ -7195,6 +7372,7 @@ paths:
   /notebooks/{notebookId}/cells/reorder:
     post:
       operationId: reorderCells
+      summary: Reorder cells
       parameters:
         - name: notebookId
           in: path
@@ -7233,7 +7411,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Notebooks
       requestBody:
         required: true
         content:
@@ -7243,6 +7421,7 @@ paths:
   /notebooks/{notebookId}/cells/{cellId}:
     patch:
       operationId: updateCell
+      summary: Update cell
       parameters:
         - name: notebookId
           in: path
@@ -7286,7 +7465,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Notebooks
       requestBody:
         required: true
         content:
@@ -7295,6 +7474,7 @@ paths:
               $ref: '#/components/schemas/UpdateCellRequest'
     delete:
       operationId: deleteCell
+      summary: Delete cell
       parameters:
         - name: notebookId
           in: path
@@ -7334,10 +7514,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Notebooks
   /notebooks/{notebookId}/jobs:
     get:
       operationId: listNotebookJobs
+      summary: List notebook jobs
       parameters:
         - name: notebookId
           in: path
@@ -7395,10 +7576,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Notebooks
   /notebooks/{notebookId}/jobs/{jobId}:
     get:
       operationId: getNotebookJob
+      summary: Get notebook job
       parameters:
         - name: notebookId
           in: path
@@ -7448,10 +7630,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Notebooks
   /notebooks/{notebookId}/sessions:
     post:
       operationId: createNotebookSession
+      summary: Create notebook session
       parameters:
         - name: notebookId
           in: path
@@ -7490,10 +7673,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Notebooks
   /notebooks/{notebookId}/sessions/{sessionId}:
     delete:
       operationId: closeNotebookSession
+      summary: Close notebook session
       parameters:
         - name: notebookId
           in: path
@@ -7533,10 +7717,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Notebooks
   /notebooks/{notebookId}/sessions/{sessionId}/execute/{cellId}:
     post:
       operationId: executeCell
+      summary: Execute cell
       parameters:
         - name: notebookId
           in: path
@@ -7585,10 +7770,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Notebooks
   /notebooks/{notebookId}/sessions/{sessionId}/run-all:
     post:
       operationId: runAllCells
+      summary: Run all cells
       parameters:
         - name: notebookId
           in: path
@@ -7632,10 +7818,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Notebooks
   /notebooks/{notebookId}/sessions/{sessionId}/run-all-async:
     post:
       operationId: runAllCellsAsync
+      summary: Run all cells asynchronously
       parameters:
         - name: notebookId
           in: path
@@ -7679,10 +7866,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Notebooks
   /pipelines:
     get:
       operationId: listPipelines
+      summary: List pipelines
       parameters:
         - name: max_results
           in: query
@@ -7723,9 +7911,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Pipelines
     post:
       operationId: createPipeline
+      summary: Create pipeline
       parameters: []
       responses:
         '201':
@@ -7759,7 +7948,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Pipelines
       requestBody:
         required: true
         content:
@@ -7769,6 +7958,7 @@ paths:
   /pipelines/runs/{runId}:
     get:
       operationId: getPipelineRun
+      summary: Get pipeline run
       parameters:
         - name: runId
           in: path
@@ -7813,10 +8003,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Pipelines
   /pipelines/runs/{runId}/cancel:
     post:
       operationId: cancelPipelineRun
+      summary: Cancel pipeline run
       parameters:
         - name: runId
           in: path
@@ -7855,10 +8046,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Pipelines
   /pipelines/runs/{runId}/jobs:
     get:
       operationId: listPipelineJobRuns
+      summary: List pipeline job runs
       parameters:
         - name: runId
           in: path
@@ -7903,10 +8095,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Pipelines
   /pipelines/{pipelineName}:
     get:
       operationId: getPipeline
+      summary: Get pipeline
       parameters:
         - name: pipelineName
           in: path
@@ -7951,9 +8144,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Pipelines
     patch:
       operationId: updatePipeline
+      summary: Update pipeline
       parameters:
         - name: pipelineName
           in: path
@@ -7992,7 +8186,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Pipelines
       requestBody:
         required: true
         content:
@@ -8001,6 +8195,7 @@ paths:
               $ref: '#/components/schemas/UpdatePipelineRequest'
     delete:
       operationId: deletePipeline
+      summary: Delete pipeline
       parameters:
         - name: pipelineName
           in: path
@@ -8035,10 +8230,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Pipelines
   /pipelines/{pipelineName}/jobs:
     get:
       operationId: listPipelineJobs
+      summary: List pipeline jobs
       parameters:
         - name: pipelineName
           in: path
@@ -8083,9 +8279,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Pipelines
     post:
       operationId: createPipelineJob
+      summary: Create pipeline job
       parameters:
         - name: pipelineName
           in: path
@@ -8124,7 +8321,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Pipelines
       requestBody:
         required: true
         content:
@@ -8134,6 +8331,7 @@ paths:
   /pipelines/{pipelineName}/jobs/{jobId}:
     delete:
       operationId: deletePipelineJob
+      summary: Delete pipeline job
       parameters:
         - name: pipelineName
           in: path
@@ -8173,10 +8371,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Pipelines
   /pipelines/{pipelineName}/runs:
     post:
       operationId: triggerPipelineRun
+      summary: Trigger pipeline run
       parameters:
         - name: pipelineName
           in: path
@@ -8215,7 +8414,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Pipelines
       requestBody:
         required: false
         content:
@@ -8224,6 +8423,7 @@ paths:
               $ref: '#/components/schemas/TriggerPipelineRunRequest'
     get:
       operationId: listPipelineRuns
+      summary: List pipeline runs
       parameters:
         - name: pipelineName
           in: path
@@ -8287,10 +8487,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Pipelines
   /principals:
     get:
       operationId: listPrincipals
+      summary: List principals
       parameters:
         - name: max_results
           in: query
@@ -8331,9 +8532,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Identity
     post:
       operationId: createPrincipal
+      summary: Create principal
       parameters: []
       responses:
         '201':
@@ -8367,7 +8569,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Identity
       requestBody:
         required: true
         content:
@@ -8377,6 +8579,7 @@ paths:
   /principals/{principalId}:
     get:
       operationId: getPrincipal
+      summary: Get principal
       parameters:
         - name: principalId
           in: path
@@ -8421,9 +8624,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Identity
     delete:
       operationId: deletePrincipal
+      summary: Delete principal
       parameters:
         - name: principalId
           in: path
@@ -8458,10 +8662,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Identity
   /principals/{principalId}/admin:
     put:
       operationId: updatePrincipalAdmin
+      summary: Update principal admin
       parameters:
         - name: principalId
           in: path
@@ -8496,7 +8701,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Identity
       requestBody:
         required: true
         content:
@@ -8506,6 +8711,8 @@ paths:
   /queries:
     post:
       operationId: submitQuery
+      summary: Submit query
+      description: Submits a SQL query for asynchronous execution and returns a query job identifier for polling and result retrieval.
       parameters: []
       responses:
         '202':
@@ -8539,7 +8746,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Queries
       requestBody:
         required: true
         content:
@@ -8549,6 +8756,7 @@ paths:
   /queries/{queryId}:
     get:
       operationId: getQuery
+      summary: Get query
       parameters:
         - name: queryId
           in: path
@@ -8593,9 +8801,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Queries
     delete:
       operationId: deleteQuery
+      summary: Delete query
       parameters:
         - name: queryId
           in: path
@@ -8630,10 +8839,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Queries
   /queries/{queryId}/cancel:
     post:
       operationId: cancelQuery
+      summary: Cancel query
       parameters:
         - name: queryId
           in: path
@@ -8678,10 +8888,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Queries
   /queries/{queryId}/results:
     get:
       operationId: getQueryResults
+      summary: Get query results
+      description: Returns a page of rows for a previously submitted query using the stored query job identifier.
       parameters:
         - name: queryId
           in: path
@@ -8739,10 +8951,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Queries
   /query:
     post:
       operationId: executeQuery
+      summary: Execute query
+      description: Executes a SQL statement synchronously and returns the first page of results in the response body.
       parameters: []
       responses:
         '200':
@@ -8776,7 +8990,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Queries
       requestBody:
         required: true
         content:
@@ -8786,6 +9000,8 @@ paths:
   /query-history:
     get:
       operationId: listQueryHistory
+      summary: List query history
+      description: Lists recorded query executions and supports filtering by principal, decision status, and time window.
       parameters:
         - name: principal_name
           in: query
@@ -8804,12 +9020,14 @@ paths:
           required: false
           schema:
             type: string
+            format: date-time
           explode: false
         - name: to
           in: query
           required: false
           schema:
             type: string
+            format: date-time
           explode: false
         - name: max_results
           in: query
@@ -8850,10 +9068,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Queries
   /row-filters/{rowFilterId}:
     delete:
       operationId: deleteRowFilter
+      summary: Delete row filter
       parameters:
         - name: rowFilterId
           in: path
@@ -8888,10 +9107,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Governance
   /row-filters/{rowFilterId}/bindings:
     get:
       operationId: listRowFilterBindings
+      summary: List row filter bindings
       parameters:
         - name: rowFilterId
           in: path
@@ -8949,9 +9169,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Governance
     post:
       operationId: bindRowFilter
+      summary: Bind row filter
       parameters:
         - name: rowFilterId
           in: path
@@ -8986,7 +9207,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Governance
       requestBody:
         required: true
         content:
@@ -8995,6 +9216,7 @@ paths:
               $ref: '#/components/schemas/RowFilterBindingRequest'
     delete:
       operationId: unbindRowFilter
+      summary: Unbind row filter
       parameters:
         - name: rowFilterId
           in: path
@@ -9041,10 +9263,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Governance
   /search:
     get:
       operationId: searchCatalog
+      summary: Search catalog
       parameters:
         - name: query
           in: query
@@ -9103,10 +9326,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Queries
   /semantic-models:
     get:
       operationId: listSemanticModels
+      summary: List semantic models
       parameters:
         - name: project_name
           in: query
@@ -9153,9 +9377,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Semantic Layer
     post:
       operationId: createSemanticModel
+      summary: Create semantic model
       parameters: []
       responses:
         '201':
@@ -9189,7 +9414,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Semantic Layer
       requestBody:
         required: true
         content:
@@ -9199,6 +9424,7 @@ paths:
   /semantic-models/{projectName}/{semanticModelName}:
     get:
       operationId: getSemanticModel
+      summary: Get semantic model
       parameters:
         - name: projectName
           in: path
@@ -9248,9 +9474,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Semantic Layer
     patch:
       operationId: updateSemanticModel
+      summary: Update semantic model
       parameters:
         - name: projectName
           in: path
@@ -9294,7 +9521,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Semantic Layer
       requestBody:
         required: true
         content:
@@ -9303,6 +9530,7 @@ paths:
               $ref: '#/components/schemas/UpdateSemanticModelRequest'
     delete:
       operationId: deleteSemanticModel
+      summary: Delete semantic model
       parameters:
         - name: projectName
           in: path
@@ -9342,10 +9570,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Semantic Layer
   /semantic-models/{projectName}/{semanticModelName}/metrics:
     get:
       operationId: listSemanticMetrics
+      summary: List semantic metrics
       parameters:
         - name: projectName
           in: path
@@ -9395,9 +9624,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Semantic Layer
     post:
       operationId: createSemanticMetric
+      summary: Create semantic metric
       parameters:
         - name: projectName
           in: path
@@ -9441,7 +9671,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Semantic Layer
       requestBody:
         required: true
         content:
@@ -9451,6 +9681,7 @@ paths:
   /semantic-models/{projectName}/{semanticModelName}/metrics/{metricName}:
     patch:
       operationId: updateSemanticMetric
+      summary: Update semantic metric
       parameters:
         - name: projectName
           in: path
@@ -9499,7 +9730,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Semantic Layer
       requestBody:
         required: true
         content:
@@ -9508,6 +9739,7 @@ paths:
               $ref: '#/components/schemas/UpdateSemanticMetricRequest'
     delete:
       operationId: deleteSemanticMetric
+      summary: Delete semantic metric
       parameters:
         - name: projectName
           in: path
@@ -9552,10 +9784,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Semantic Layer
   /semantic-models/{projectName}/{semanticModelName}/pre-aggregations:
     get:
       operationId: listSemanticPreAggregations
+      summary: List semantic pre aggregations
       parameters:
         - name: projectName
           in: path
@@ -9605,9 +9838,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Semantic Layer
     post:
       operationId: createSemanticPreAggregation
+      summary: Create semantic pre aggregation
       parameters:
         - name: projectName
           in: path
@@ -9651,7 +9885,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Semantic Layer
       requestBody:
         required: true
         content:
@@ -9661,6 +9895,7 @@ paths:
   /semantic-models/{projectName}/{semanticModelName}/pre-aggregations/{preAggregationName}:
     patch:
       operationId: updateSemanticPreAggregation
+      summary: Update semantic pre aggregation
       parameters:
         - name: projectName
           in: path
@@ -9709,7 +9944,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Semantic Layer
       requestBody:
         required: true
         content:
@@ -9718,6 +9953,7 @@ paths:
               $ref: '#/components/schemas/UpdateSemanticPreAggregationRequest'
     delete:
       operationId: deleteSemanticPreAggregation
+      summary: Delete semantic pre aggregation
       parameters:
         - name: projectName
           in: path
@@ -9762,10 +9998,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Semantic Layer
   /semantic-relationships:
     get:
       operationId: listSemanticRelationships
+      summary: List semantic relationships
       parameters:
         - name: max_results
           in: query
@@ -9806,9 +10043,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Semantic Layer
     post:
       operationId: createSemanticRelationship
+      summary: Create semantic relationship
       parameters: []
       responses:
         '201':
@@ -9842,7 +10080,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Semantic Layer
       requestBody:
         required: true
         content:
@@ -9852,6 +10090,7 @@ paths:
   /semantic-relationships/{relationshipName}:
     patch:
       operationId: updateSemanticRelationship
+      summary: Update semantic relationship
       parameters:
         - name: relationshipName
           in: path
@@ -9890,7 +10129,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Semantic Layer
       requestBody:
         required: true
         content:
@@ -9899,6 +10138,7 @@ paths:
               $ref: '#/components/schemas/UpdateSemanticRelationshipRequest'
     delete:
       operationId: deleteSemanticRelationship
+      summary: Delete semantic relationship
       parameters:
         - name: relationshipName
           in: path
@@ -9933,10 +10173,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Semantic Layer
   /sources/{sourceSchema}/{sourceTable}/freshness:
     get:
       operationId: checkSourceFreshness
+      summary: Check source freshness
       parameters:
         - name: sourceSchema
           in: path
@@ -9999,10 +10240,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Semantic Layer
   /storage-credentials:
     get:
       operationId: listStorageCredentials
+      summary: List storage credentials
       parameters:
         - name: max_results
           in: query
@@ -10043,9 +10285,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Storage
     post:
       operationId: createStorageCredential
+      summary: Create storage credential
+      description: Creates a reusable storage credential that can be referenced by external locations and managed catalogs.
       parameters: []
       responses:
         '201':
@@ -10079,7 +10323,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Storage
       requestBody:
         required: true
         content:
@@ -10095,6 +10339,7 @@ paths:
   /storage-credentials/{credentialName}:
     get:
       operationId: getStorageCredential
+      summary: Get storage credential
       parameters:
         - name: credentialName
           in: path
@@ -10139,9 +10384,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Storage
     patch:
       operationId: updateStorageCredential
+      summary: Update storage credential
       parameters:
         - name: credentialName
           in: path
@@ -10180,7 +10426,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Storage
       requestBody:
         required: true
         content:
@@ -10195,6 +10441,7 @@ paths:
             securable_id_source: runtime_resolved_object_id
     delete:
       operationId: deleteStorageCredential
+      summary: Delete storage credential
       parameters:
         - name: credentialName
           in: path
@@ -10229,7 +10476,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Storage
       x-authz:
         mode: privilege
         checks:
@@ -10239,6 +10486,7 @@ paths:
   /tables/{tableId}/column-masks:
     get:
       operationId: listColumnMasks
+      summary: List column masks
       parameters:
         - name: tableId
           in: path
@@ -10296,9 +10544,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Governance
     post:
       operationId: createColumnMask
+      summary: Create column mask
       parameters:
         - name: tableId
           in: path
@@ -10337,7 +10586,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Governance
       requestBody:
         required: true
         content:
@@ -10347,6 +10596,7 @@ paths:
   /tables/{tableId}/row-filters:
     get:
       operationId: listRowFilters
+      summary: List row filters
       parameters:
         - name: tableId
           in: path
@@ -10404,9 +10654,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Governance
     post:
       operationId: createRowFilter
+      summary: Create row filter
       parameters:
         - name: tableId
           in: path
@@ -10445,7 +10696,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Governance
       requestBody:
         required: true
         content:
@@ -10455,6 +10706,7 @@ paths:
   /tag-assignments/{assignmentId}:
     delete:
       operationId: deleteTagAssignment
+      summary: Delete tag assignment
       parameters:
         - name: assignmentId
           in: path
@@ -10489,10 +10741,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Governance
   /tags:
     get:
       operationId: listTags
+      summary: List tags
       parameters:
         - name: max_results
           in: query
@@ -10533,9 +10786,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Governance
     post:
       operationId: createTag
+      summary: Create tag
       parameters: []
       responses:
         '201':
@@ -10569,7 +10823,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Governance
       requestBody:
         required: true
         content:
@@ -10579,6 +10833,7 @@ paths:
   /tags/{tagId}:
     delete:
       operationId: deleteTag
+      summary: Delete tag
       parameters:
         - name: tagId
           in: path
@@ -10613,10 +10868,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Governance
   /tags/{tagId}/assignments:
     get:
       operationId: listTagAssignments
+      summary: List tag assignments
       parameters:
         - name: tagId
           in: path
@@ -10674,9 +10930,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Governance
     post:
       operationId: createTagAssignment
+      summary: Create tag assignment
       parameters:
         - name: tagId
           in: path
@@ -10715,7 +10972,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       tags:
-        - Duck
+        - Governance
       requestBody:
         required: true
         content:
@@ -10748,6 +11005,8 @@ components:
         created_at:
           type: string
           format: date-time
+      description: Represents a stored API key without returning the full secret value.
+      title: API key metadata.
     Asset:
       type: object
       properties:
@@ -12160,6 +12419,8 @@ components:
           type: object
           additionalProperties:
             type: string
+      description: Errors use a shared schema across the API so clients can handle failure responses consistently.
+      title: Standard API error response.
     ExternalLocation:
       type: object
       required:
@@ -12284,6 +12545,7 @@ components:
       properties:
         status:
           type: string
+      title: Service health status.
     IngestionOptions:
       type: object
       properties:
@@ -13777,6 +14039,7 @@ components:
         created_at:
           type: string
           format: date-time
+      title: Authenticated principal.
     PrincipalType:
       type: string
       enum:
@@ -13916,6 +14179,8 @@ components:
       properties:
         sql:
           type: string
+      description: Submits a SQL statement for immediate execution and returns a tabular result when the request completes.
+      title: Synchronous SQL query request.
     QueryResult:
       type: object
       required:
@@ -13936,6 +14201,8 @@ components:
           format: int64
         next_page_token:
           type: string
+      description: Contains result-set columns, row data, and an optional continuation token when additional rows are available.
+      title: Tabular SQL query result.
     ReorderCellsRequest:
       type: object
       required:
@@ -14360,6 +14627,7 @@ components:
       properties:
         name:
           type: string
+      title: Metadata for a result-set column.
     Tag:
       type: object
       properties:
@@ -14861,6 +15129,6 @@ components:
       in: header
       name: X-API-Key
 servers:
-  - url: https://api.example.com/v1
-    description: Primary API server
+  - url: https://localhost:8443/v1
+    description: HTTPS base URL for local and proxied deployments
     variables: {}

--- a/api/spec/main.tsp
+++ b/api/spec/main.tsp
@@ -14,8 +14,25 @@ using TypeSpec.Http;
 using TypeSpec.OpenAPI;
 
 @service(#{ title: "Duck Data Platform API" })
-@doc("Secure SQL query layer over DuckDB with RBAC, row-level security, and column masking, backed by SQLite metadata.")
-@server("https://api.example.com/v1", "Primary API server")
-@tag("Duck")
+@doc("Duck Data Platform exposes a secure SQL query layer over DuckDB together with metadata management, RBAC, row-level security, column masking, lineage, orchestration, and semantic modeling APIs backed by SQLite metadata.")
+@info(#{
+  version: "0.1.0"
+})
+@server("https://localhost:8443/v1", "HTTPS base URL for local and proxied deployments")
+@tagMetadata("Health", #{ description: "Operational readiness and service health endpoints." })
+@tagMetadata("Auth", #{ description: "Authentication bootstrap, login, OIDC configuration, and web session administration." })
+@tagMetadata("Identity", #{ description: "Principals, groups, and API key management for authenticated access." })
+@tagMetadata("Governance", #{ description: "Privileges, tags, classifications, row filters, and column masking controls." })
+@tagMetadata("Catalogs", #{ description: "Catalog, schema, table, view, volume, and ingestion management APIs." })
+@tagMetadata("Assets", #{ description: "Data asset definitions, runs, checks, partitions, and materialization workflows." })
+@tagMetadata("Queries", #{ description: "Synchronous and asynchronous SQL query execution, search, and query history endpoints." })
+@tagMetadata("Lineage", #{ description: "Table and column lineage inspection together with lineage maintenance operations." })
+@tagMetadata("Storage", #{ description: "Storage credentials and external location configuration for object storage access." })
+@tagMetadata("Compute", #{ description: "Compute endpoint lifecycle, assignments, and health checks." })
+@tagMetadata("Notebooks", #{ description: "Notebook authoring, sessions, cells, and job execution endpoints." })
+@tagMetadata("Integrations", #{ description: "Git repository and external integration lifecycle operations." })
+@tagMetadata("Pipelines", #{ description: "Pipeline definitions, jobs, runs, and orchestration controls." })
+@tagMetadata("Models", #{ description: "Model, macro, and model run management for transformation workflows." })
+@tagMetadata("Semantic Layer", #{ description: "Semantic models, metrics, relationships, and metric query execution." })
 @useAuth(BearerAuth | ApiKeyAuth<ApiKeyLocation.header, "X-API-Key">)
 namespace Duck;

--- a/api/spec/models/core.tsp
+++ b/api/spec/models/core.tsp
@@ -60,11 +60,14 @@ enum URLStyle {
   vhost,
 }
 
+@summary("Metadata for a result-set column.")
 model TabularColumn {
   name: string;
 }
 
 @error
+@summary("Standard API error response.")
+@doc("Errors use a shared schema across the API so clients can handle failure responses consistently.")
 model Error {
   code: int32;
   message: string;
@@ -152,14 +155,19 @@ alias StandardErrorResponses = UnauthorizedResponse | TooManyRequestsResponse | 
 alias MutatingErrorResponses = StandardErrorResponses | ForbiddenResponse;
 alias ResourceErrorResponses = MutatingErrorResponses | NotFoundResponse;
 
+@summary("Service health status.")
 model HealthResponse {
   status: string;
 }
 
+@summary("Synchronous SQL query request.")
+@doc("Submits a SQL statement for immediate execution and returns a tabular result when the request completes.")
 model QueryRequest {
   sql: string;
 }
 
+@summary("Tabular SQL query result.")
+@doc("Contains result-set columns, row data, and an optional continuation token when additional rows are available.")
 model QueryResult {
   columns: TabularColumn[];
   rows: JsonObject[];
@@ -196,6 +204,7 @@ model CancelQueryResponse {
   status: QueryJobStatus;
 }
 
+@summary("Authenticated principal.")
 model Principal {
   id: string;
   name: string;
@@ -345,6 +354,8 @@ model CreateGrantRequest {
   privilege: string;
 }
 
+@summary("API key metadata.")
+@doc("Represents a stored API key without returning the full secret value.")
 model APIKeyInfo {
   id: string;
   principal_id: string;

--- a/api/spec/operations/assets.tsp
+++ b/api/spec/operations/assets.tsp
@@ -4,60 +4,92 @@ namespace Duck;
 
 @route("/assets")
 @get
+@tag("Assets")
+@summary("List assets")
 op listAssets(@query max_results?: int32, @query page_token?: string): Ok<PaginatedAssets> | StandardErrorResponses;
 
 @route("/assets")
 @post
+@tag("Assets")
+@summary("Create asset")
+@doc("Creates a managed asset definition together with its ownership, checks, tags, and upstream lineage metadata.")
 op createAsset(@body body: CreateAssetRequest): Created<Asset> | MutatingErrorResponses | ConflictResponse;
 
 @route("/assets/{assetKey}")
 @get
+@tag("Assets")
+@summary("Get asset")
 op getAsset(assetKey: string): Ok<Asset> | ResourceErrorResponses;
 
 @route("/assets/{assetKey}")
 @put
+@tag("Assets")
+@summary("Update asset")
 op updateAsset(assetKey: string, @body body: UpdateAssetRequest): Ok<Asset> | ResourceErrorResponses;
 
 @route("/assets/{assetKey}")
 @delete
+@tag("Assets")
+@summary("Delete asset")
 op deleteAsset(assetKey: string): NoContent | ResourceErrorResponses;
 
 @route("/assets/{assetKey}/graph")
 @get
+@tag("Assets")
+@summary("Get asset graph")
 op getAssetGraph(assetKey: string): Ok<AssetGraph> | ResourceErrorResponses;
 
 @route("/assets/{assetKey}/partitions")
 @get
+@tag("Assets")
+@summary("List asset partitions")
 op listAssetPartitions(assetKey: string, @query max_results?: int32, @query page_token?: string): Ok<PaginatedAssetPartitions> | ResourceErrorResponses;
 
 @route("/assets/{assetKey}/runs")
 @get
+@tag("Assets")
+@summary("List asset runs")
 op listAssetRuns(assetKey: string, @query status?: AssetRunStatus, @query max_results?: int32, @query page_token?: string): Ok<PaginatedAssetRuns> | ResourceErrorResponses;
 
 @route("/assets/{assetKey}/materialize")
 @post
+@tag("Assets")
+@summary("Trigger asset materialization")
+@doc("Starts a materialization run for the specified asset and returns the queued execution metadata.")
 op triggerAssetMaterialization(assetKey: string, @body body?: TriggerAssetMaterializationRequest): Accepted<AssetTriggerResponse> | ResourceErrorResponses;
 
 @route("/assets/{assetKey}/materializations")
 @get
+@tag("Assets")
+@summary("List asset materializations")
 op listAssetMaterializations(assetKey: string, @query max_results?: int32, @query page_token?: string): Ok<PaginatedAssetMaterializations> | ResourceErrorResponses;
 
 @route("/assets/{assetKey}/checks")
 @get
+@tag("Assets")
+@summary("List asset checks")
 op listAssetChecks(assetKey: string): Ok<AssetCheckList> | ResourceErrorResponses;
 
 @route("/assets/{assetKey}/check-results")
 @get
+@tag("Assets")
+@summary("List asset check results")
 op listAssetCheckResults(assetKey: string, @query max_results?: int32, @query page_token?: string): Ok<PaginatedAssetCheckResults> | ResourceErrorResponses;
 
 @route("/assets/{assetKey}/backfills")
 @get
+@tag("Assets")
+@summary("List asset backfills")
 op listAssetBackfills(assetKey: string, @query status?: AssetRunStatus, @query max_results?: int32, @query page_token?: string): Ok<PaginatedBackfillRequests> | ResourceErrorResponses;
 
 @route("/assets/{assetKey}/backfills")
 @post
+@tag("Assets")
+@summary("Create asset backfill")
 op createAssetBackfill(assetKey: string, @body body: CreateAssetBackfillRequest): Created<CreateAssetBackfillResponse> | ResourceErrorResponses;
 
 @route("/assets/{assetKey}/backfills/{backfillId}")
 @get
+@tag("Assets")
+@summary("Get asset backfill")
 op getAssetBackfill(assetKey: string, backfillId: string): Ok<AssetBackfillDetails> | ResourceErrorResponses;

--- a/api/spec/operations/auth.tsp
+++ b/api/spec/operations/auth.tsp
@@ -5,29 +5,44 @@ namespace Duck;
 @route("/auth/bootstrap/complete")
 @post
 @useAuth([])
+@tag("Auth")
+@summary("Bootstrap complete")
 op bootstrapComplete(@body body: BootstrapCompleteRequest): Created<AuthLoginResponse> | BadRequestResponse | UnauthorizedResponse | ForbiddenResponse | ConflictResponse | TooManyRequestsResponse | InternalServerErrorResponse;
 
 @route("/auth/local/login")
 @post
 @useAuth([])
+@tag("Auth")
+@summary("Local login")
+@doc("Authenticates a local user with username and password and returns a bearer token for subsequent API calls.")
 op localLogin(@body body: LocalLoginRequest): Created<AuthLoginResponse> | BadRequestResponse | UnauthorizedResponse | ForbiddenResponse | TooManyRequestsResponse | InternalServerErrorResponse;
 
 @route("/auth/bootstrap/tokens")
 @post
+@tag("Auth")
+@summary("Create bootstrap token")
 op createBootstrapToken(@body body: BootstrapTokenRequest): Created<BootstrapTokenResponse> | BadRequestResponse | UnauthorizedResponse | ForbiddenResponse | TooManyRequestsResponse | InternalServerErrorResponse;
 
 @route("/auth/provider/oidc")
 @get
+@tag("Auth")
+@summary("Get OIDC provider")
 op getOIDCProvider(): Ok<OIDCProviderResponse> | UnauthorizedResponse | ForbiddenResponse | TooManyRequestsResponse | InternalServerErrorResponse;
 
 @route("/auth/provider/oidc")
 @put
+@tag("Auth")
+@summary("Upsert OIDC provider")
 op upsertOIDCProvider(@body body: OIDCProviderRequest): NoContent | BadRequestResponse | UnauthorizedResponse | ForbiddenResponse | TooManyRequestsResponse | InternalServerErrorResponse;
 
 @route("/auth/sessions/revoke-all")
 @post
+@tag("Auth")
+@summary("Revoke all web sessions")
 op revokeAllWebSessions(@body body: RevokeWebSessionsRequest): NoContent | BadRequestResponse | UnauthorizedResponse | ForbiddenResponse | TooManyRequestsResponse | InternalServerErrorResponse | ServiceUnavailableResponse;
 
 @route("/auth/sessions/stats")
 @get
+@tag("Auth")
+@summary("Get web session stats")
 op getWebSessionStats(): Ok<WebSessionStatsResponse> | UnauthorizedResponse | ForbiddenResponse | TooManyRequestsResponse | InternalServerErrorResponse | ServiceUnavailableResponse;

--- a/api/spec/operations/core.tsp
+++ b/api/spec/operations/core.tsp
@@ -4,62 +4,94 @@ namespace Duck;
 
 @route("/healthz")
 @get
+@useAuth([])
+@tag("Health")
+@summary("Get health")
 op getHealth(): Ok<HealthResponse> | StandardErrorResponses;
 
 @route("/query")
 @post
+@tag("Queries")
+@summary("Execute query")
+@doc("Executes a SQL statement synchronously and returns the first page of results in the response body.")
 op executeQuery(@body body: QueryRequest): Ok<QueryResult> | MutatingErrorResponses;
 
 @route("/principals")
 @get
+@tag("Identity")
+@summary("List principals")
 op listPrincipals(@query max_results?: int32, @query page_token?: string): Ok<PaginatedPrincipals> | StandardErrorResponses;
 
 @route("/principals")
 @post
+@tag("Identity")
+@summary("Create principal")
 op createPrincipal(@body body: CreatePrincipalRequest): Created<Principal> | MutatingErrorResponses;
 
 @route("/principals/{principalId}")
 @get
+@tag("Identity")
+@summary("Get principal")
 op getPrincipal(principalId: string): Ok<Principal> | ResourceErrorResponses;
 
 @route("/principals/{principalId}")
 @delete
+@tag("Identity")
+@summary("Delete principal")
 op deletePrincipal(principalId: string): NoContent | MutatingErrorResponses;
 
 @route("/principals/{principalId}/admin")
 @put
+@tag("Identity")
+@summary("Update principal admin")
 op updatePrincipalAdmin(principalId: string, @body body: UpdatePrincipalAdminRequest): NoContent | MutatingErrorResponses;
 
 @route("/groups")
 @get
+@tag("Identity")
+@summary("List groups")
 op listGroups(@query max_results?: int32, @query page_token?: string): Ok<PaginatedGroups> | StandardErrorResponses;
 
 @route("/groups")
 @post
+@tag("Identity")
+@summary("Create group")
 op createGroup(@body body: CreateGroupRequest): Created<Group> | MutatingErrorResponses;
 
 @route("/groups/{groupId}")
 @get
+@tag("Identity")
+@summary("Get group")
 op getGroup(groupId: string): Ok<Group> | ResourceErrorResponses;
 
 @route("/groups/{groupId}")
 @delete
+@tag("Identity")
+@summary("Delete group")
 op deleteGroup(groupId: string): NoContent | MutatingErrorResponses;
 
 @route("/groups/{groupId}/members")
 @get
+@tag("Identity")
+@summary("List group members")
 op listGroupMembers(groupId: string, @query max_results?: int32, @query page_token?: string): Ok<PaginatedGroupMembers> | ResourceErrorResponses;
 
 @route("/groups/{groupId}/members")
 @post
+@tag("Identity")
+@summary("Create group member")
 op createGroupMember(groupId: string, @body body: CreateGroupMemberRequest): CreatedEmpty | MutatingErrorResponses;
 
 @route("/groups/{groupId}/members")
 @delete
+@tag("Identity")
+@summary("Delete group member")
 op deleteGroupMember(groupId: string, @query member_type: PrincipalType, @query member_id: string): NoContent | MutatingErrorResponses;
 
 @route("/grants")
 @get
+@tag("Governance")
+@summary("List grants")
 op listGrants(
   @query principal_id?: string,
   @query principal_type?: PrincipalType,
@@ -71,42 +103,62 @@ op listGrants(
 
 @route("/grants")
 @post
+@tag("Governance")
+@summary("Create grant")
 op createGrant(@body body: CreateGrantRequest): Created<PrivilegeGrant> | MutatingErrorResponses;
 
 @route("/grants/{grantId}")
 @delete
+@tag("Governance")
+@summary("Delete grant")
 op deleteGrant(grantId: string): NoContent | MutatingErrorResponses;
 
 @route("/api-keys")
 @get
+@tag("Identity")
+@summary("List API keys")
 op listAPIKeys(@query principal_id?: string, @query max_results?: int32, @query page_token?: string): Ok<PaginatedAPIKeys> | StandardErrorResponses;
 
 @route("/api-keys")
 @post
+@tag("Identity")
+@summary("Create API key")
 op createAPIKey(@body body: CreateAPIKeyRequest): Created<CreateAPIKeyResponse> | MutatingErrorResponses;
 
 @route("/api-keys/{apiKeyId}")
 @delete
+@tag("Identity")
+@summary("Delete API key")
 op deleteAPIKey(apiKeyId: string): NoContent | MutatingErrorResponses;
 
 @route("/api-keys/cleanup")
 @post
+@tag("Identity")
+@summary("Clean up expired API keys")
 op cleanupExpiredAPIKeys(): Ok<CleanupAPIKeysResponse> | MutatingErrorResponses;
 
 @route("/tables/{tableId}/row-filters")
 @get
+@tag("Governance")
+@summary("List row filters")
 op listRowFilters(tableId: string, @query max_results?: int32, @query page_token?: string): Ok<PaginatedRowFilters> | ResourceErrorResponses;
 
 @route("/tables/{tableId}/row-filters")
 @post
+@tag("Governance")
+@summary("Create row filter")
 op createRowFilter(tableId: string, @body body: CreateRowFilterRequest): Created<RowFilter> | MutatingErrorResponses;
 
 @route("/row-filters/{rowFilterId}")
 @delete
+@tag("Governance")
+@summary("Delete row filter")
 op deleteRowFilter(rowFilterId: string): NoContent | MutatingErrorResponses;
 
 @route("/row-filters/{rowFilterId}/bindings")
 @get
+@tag("Governance")
+@summary("List row filter bindings")
 op listRowFilterBindings(
   rowFilterId: string,
   @query max_results?: int32,
@@ -115,26 +167,38 @@ op listRowFilterBindings(
 
 @route("/row-filters/{rowFilterId}/bindings")
 @post
+@tag("Governance")
+@summary("Bind row filter")
 op bindRowFilter(rowFilterId: string, @body body: RowFilterBindingRequest): CreatedEmpty | MutatingErrorResponses;
 
 @route("/row-filters/{rowFilterId}/bindings")
 @delete
+@tag("Governance")
+@summary("Unbind row filter")
 op unbindRowFilter(rowFilterId: string, @query principal_id: string, @query principal_type: PrincipalType): NoContent | MutatingErrorResponses;
 
 @route("/tables/{tableId}/column-masks")
 @get
+@tag("Governance")
+@summary("List column masks")
 op listColumnMasks(tableId: string, @query max_results?: int32, @query page_token?: string): Ok<PaginatedColumnMasks> | ResourceErrorResponses;
 
 @route("/tables/{tableId}/column-masks")
 @post
+@tag("Governance")
+@summary("Create column mask")
 op createColumnMask(tableId: string, @body body: CreateColumnMaskRequest): Created<ColumnMask> | MutatingErrorResponses;
 
 @route("/column-masks/{columnMaskId}")
 @delete
+@tag("Governance")
+@summary("Delete column mask")
 op deleteColumnMask(columnMaskId: string): NoContent | MutatingErrorResponses;
 
 @route("/column-masks/{columnMaskId}/bindings")
 @get
+@tag("Governance")
+@summary("List column mask bindings")
 op listColumnMaskBindings(
   columnMaskId: string,
   @query max_results?: int32,
@@ -143,18 +207,26 @@ op listColumnMaskBindings(
 
 @route("/column-masks/{columnMaskId}/bindings")
 @post
+@tag("Governance")
+@summary("Bind column mask")
 op bindColumnMask(columnMaskId: string, @body body: ColumnMaskBindingRequest): CreatedEmpty | MutatingErrorResponses;
 
 @route("/column-masks/{columnMaskId}/bindings")
 @delete
+@tag("Governance")
+@summary("Unbind column mask")
 op unbindColumnMask(columnMaskId: string, @query principal_id: string, @query principal_type: PrincipalType): NoContent | MutatingErrorResponses;
 
 @route("/manifest")
 @post
+@tag("Catalogs")
+@summary("Create manifest")
 op createManifest(@body body: ManifestRequest): Ok<ManifestResponse> | MutatingErrorResponses;
 
 @route("/audit-logs")
 @get
+@tag("Queries")
+@summary("List audit logs")
 op listAuditLogs(
   @query principal_name?: string,
   @query action?: string,
@@ -165,53 +237,78 @@ op listAuditLogs(
 
 @route("/catalogs/{catalogName}/metastore/summary")
 @get
+@tag("Catalogs")
+@summary("Get metastore summary")
 op getMetastoreSummary(catalogName: string): Ok<MetastoreSummary> | ResourceErrorResponses;
 
 @route("/query-history")
 @get
+@tag("Queries")
+@summary("List query history")
+@doc("Lists recorded query executions and supports filtering by principal, decision status, and time window.")
 op listQueryHistory(
   @query principal_name?: string,
   @query status?: AuditDecisionStatus,
-  @query from?: string,
-  @query to?: string,
+  @query from?: utcDateTime,
+  @query to?: utcDateTime,
   @query max_results?: int32,
   @query page_token?: string,
 ): Ok<PaginatedQueryHistoryEntries> | StandardErrorResponses;
 
 @route("/catalogs")
 @post
+@tag("Catalogs")
+@summary("Register catalog")
 op registerCatalog(@body body: CreateCatalogRequest): Created<CatalogRegistration> | MutatingErrorResponses;
 
 @route("/catalogs")
 @get
+@tag("Catalogs")
+@summary("List catalogs")
+@doc("Lists registered catalogs and returns a paginated catalog registration view for management clients.")
 op listCatalogs(@query max_results?: int32, @query page_token?: string): Ok<CatalogRegistrationList> | StandardErrorResponses;
 
 @route("/catalogs/{catalogName}")
 @get
+@tag("Catalogs")
+@summary("Get catalog registration")
 op getCatalogRegistration(catalogName: string): Ok<CatalogRegistration> | ResourceErrorResponses;
 
 @route("/catalogs/{catalogName}")
 @patch(#{ implicitOptionality: true })
+@tag("Catalogs")
+@summary("Update catalog registration")
 op updateCatalogRegistration(catalogName: string, @body body: UpdateCatalogRegistrationRequest): Ok<CatalogRegistration> | MutatingErrorResponses;
 
 @route("/catalogs/{catalogName}")
 @delete
+@tag("Catalogs")
+@summary("Delete catalog registration")
 op deleteCatalogRegistration(catalogName: string): NoContent | MutatingErrorResponses;
 
 @route("/catalogs/{catalogName}/set-default")
 @post
+@tag("Catalogs")
+@summary("Set default catalog")
 op setDefaultCatalog(catalogName: string, @body body: SetDefaultCatalogRequest): Ok<CatalogRegistration> | MutatingErrorResponses;
 
 @route("/catalogs/{catalogName}/info")
 @get
+@tag("Catalogs")
+@summary("Get catalog")
+@doc("Returns runtime catalog information, including metastore details and status for the named catalog.")
 op getCatalog(catalogName: string): Ok<CatalogInfo> | ResourceErrorResponses;
 
 @route("/catalogs/{catalogName}/version-summary")
 @get
+@tag("Catalogs")
+@summary("Get catalog version summary")
 op getCatalogVersionSummary(catalogName: string): Ok<CatalogVersionSummary> | ResourceErrorResponses;
 
 @route("/catalogs/{catalogName}/history")
 @get
+@tag("Catalogs")
+@summary("List catalog history")
 op listCatalogHistory(
   catalogName: string,
   @query entity_type?: string,
@@ -222,46 +319,68 @@ op listCatalogHistory(
 
 @route("/catalogs/{catalogName}/schemas")
 @get
+@tag("Catalogs")
+@summary("List schemas")
 op listSchemas(catalogName: string, @query max_results?: int32, @query page_token?: string): Ok<PaginatedSchemaDetails> | ResourceErrorResponses;
 
 @route("/catalogs/{catalogName}/schemas")
 @post
+@tag("Catalogs")
+@summary("Create schema")
 op createSchema(catalogName: string, @body body: CreateSchemaRequest): Created<SchemaDetail> | MutatingErrorResponses;
 
 @route("/catalogs/{catalogName}/schemas/{schemaName}")
 @get
+@tag("Catalogs")
+@summary("Get schema")
 op getSchema(catalogName: string, schemaName: string): Ok<SchemaDetail> | ResourceErrorResponses;
 
 @route("/catalogs/{catalogName}/schemas/{schemaName}")
 @patch(#{ implicitOptionality: true })
+@tag("Catalogs")
+@summary("Update schema")
 op updateSchema(catalogName: string, schemaName: string, @body body: UpdateSchemaRequest): Ok<SchemaDetail> | MutatingErrorResponses;
 
 @route("/catalogs/{catalogName}/schemas/{schemaName}")
 @delete
+@tag("Catalogs")
+@summary("Delete schema")
 op deleteSchema(catalogName: string, schemaName: string, @query force?: boolean): NoContent | MutatingErrorResponses;
 
 @route("/catalogs/{catalogName}/schemas/{schemaName}/tables")
 @get
+@tag("Catalogs")
+@summary("List tables")
 op listTables(catalogName: string, schemaName: string, @query max_results?: int32, @query page_token?: string): Ok<PaginatedTableDetails> | ResourceErrorResponses;
 
 @route("/catalogs/{catalogName}/schemas/{schemaName}/tables")
 @post
+@tag("Catalogs")
+@summary("Create table")
 op createTable(catalogName: string, schemaName: string, @body body: CreateTableRequest): Created<TableDetail> | MutatingErrorResponses;
 
 @route("/catalogs/{catalogName}/schemas/{schemaName}/tables/{tableName}")
 @get
+@tag("Catalogs")
+@summary("Get table")
 op getTable(catalogName: string, schemaName: string, tableName: string): Ok<TableDetail> | ResourceErrorResponses;
 
 @route("/catalogs/{catalogName}/schemas/{schemaName}/tables/{tableName}")
 @patch(#{ implicitOptionality: true })
+@tag("Catalogs")
+@summary("Update table")
 op updateTable(catalogName: string, schemaName: string, tableName: string, @body body: UpdateTableRequest): Ok<TableDetail> | MutatingErrorResponses;
 
 @route("/catalogs/{catalogName}/schemas/{schemaName}/tables/{tableName}")
 @delete
+@tag("Catalogs")
+@summary("Delete table")
 op deleteTable(catalogName: string, schemaName: string, tableName: string): NoContent | MutatingErrorResponses;
 
 @route("/catalogs/{catalogName}/schemas/{schemaName}/tables/{tableName}/columns")
 @get
+@tag("Catalogs")
+@summary("List table columns")
 op listTableColumns(
   catalogName: string,
   schemaName: string,
@@ -272,6 +391,8 @@ op listTableColumns(
 
 @route("/catalogs/{catalogName}/schemas/{schemaName}/tables/{tableName}/columns/{columnName}")
 @patch(#{ implicitOptionality: true })
+@tag("Catalogs")
+@summary("Update column")
 op updateColumn(
   catalogName: string,
   schemaName: string,
@@ -282,44 +403,66 @@ op updateColumn(
 
 @route("/catalogs/{catalogName}/schemas/{schemaName}/tables/{tableName}/profile")
 @post
+@tag("Catalogs")
+@summary("Profile table")
 op profileTable(catalogName: string, schemaName: string, tableName: string): Ok<TableStatistics> | MutatingErrorResponses;
 
 @route("/catalogs/{catalogName}/schemas/{schemaName}/views")
 @get
+@tag("Catalogs")
+@summary("List views")
 op listViews(catalogName: string, schemaName: string, @query max_results?: int32, @query page_token?: string): Ok<PaginatedViewDetails> | ResourceErrorResponses;
 
 @route("/catalogs/{catalogName}/schemas/{schemaName}/views")
 @post
+@tag("Catalogs")
+@summary("Create view")
 op createView(catalogName: string, schemaName: string, @body body: CreateViewRequest): Created<ViewDetail> | MutatingErrorResponses;
 
 @route("/catalogs/{catalogName}/schemas/{schemaName}/views/{viewName}")
 @get
+@tag("Catalogs")
+@summary("Get view")
 op getView(catalogName: string, schemaName: string, viewName: string): Ok<ViewDetail> | ResourceErrorResponses;
 
 @route("/catalogs/{catalogName}/schemas/{schemaName}/views/{viewName}")
 @patch(#{ implicitOptionality: true })
+@tag("Catalogs")
+@summary("Update view")
 op updateView(catalogName: string, schemaName: string, viewName: string, @body body: UpdateViewRequest): Ok<ViewDetail> | MutatingErrorResponses;
 
 @route("/catalogs/{catalogName}/schemas/{schemaName}/views/{viewName}")
 @delete
+@tag("Catalogs")
+@summary("Delete view")
 op deleteView(catalogName: string, schemaName: string, viewName: string): NoContent | MutatingErrorResponses;
 
 @route("/catalogs/{catalogName}/schemas/{schemaName}/volumes")
 @get
+@tag("Catalogs")
+@summary("List volumes")
 op listVolumes(catalogName: string, schemaName: string, @query max_results?: int32, @query page_token?: string): Ok<PaginatedVolumes> | ResourceErrorResponses;
 
 @route("/catalogs/{catalogName}/schemas/{schemaName}/volumes")
 @post
+@tag("Catalogs")
+@summary("Create volume")
 op createVolume(catalogName: string, schemaName: string, @body body: CreateVolumeRequest): Created<VolumeDetail> | MutatingErrorResponses;
 
 @route("/catalogs/{catalogName}/schemas/{schemaName}/volumes/{volumeName}")
 @get
+@tag("Catalogs")
+@summary("Get volume")
 op getVolume(catalogName: string, schemaName: string, volumeName: string): Ok<VolumeDetail> | ResourceErrorResponses;
 
 @route("/catalogs/{catalogName}/schemas/{schemaName}/volumes/{volumeName}")
 @patch(#{ implicitOptionality: true })
+@tag("Catalogs")
+@summary("Update volume")
 op updateVolume(catalogName: string, schemaName: string, volumeName: string, @body body: UpdateVolumeRequest): Ok<VolumeDetail> | MutatingErrorResponses;
 
 @route("/catalogs/{catalogName}/schemas/{schemaName}/volumes/{volumeName}")
 @delete
+@tag("Catalogs")
+@summary("Delete volume")
 op deleteVolume(catalogName: string, schemaName: string, volumeName: string): NoContent | MutatingErrorResponses;

--- a/api/spec/operations/extensions.tsp
+++ b/api/spec/operations/extensions.tsp
@@ -4,82 +4,124 @@ namespace Duck;
 
 @route("/queries")
 @post
+@tag("Queries")
+@summary("Submit query")
+@doc("Submits a SQL query for asynchronous execution and returns a query job identifier for polling and result retrieval.")
 op submitQuery(@body body: SubmitQueryRequest): Accepted<SubmitQueryResponse> | MutatingErrorResponses;
 
 @route("/queries/{queryId}")
 @get
+@tag("Queries")
+@summary("Get query")
 op getQuery(queryId: string): Ok<QueryJob> | ResourceErrorResponses;
 
 @route("/queries/{queryId}")
 @delete
+@tag("Queries")
+@summary("Delete query")
 op deleteQuery(queryId: string): NoContent | MutatingErrorResponses;
 
 @route("/queries/{queryId}/results")
 @get
+@tag("Queries")
+@summary("Get query results")
+@doc("Returns a page of rows for a previously submitted query using the stored query job identifier.")
 op getQueryResults(queryId: string, @query max_results?: int32, @query page_token?: string): Ok<QueryResult> | ResourceErrorResponses;
 
 @route("/queries/{queryId}/cancel")
 @post
+@tag("Queries")
+@summary("Cancel query")
 op cancelQuery(queryId: string): Accepted<CancelQueryResponse> | ResourceErrorResponses;
 
 @route("/catalogs/{catalogName}/schemas/{schemaName}/tables/{tableName}/ingestion/upload-url")
 @post
+@tag("Catalogs")
+@summary("Create upload URL")
 op createUploadUrl(catalogName: string, schemaName: string, tableName: string, @body body: UploadUrlRequest): Ok<UploadUrlResponse> | MutatingErrorResponses;
 
 @route("/catalogs/{catalogName}/schemas/{schemaName}/tables/{tableName}/ingestion/commit")
 @post
+@tag("Catalogs")
+@summary("Commit table ingestion")
 op commitTableIngestion(catalogName: string, schemaName: string, tableName: string, @body body: CommitIngestionRequest): Ok<IngestionResult> | MutatingErrorResponses;
 
 @route("/catalogs/{catalogName}/schemas/{schemaName}/tables/{tableName}/ingestion/load")
 @post
+@tag("Catalogs")
+@summary("Load table external files")
 op loadTableExternalFiles(catalogName: string, schemaName: string, tableName: string, @body body: LoadExternalRequest): Ok<IngestionResult> | MutatingErrorResponses;
 
 @route("/search")
 @get
+@tag("Queries")
+@summary("Search catalog")
 op searchCatalog(@query query: string, @query type?: string, @query catalog?: string, @query max_results?: int32, @query page_token?: string): Ok<PaginatedSearchResults> | StandardErrorResponses;
 
 @route("/lineage/tables/{schemaName}/{tableName}")
 @get
+@tag("Lineage")
+@summary("Get table lineage")
 op getTableLineage(schemaName: string, tableName: string, @query max_results?: int32, @query page_token?: string): Ok<LineageNode> | ResourceErrorResponses;
 
 @route("/lineage/tables/{schemaName}/{tableName}/upstream")
 @get
+@tag("Lineage")
+@summary("Get upstream lineage")
 op getUpstreamLineage(schemaName: string, tableName: string, @query max_results?: int32, @query page_token?: string): Ok<PaginatedLineageEdges> | ResourceErrorResponses;
 
 @route("/lineage/tables/{schemaName}/{tableName}/downstream")
 @get
+@tag("Lineage")
+@summary("Get downstream lineage")
 op getDownstreamLineage(schemaName: string, tableName: string, @query max_results?: int32, @query page_token?: string): Ok<PaginatedLineageEdges> | ResourceErrorResponses;
 
 @route("/lineage/edges/{edgeId}")
 @delete
+@tag("Lineage")
+@summary("Delete lineage edge")
 op deleteLineageEdge(edgeId: string): NoContent | MutatingErrorResponses;
 
 @route("/lineage/columns/{schemaName}/{tableName}")
 @get
+@tag("Lineage")
+@summary("Get column lineage")
 op getColumnLineage(schemaName: string, tableName: string, @query max_results?: int32, @query page_token?: string): Ok<PaginatedColumnLineageEdges> | ResourceErrorResponses;
 
 @route("/lineage/columns/{schemaName}/{tableName}/{columnName}/impact")
 @get
+@tag("Lineage")
+@summary("Get column impact")
 op getColumnImpact(schemaName: string, tableName: string, columnName: string, @query max_results?: int32, @query page_token?: string): Ok<PaginatedColumnLineageEdges> | ResourceErrorResponses;
 
 @route("/lineage/purge")
 @post
+@tag("Lineage")
+@summary("Purge lineage")
 op purgeLineage(@body body: PurgeLineageRequest): Ok<PurgeLineageResponse> | MutatingErrorResponses;
 
 @route("/tags")
 @get
+@tag("Governance")
+@summary("List tags")
 op listTags(@query max_results?: int32, @query page_token?: string): Ok<PaginatedTags> | StandardErrorResponses;
 
 @route("/tags")
 @post
+@tag("Governance")
+@summary("Create tag")
 op createTag(@body body: CreateTagRequest): Created<Tag> | MutatingErrorResponses;
 
 @route("/tags/{tagId}")
 @delete
+@tag("Governance")
+@summary("Delete tag")
 op deleteTag(tagId: string): NoContent | MutatingErrorResponses;
 
 @route("/tags/{tagId}/assignments")
 @get
+@tag("Governance")
+@summary("List tag assignments")
 op listTagAssignments(
   tagId: string,
   @query max_results?: int32,
@@ -88,409 +130,615 @@ op listTagAssignments(
 
 @route("/tags/{tagId}/assignments")
 @post
+@tag("Governance")
+@summary("Create tag assignment")
 op createTagAssignment(tagId: string, @body body: CreateTagAssignmentRequest): Created<TagAssignment> | MutatingErrorResponses;
 
 @route("/tag-assignments/{assignmentId}")
 @delete
+@tag("Governance")
+@summary("Delete tag assignment")
 op deleteTagAssignment(assignmentId: string): NoContent | MutatingErrorResponses;
 
 @route("/classifications")
 @get
+@tag("Governance")
+@summary("List classifications")
 op listClassifications(@query max_results?: int32, @query page_token?: string): Ok<PaginatedTags> | StandardErrorResponses;
 
 @route("/storage-credentials")
 @get
+@tag("Storage")
+@summary("List storage credentials")
 op listStorageCredentials(@query max_results?: int32, @query page_token?: string): Ok<PaginatedStorageCredentials> | StandardErrorResponses;
 
 @route("/storage-credentials")
 @post
+@tag("Storage")
+@summary("Create storage credential")
+@doc("Creates a reusable storage credential that can be referenced by external locations and managed catalogs.")
 op createStorageCredential(@body body: CreateStorageCredentialRequest): Created<StorageCredential> | MutatingErrorResponses;
 
 @route("/storage-credentials/{credentialName}")
 @get
+@tag("Storage")
+@summary("Get storage credential")
 op getStorageCredential(credentialName: string): Ok<StorageCredential> | ResourceErrorResponses;
 
 @route("/storage-credentials/{credentialName}")
 @patch(#{ implicitOptionality: true })
+@tag("Storage")
+@summary("Update storage credential")
 op updateStorageCredential(credentialName: string, @body body: UpdateStorageCredentialRequest): Ok<StorageCredential> | MutatingErrorResponses;
 
 @route("/storage-credentials/{credentialName}")
 @delete
+@tag("Storage")
+@summary("Delete storage credential")
 op deleteStorageCredential(credentialName: string): NoContent | MutatingErrorResponses;
 
 @route("/external-locations")
 @get
+@tag("Storage")
+@summary("List external locations")
 op listExternalLocations(@query max_results?: int32, @query page_token?: string): Ok<PaginatedExternalLocations> | StandardErrorResponses;
 
 @route("/external-locations")
 @post
 @doc("Creates a new external location and configures DuckDB with the associated credential. Catalog registrations are managed separately; creating a location does not attach or create a DuckLake catalog.")
+@tag("Storage")
+@summary("Create external location")
 op createExternalLocation(@body body: CreateExternalLocationRequest): Created<ExternalLocation> | MutatingErrorResponses;
 
 @route("/external-locations/{locationName}")
 @get
+@tag("Storage")
+@summary("Get external location")
 op getExternalLocation(locationName: string): Ok<ExternalLocation> | ResourceErrorResponses;
 
 @route("/external-locations/{locationName}")
 @patch(#{ implicitOptionality: true })
+@tag("Storage")
+@summary("Update external location")
 op updateExternalLocation(locationName: string, @body body: UpdateExternalLocationRequest): Ok<ExternalLocation> | MutatingErrorResponses;
 
 @route("/external-locations/{locationName}")
 @delete
+@tag("Storage")
+@summary("Delete external location")
 op deleteExternalLocation(locationName: string): NoContent | MutatingErrorResponses;
 
 @route("/compute-endpoints")
 @get
+@tag("Compute")
+@summary("List compute endpoints")
 op listComputeEndpoints(@query max_results?: int32, @query page_token?: string): Ok<PaginatedComputeEndpoints> | StandardErrorResponses;
 
 @route("/compute-endpoints")
 @post
+@tag("Compute")
+@summary("Create compute endpoint")
+@doc("Registers a compute endpoint that can execute remote workloads and accept assignment-based routing.")
 op createComputeEndpoint(@body body: CreateComputeEndpointRequest): Created<ComputeEndpoint> | MutatingErrorResponses;
 
 @route("/compute-endpoints/{endpointName}")
 @get
+@tag("Compute")
+@summary("Get compute endpoint")
 op getComputeEndpoint(endpointName: string): Ok<ComputeEndpoint> | ResourceErrorResponses;
 
 @route("/compute-endpoints/{endpointName}")
 @patch(#{ implicitOptionality: true })
+@tag("Compute")
+@summary("Update compute endpoint")
 op updateComputeEndpoint(endpointName: string, @body body: UpdateComputeEndpointRequest): Ok<ComputeEndpoint> | MutatingErrorResponses;
 
 @route("/compute-endpoints/{endpointName}")
 @delete
+@tag("Compute")
+@summary("Delete compute endpoint")
 op deleteComputeEndpoint(endpointName: string): NoContent | MutatingErrorResponses;
 
 @route("/compute-endpoints/{endpointName}/assignments")
 @get
+@tag("Compute")
+@summary("List compute assignments")
 op listComputeAssignments(endpointName: string, @query max_results?: int32, @query page_token?: string): Ok<PaginatedComputeAssignments> | ResourceErrorResponses;
 
 @route("/compute-endpoints/{endpointName}/assignments")
 @post
+@tag("Compute")
+@summary("Create compute assignment")
 op createComputeAssignment(endpointName: string, @body body: CreateComputeAssignmentRequest): Created<ComputeAssignment> | MutatingErrorResponses;
 
 @route("/compute-endpoints/{endpointName}/health")
 @get
+@tag("Compute")
+@summary("Get compute endpoint health")
 op getComputeEndpointHealth(endpointName: string): Ok<ComputeEndpointHealth> | BadRequestResponse | ResourceErrorResponses | BadGatewayResponse;
 
 @route("/compute-endpoints/{endpointName}/assignments/{assignmentId}")
 @delete
+@tag("Compute")
+@summary("Delete compute assignment")
 op deleteComputeAssignment(endpointName: string, assignmentId: string): NoContent | MutatingErrorResponses;
 
 @route("/notebooks")
 @get
+@tag("Notebooks")
+@summary("List notebooks")
 op listNotebooks(@query owner?: string, @query max_results?: int32, @query page_token?: string): Ok<PaginatedNotebooks> | StandardErrorResponses;
 
 @route("/notebooks")
 @post
+@tag("Notebooks")
+@summary("Create notebook")
 op createNotebook(@body body: CreateNotebookRequest): Created<Notebook> | MutatingErrorResponses;
 
 @route("/notebooks/{notebookId}")
 @get
+@tag("Notebooks")
+@summary("Get notebook")
 op getNotebook(notebookId: string): Ok<NotebookDetail> | ResourceErrorResponses;
 
 @route("/notebooks/{notebookId}")
 @patch(#{ implicitOptionality: true })
+@tag("Notebooks")
+@summary("Update notebook")
 op updateNotebook(notebookId: string, @body body: UpdateNotebookRequest): Ok<Notebook> | MutatingErrorResponses;
 
 @route("/notebooks/{notebookId}")
 @delete
+@tag("Notebooks")
+@summary("Delete notebook")
 op deleteNotebook(notebookId: string): NoContent | MutatingErrorResponses;
 
 @route("/notebooks/{notebookId}/cells")
 @post
+@tag("Notebooks")
+@summary("Create cell")
 op createCell(notebookId: string, @body body: CreateCellRequest): Created<Cell> | MutatingErrorResponses;
 
 @route("/notebooks/{notebookId}/cells/reorder")
 @post
+@tag("Notebooks")
+@summary("Reorder cells")
 op reorderCells(notebookId: string, @body body: ReorderCellsRequest): Ok<CellList> | MutatingErrorResponses;
 
 @route("/notebooks/{notebookId}/cells/{cellId}")
 @patch(#{ implicitOptionality: true })
+@tag("Notebooks")
+@summary("Update cell")
 op updateCell(notebookId: string, cellId: string, @body body: UpdateCellRequest): Ok<Cell> | MutatingErrorResponses;
 
 @route("/notebooks/{notebookId}/cells/{cellId}")
 @delete
+@tag("Notebooks")
+@summary("Delete cell")
 op deleteCell(notebookId: string, cellId: string): NoContent | MutatingErrorResponses;
 
 @route("/notebooks/{notebookId}/sessions")
 @post
+@tag("Notebooks")
+@summary("Create notebook session")
 op createNotebookSession(notebookId: string): Created<NotebookSession> | MutatingErrorResponses;
 
 @route("/notebooks/{notebookId}/sessions/{sessionId}")
 @delete
+@tag("Notebooks")
+@summary("Close notebook session")
 op closeNotebookSession(notebookId: string, sessionId: string): NoContent | MutatingErrorResponses;
 
 @route("/notebooks/{notebookId}/sessions/{sessionId}/execute/{cellId}")
 @post
+@tag("Notebooks")
+@summary("Execute cell")
 op executeCell(notebookId: string, sessionId: string, cellId: string): Ok<CellExecutionResult> | MutatingErrorResponses;
 
 @route("/notebooks/{notebookId}/sessions/{sessionId}/run-all")
 @post
+@tag("Notebooks")
+@summary("Run all cells")
 op runAllCells(notebookId: string, sessionId: string): Ok<RunAllResult> | MutatingErrorResponses;
 
 @route("/notebooks/{notebookId}/sessions/{sessionId}/run-all-async")
 @post
+@tag("Notebooks")
+@summary("Run all cells asynchronously")
 op runAllCellsAsync(notebookId: string, sessionId: string): Accepted<NotebookJob> | MutatingErrorResponses;
 
 @route("/notebooks/{notebookId}/jobs")
 @get
+@tag("Notebooks")
+@summary("List notebook jobs")
 op listNotebookJobs(notebookId: string, @query max_results?: int32, @query page_token?: string): Ok<PaginatedNotebookJobs> | ResourceErrorResponses;
 
 @route("/notebooks/{notebookId}/jobs/{jobId}")
 @get
+@tag("Notebooks")
+@summary("Get notebook job")
 op getNotebookJob(notebookId: string, jobId: string): Ok<NotebookJob> | ResourceErrorResponses;
 
 @route("/git-repos")
 @get
+@tag("Integrations")
+@summary("List git repos")
 op listGitRepos(@query max_results?: int32, @query page_token?: string): Ok<PaginatedGitRepos> | StandardErrorResponses;
 
 @route("/git-repos")
 @post
+@tag("Integrations")
+@summary("Create git repo")
 op createGitRepo(@body body: CreateGitRepoRequest): Created<GitRepo> | MutatingErrorResponses;
 
 @route("/git-repos/{gitRepoId}")
 @get
+@tag("Integrations")
+@summary("Get git repo")
 op getGitRepo(gitRepoId: string): Ok<GitRepo> | ResourceErrorResponses;
 
 @route("/git-repos/{gitRepoId}")
 @delete
+@tag("Integrations")
+@summary("Delete git repo")
 op deleteGitRepo(gitRepoId: string): NoContent | MutatingErrorResponses;
 
 @route("/git-repos/{gitRepoId}/sync")
 @post
+@tag("Integrations")
+@summary("Sync git repo")
 op syncGitRepo(gitRepoId: string): Ok<GitSyncResult> | MutatingErrorResponses;
 
 @route("/pipelines")
 @get
+@tag("Pipelines")
+@summary("List pipelines")
 op listPipelines(@query max_results?: int32, @query page_token?: string): Ok<PaginatedPipelines> | StandardErrorResponses;
 
 @route("/pipelines")
 @post
+@tag("Pipelines")
+@summary("Create pipeline")
 op createPipeline(@body body: CreatePipelineRequest): Created<Pipeline> | MutatingErrorResponses;
 
 @route("/pipelines/{pipelineName}")
 @get
+@tag("Pipelines")
+@summary("Get pipeline")
 op getPipeline(pipelineName: string): Ok<Pipeline> | ResourceErrorResponses;
 
 @route("/pipelines/{pipelineName}")
 @patch(#{ implicitOptionality: true })
+@tag("Pipelines")
+@summary("Update pipeline")
 op updatePipeline(pipelineName: string, @body body: UpdatePipelineRequest): Ok<Pipeline> | MutatingErrorResponses;
 
 @route("/pipelines/{pipelineName}")
 @delete
+@tag("Pipelines")
+@summary("Delete pipeline")
 op deletePipeline(pipelineName: string): NoContent | MutatingErrorResponses;
 
 @route("/pipelines/{pipelineName}/jobs")
 @get
+@tag("Pipelines")
+@summary("List pipeline jobs")
 op listPipelineJobs(pipelineName: string): Ok<PipelineJobList> | ResourceErrorResponses;
 
 @route("/pipelines/{pipelineName}/jobs")
 @post
+@tag("Pipelines")
+@summary("Create pipeline job")
 op createPipelineJob(pipelineName: string, @body body: CreatePipelineJobRequest): Created<PipelineJob> | MutatingErrorResponses;
 
 @route("/pipelines/{pipelineName}/jobs/{jobId}")
 @delete
+@tag("Pipelines")
+@summary("Delete pipeline job")
 op deletePipelineJob(pipelineName: string, jobId: string): NoContent | MutatingErrorResponses;
 
 @route("/pipelines/{pipelineName}/runs")
 @post
+@tag("Pipelines")
+@summary("Trigger pipeline run")
 op triggerPipelineRun(pipelineName: string, @body body?: TriggerPipelineRunRequest): Ok<PipelineRun> | MutatingErrorResponses;
 
 @route("/pipelines/{pipelineName}/runs")
 @get
+@tag("Pipelines")
+@summary("List pipeline runs")
 op listPipelineRuns(pipelineName: string, @query max_results?: int32, @query page_token?: string, @query status?: string): Ok<PaginatedPipelineRuns> | ResourceErrorResponses;
 
 @route("/pipelines/runs/{runId}")
 @get
+@tag("Pipelines")
+@summary("Get pipeline run")
 op getPipelineRun(runId: string): Ok<PipelineRun> | ResourceErrorResponses;
 
 @route("/pipelines/runs/{runId}/cancel")
 @post
+@tag("Pipelines")
+@summary("Cancel pipeline run")
 op cancelPipelineRun(runId: string): Ok<PipelineRun> | MutatingErrorResponses;
 
 @route("/pipelines/runs/{runId}/jobs")
 @get
+@tag("Pipelines")
+@summary("List pipeline job runs")
 op listPipelineJobRuns(runId: string): Ok<PipelineJobRunList> | ResourceErrorResponses;
 
 @route("/models")
 @get
+@tag("Models")
+@summary("List models")
 op listModels(@query project_name?: string, @query max_results?: int32, @query page_token?: string): Ok<PaginatedModels> | StandardErrorResponses;
 
 @route("/models")
 @post
+@tag("Models")
+@summary("Create model")
 op createModel(@body body: CreateModelRequest): Created<Model> | MutatingErrorResponses;
 
 @route("/models/{projectName}/{modelName}")
 @get
+@tag("Models")
+@summary("Get model")
 op getModel(projectName: string, modelName: string): Ok<Model> | ResourceErrorResponses;
 
 @route("/models/{projectName}/{modelName}")
 @patch(#{ implicitOptionality: true })
+@tag("Models")
+@summary("Update model")
 op updateModel(projectName: string, modelName: string, @body body: UpdateModelRequest): Ok<Model> | MutatingErrorResponses;
 
 @route("/models/{projectName}/{modelName}")
 @delete
+@tag("Models")
+@summary("Delete model")
 op deleteModel(projectName: string, modelName: string): NoContent | MutatingErrorResponses;
 
 @route("/models/dag")
 @get
+@tag("Models")
+@summary("Get model DAG")
 op getModelDAG(@query project_name?: string): Ok<ModelDAG> | StandardErrorResponses;
 
 @route("/model-runs")
 @post
+@tag("Models")
+@summary("Trigger model run")
 op triggerModelRun(@body body: TriggerModelRunRequest): Created<ModelRun> | MutatingErrorResponses;
 
 @route("/model-runs")
 @get
+@tag("Models")
+@summary("List model runs")
 op listModelRuns(@query status?: string, @query max_results?: int32, @query page_token?: string): Ok<PaginatedModelRuns> | StandardErrorResponses;
 
 @route("/model-runs/{runId}")
 @get
+@tag("Models")
+@summary("Get model run")
 op getModelRun(runId: string): Ok<ModelRun> | ResourceErrorResponses;
 
 @route("/model-runs/{runId}/steps")
 @get
+@tag("Models")
+@summary("List model run steps")
 op listModelRunSteps(runId: string): Ok<ModelRunStepList> | ResourceErrorResponses;
 
 @route("/models/{projectName}/{modelName}/tests")
 @post
+@tag("Models")
+@summary("Create model test")
 op createModelTest(projectName: string, modelName: string, @body body: CreateModelTestRequest): Created<ModelTest> | MutatingErrorResponses;
 
 @route("/models/{projectName}/{modelName}/tests")
 @get
+@tag("Models")
+@summary("List model tests")
 op listModelTests(projectName: string, modelName: string): Ok<ModelTestList> | ResourceErrorResponses;
 
 @route("/models/{projectName}/{modelName}/tests/{testId}")
 @delete
+@tag("Models")
+@summary("Delete model test")
 op deleteModelTest(projectName: string, modelName: string, testId: string): NoContent | MutatingErrorResponses;
 
 @route("/model-runs/{runId}/steps/{stepId}/test-results")
 @get
+@tag("Models")
+@summary("List model test results")
 op listModelTestResults(runId: string, stepId: string): Ok<ModelTestResultList> | ResourceErrorResponses;
 
 @route("/models/{projectName}/{modelName}/freshness")
 @get
+@tag("Models")
+@summary("Check model freshness")
 op checkModelFreshness(projectName: string, modelName: string): Ok<FreshnessStatus> | ResourceErrorResponses;
 
 @route("/sources/{sourceSchema}/{sourceTable}/freshness")
 @get
+@tag("Semantic Layer")
+@summary("Check source freshness")
 op checkSourceFreshness(sourceSchema: string, sourceTable: string, @query timestamp_column?: string, @query max_lag_seconds?: int64): Ok<SourceFreshnessStatus> | ResourceErrorResponses;
 
 @route("/models/from-notebook")
 @post
+@tag("Models")
+@summary("Promote notebook to model")
 op promoteNotebookToModel(@body body: PromoteNotebookRequest): Created<Model> | MutatingErrorResponses;
 
 @route("/model-runs/{runId}/cancel")
 @post
+@tag("Models")
+@summary("Cancel model run")
 op cancelModelRun(runId: string): Ok<ModelRun> | MutatingErrorResponses;
 
 @route("/macros")
 @get
+@tag("Models")
+@summary("List macros")
 op listMacros(@query max_results?: int32, @query page_token?: string): Ok<PaginatedMacros> | StandardErrorResponses;
 
 @route("/macros")
 @post
+@tag("Models")
+@summary("Create macro")
 op createMacro(@body body: CreateMacroRequest): Created<Macro> | MutatingErrorResponses;
 
 @route("/macros/{macroName}")
 @get
+@tag("Models")
+@summary("Get macro")
 op getMacro(macroName: string): Ok<Macro> | ResourceErrorResponses;
 
 @route("/macros/{macroName}")
 @patch(#{ implicitOptionality: true })
+@tag("Models")
+@summary("Update macro")
 op updateMacro(macroName: string, @body body: UpdateMacroRequest): Ok<Macro> | MutatingErrorResponses;
 
 @route("/macros/{macroName}")
 @delete
+@tag("Models")
+@summary("Delete macro")
 op deleteMacro(macroName: string): NoContent | MutatingErrorResponses;
 
 @route("/macros/{macroName}/revisions")
 @get
+@tag("Models")
+@summary("List macro revisions")
 op listMacroRevisions(macroName: string): Ok<MacroRevisionList> | ResourceErrorResponses;
 
 @route("/macros/{macroName}/impact")
 @get
+@tag("Models")
+@summary("Get macro impact")
 op getMacroImpact(macroName: string, @query max_results?: int32, @query page_token?: string): Ok<MacroImpactList> | ResourceErrorResponses;
 
 @route("/macros/{macroName}/diff")
 @get
+@tag("Models")
+@summary("Diff macro revisions")
 op diffMacroRevisions(macroName: string, @query from_version: int32, @query to_version: int32): Ok<MacroRevisionDiff> | ResourceErrorResponses;
 
 @route("/semantic-models")
 @get
+@tag("Semantic Layer")
+@summary("List semantic models")
 op listSemanticModels(@query project_name?: string, @query max_results?: int32, @query page_token?: string): Ok<PaginatedSemanticModels> | StandardErrorResponses;
 
 @route("/semantic-models")
 @post
+@tag("Semantic Layer")
+@summary("Create semantic model")
 op createSemanticModel(@body body: CreateSemanticModelRequest): Created<SemanticModel> | MutatingErrorResponses;
 
 @route("/semantic-models/{projectName}/{semanticModelName}")
 @get
+@tag("Semantic Layer")
+@summary("Get semantic model")
 op getSemanticModel(projectName: string, semanticModelName: string): Ok<SemanticModel> | ResourceErrorResponses;
 
 @route("/semantic-models/{projectName}/{semanticModelName}")
 @patch(#{ implicitOptionality: true })
+@tag("Semantic Layer")
+@summary("Update semantic model")
 op updateSemanticModel(projectName: string, semanticModelName: string, @body body: UpdateSemanticModelRequest): Ok<SemanticModel> | MutatingErrorResponses;
 
 @route("/semantic-models/{projectName}/{semanticModelName}")
 @delete
+@tag("Semantic Layer")
+@summary("Delete semantic model")
 op deleteSemanticModel(projectName: string, semanticModelName: string): NoContent | MutatingErrorResponses;
 
 @route("/semantic-models/{projectName}/{semanticModelName}/metrics")
 @get
+@tag("Semantic Layer")
+@summary("List semantic metrics")
 op listSemanticMetrics(projectName: string, semanticModelName: string): Ok<SemanticMetricList> | ResourceErrorResponses;
 
 @route("/semantic-models/{projectName}/{semanticModelName}/metrics")
 @post
+@tag("Semantic Layer")
+@summary("Create semantic metric")
 op createSemanticMetric(projectName: string, semanticModelName: string, @body body: CreateSemanticMetricRequest): Created<SemanticMetric> | MutatingErrorResponses;
 
 @route("/semantic-models/{projectName}/{semanticModelName}/metrics/{metricName}")
 @patch(#{ implicitOptionality: true })
+@tag("Semantic Layer")
+@summary("Update semantic metric")
 op updateSemanticMetric(projectName: string, semanticModelName: string, metricName: string, @body body: UpdateSemanticMetricRequest): Ok<SemanticMetric> | MutatingErrorResponses;
 
 @route("/semantic-models/{projectName}/{semanticModelName}/metrics/{metricName}")
 @delete
+@tag("Semantic Layer")
+@summary("Delete semantic metric")
 op deleteSemanticMetric(projectName: string, semanticModelName: string, metricName: string): NoContent | MutatingErrorResponses;
 
 @route("/semantic-models/{projectName}/{semanticModelName}/pre-aggregations")
 @get
+@tag("Semantic Layer")
+@summary("List semantic pre aggregations")
 op listSemanticPreAggregations(projectName: string, semanticModelName: string): Ok<SemanticPreAggregationList> | ResourceErrorResponses;
 
 @route("/semantic-models/{projectName}/{semanticModelName}/pre-aggregations")
 @post
+@tag("Semantic Layer")
+@summary("Create semantic pre aggregation")
 op createSemanticPreAggregation(projectName: string, semanticModelName: string, @body body: CreateSemanticPreAggregationRequest): Created<SemanticPreAggregation> | MutatingErrorResponses;
 
 @route("/semantic-models/{projectName}/{semanticModelName}/pre-aggregations/{preAggregationName}")
 @patch(#{ implicitOptionality: true })
+@tag("Semantic Layer")
+@summary("Update semantic pre aggregation")
 op updateSemanticPreAggregation(projectName: string, semanticModelName: string, preAggregationName: string, @body body: UpdateSemanticPreAggregationRequest): Ok<SemanticPreAggregation> | MutatingErrorResponses;
 
 @route("/semantic-models/{projectName}/{semanticModelName}/pre-aggregations/{preAggregationName}")
 @delete
+@tag("Semantic Layer")
+@summary("Delete semantic pre aggregation")
 op deleteSemanticPreAggregation(projectName: string, semanticModelName: string, preAggregationName: string): NoContent | MutatingErrorResponses;
 
 @route("/semantic-relationships")
 @get
+@tag("Semantic Layer")
+@summary("List semantic relationships")
 op listSemanticRelationships(@query max_results?: int32, @query page_token?: string): Ok<PaginatedSemanticRelationships> | StandardErrorResponses;
 
 @route("/semantic-relationships")
 @post
+@tag("Semantic Layer")
+@summary("Create semantic relationship")
 op createSemanticRelationship(@body body: CreateSemanticRelationshipRequest): Created<SemanticRelationship> | MutatingErrorResponses;
 
 @route("/semantic-relationships/{relationshipName}")
 @patch(#{ implicitOptionality: true })
+@tag("Semantic Layer")
+@summary("Update semantic relationship")
 op updateSemanticRelationship(relationshipName: string, @body body: UpdateSemanticRelationshipRequest): Ok<SemanticRelationship> | MutatingErrorResponses;
 
 @route("/semantic-relationships/{relationshipName}")
 @delete
+@tag("Semantic Layer")
+@summary("Delete semantic relationship")
 op deleteSemanticRelationship(relationshipName: string): NoContent | MutatingErrorResponses;
 
 @route("/metric-queries:explain")
 @post
+@tag("Semantic Layer")
+@summary("Explain metric query")
 op explainMetricQuery(@body body: MetricQueryRequest): Ok<MetricQueryExplainResponse> | MutatingErrorResponses;
 
 @route("/metric-queries:run")
 @post
+@tag("Semantic Layer")
+@summary("Run metric query")
 op runMetricQuery(@body body: MetricQueryRequest): Ok<MetricQueryRunResponse> | MutatingErrorResponses;
 
 @route("/metrics/{metricName}/freshness")
 @get
+@tag("Semantic Layer")
+@summary("Check metric freshness")
 op checkMetricFreshness(metricName: string, @query project_name?: string, @query semantic_model_name?: string): Ok<MetricFreshnessStatus> | ResourceErrorResponses;

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -16,11 +16,11 @@ The generated API reference is the source of truth for request and response deta
 
 | Need | Start here |
 | --- | --- |
-| Query execution | [Duck Endpoint Index](/reference/generated/api/endpoints/duck) |
-| Identity and access | [Duck Endpoint Index](/reference/generated/api/endpoints/duck) |
-| Catalog and object management | [Duck Endpoint Index](/reference/generated/api/endpoints/duck) |
-| Data load paths | [Duck Endpoint Index](/reference/generated/api/endpoints/duck) |
-| Remote execution | [Duck Endpoint Index](/reference/generated/api/endpoints/duck) |
+| Query execution | [Queries Endpoint Index](/reference/generated/api/endpoints/queries) |
+| Identity and access | [Identity Endpoint Index](/reference/generated/api/endpoints/identity) and [Auth Endpoint Index](/reference/generated/api/endpoints/auth) |
+| Catalog and object management | [Catalogs Endpoint Index](/reference/generated/api/endpoints/catalogs) |
+| Data load paths | [Storage Endpoint Index](/reference/generated/api/endpoints/storage) |
+| Remote execution | [Compute Endpoint Index](/reference/generated/api/endpoints/compute) |
 
 ## When To Use Generated API Reference
 


### PR DESCRIPTION
# Production-Grade OpenAPI Upgrade Plan, Linter-Compatible

## Summary
Upgrade the TypeSpec-authored API contract to production-grade quality without violating the repo’s OpenAPI lint rules in [/Users/yacobolo/.codex/worktrees/4f70/main/pkg/apilint/ruleset.yaml](/Users/yacobolo/.codex/worktrees/4f70/main/pkg/apilint/ruleset.yaml). All changes should be made in TypeSpec and regenerated into [/Users/yacobolo/.codex/worktrees/4f70/main/api/gen/openapi.yaml](/Users/yacobolo/.codex/worktrees/4f70/main/api/gen/openapi.yaml).

Goal:
- Improve external docs, SDK ergonomics, and contract clarity while preserving current runtime behavior and passing the existing linter/parity checks.

## Key Changes
### 1. Service metadata and top-level contract
- Replace placeholder metadata in [/Users/yacobolo/.codex/worktrees/4f70/main/api/spec/main.tsp](/Users/yacobolo/.codex/worktrees/4f70/main/api/spec/main.tsp):
  - Real semantic version instead of `0.0.0`.
  - Real server URLs or server variables for supported environments.
  - Expanded service description.
- Replace the single `Duck` tag with domain tags, while keeping every operation tagged to satisfy `operation-tags`.
- Add tag descriptions only if TypeSpec emits them cleanly; do not hand-edit generated YAML.

### 2. Auth and authz semantics, without breaking lint
- Make `/healthz` explicitly public with `@useAuth([])`.
- Keep login/bootstrap endpoints public using the same empty-security pattern already emitted for auth endpoints.
- Preserve global bearer/API-key auth for all other operations.
- Preserve existing `x-authz` extensions and ensure critical mutating operations continue to satisfy:
  - `check-authz-metadata-present`
  - `check-authz-metadata-shape`
- Keep existing `401`, `403`, `429`, and `500` response coverage on protected/mutating endpoints.

### 3. Operation docs that align with the ruleset
- Add `@summary` to every operation. This directly satisfies the custom `operation-summary` rule.
- Add `@doc` to priority operations and shared schemas, but treat summaries as mandatory and long descriptions as secondary.
- Keep operation IDs stable and lowerCamelCase.
- Ensure every operation still declares at least one success response.

### 4. Schema hardening within current lint boundaries
- Keep request and response payloads referenced via named models only; do not introduce inline anonymous schemas because `check-schema-ref` warns on them.
- Preserve the shared `Error` schema for all error responses so `check-error-schema-ref` continues to pass.
- Evolve the `Error` model compatibly:
  - Additive fields only, such as stable string code or request ID, and only if runtime can emit them.
- Tighten obvious temporal parameters such as `query-history.from` and `query-history.to` to typed date/time scalars if they are truly timestamps.
- Add `readOnly`, `writeOnly`, and stronger `required` fields only where runtime guarantees already exist.

### 5. Pagination, create/delete, and resource conventions
- Preserve current pagination shape:
  - Paginated GET endpoints keep `max_results` and `page_token`.
  - `Paginated*` schemas keep `data` and `next_page_token`.
- Do not rename pagination fields.
- Keep create-style `POST` operations returning `201` where they are true creates.
- Keep `DELETE` operations returning `204`.
- Keep singular resource GETs returning `404`.

## Acceptance Criteria
- `task lint:api` passes with no new violations after regeneration.
- `task lint` passes if run as the broader gate.
- The generated spec no longer contains placeholder top-level metadata:
  - `info.version` is not `0.0.0`.
  - `servers` does not point only to `https://api.example.com/v1`.
- Every operation in the generated spec has:
  - At least one tag.
  - A lowerCamelCase `operationId`.
  - A `summary`.
  - At least one success response.
- `/healthz` is explicitly unauthenticated in the generated spec.
- Login/bootstrap endpoints remain explicitly public in the generated spec.
- All request bodies and response bodies continue to use `$ref` schemas rather than inline anonymous objects.
- All error responses continue to reference the shared `Error` schema.
- All paginated GET endpoints continue to satisfy the repo’s pagination lint rules:
  - `max_results` and `page_token` parameters are present.
  - Referenced `Paginated*` schemas contain `data` and `next_page_token`.
- All critical mutating operations that currently require `x-authz` still include valid `x-authz` metadata after regeneration.
- No existing operation path or `operationId` changes in the first pass unless there is a documented compatibility reason.
- Representative rendered docs for auth, query, catalog, asset, and compute endpoints show improved grouping and human-readable summaries.
- OpenAPI parity and authz parity tests that consume the generated spec continue to pass.

## Test Plan
- Regenerate the OpenAPI artifact from TypeSpec.
- Run `task lint:api` and fix all introduced warnings/errors.
- Run the parity tests that consume the generated spec, especially OpenAPI contract parity and authz contract parity tests.
- Spot-check the generated YAML for:
  - top-level metadata,
  - health/auth security requirements,
  - summaries,
  - tag grouping,
  - shared error schema refs,
  - pagination shape.
- Manually inspect rendered docs for auth, query, catalog, asset, and compute flows.

## Assumptions and Defaults
- The repo’s custom linter is the source of truth for compatibility; improvements must fit that ruleset rather than requiring rule changes.
- The first pass is additive and contract-hardening, not a public API redesign.
- Existing wire behavior remains authoritative; TypeSpec should document current runtime guarantees, not aspirational ones.
- If a desired improvement would require changing lint rules, defer it to a separate, explicit follow-up unless there is a strong product need.
