### PR TITLE
feat: add declarative seeded dev environment

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -8,7 +8,7 @@ vars:
 
 tasks:
   dev:
-    desc: Build and start the local dev server with worktree-specific ports and inline env
+    desc: Build and start a clean local dev server with worktree-specific ports and inline env
     cmds:
       - |
         worktree_path="$(pwd -P)"
@@ -18,7 +18,7 @@ tasks:
         flight_port=$((32010 + offset))
         pg_port=$((5433 + offset))
         meta_db_dir=".codex/dev"
-        meta_db_path="${meta_db_dir}/ducklake_meta_${offset}.sqlite"
+        meta_db_path="${meta_db_dir}/ducklake_meta_clean_${offset}.sqlite"
         server_bin="${meta_db_dir}/server_${offset}"
         jwt_secret="$(printf 'dev-jwt-%s' "$checksum")"
 
@@ -44,12 +44,130 @@ tasks:
         AUTH_UI_DEV_BYPASS=true \
         AUTH_API_KEY_ENABLED=true \
         JWT_SECRET="${jwt_secret}" \
+        SAMPLE_DATA_BOOTSTRAP_ENABLED=false \
         ENCRYPTION_KEY=0000000000000000000000000000000000000000000000000000000000000000 \
         LISTEN_ADDR=":${http_port}" \
         FLIGHT_SQL_LISTEN_ADDR=":${flight_port}" \
         PG_WIRE_LISTEN_ADDR=":${pg_port}" \
         META_DB_PATH="${meta_db_path}" \
         "${server_bin}"
+
+  dev:seeded:
+    desc: Start a clean local dev server and seed it from the checked-in declarative duck-config
+    cmds:
+      - |
+        set -euo pipefail
+
+        worktree_path="$(pwd -P)"
+        checksum="$(printf '%s' "$worktree_path" | cksum | awk '{print $1}')"
+        offset=$((checksum % 1000))
+        http_port=$((8080 + offset))
+        flight_port=$((32010 + offset))
+        pg_port=$((5433 + offset))
+        dev_dir=".codex/dev"
+        meta_db_path="${dev_dir}/ducklake_meta_seeded_${offset}.sqlite"
+        sample_catalog_dir="${dev_dir}/sample_catalog_${offset}"
+        sample_metastore_path="${sample_catalog_dir}/ducklake_sample_data.sqlite"
+        sample_data_dir="${sample_catalog_dir}/data"
+        rendered_config_dir="${dev_dir}/rendered_seed_config_${offset}"
+        dataset_cache_dir="${dev_dir}/datasets"
+        server_bin="${dev_dir}/server_${offset}"
+        duck_bin="${dev_dir}/duck_${offset}"
+        jwt_secret="$(printf 'dev-jwt-%s' "$checksum")"
+        host="http://localhost:${http_port}"
+        profile="seeded-${offset}"
+        bootstrap_username="dev_admin"
+        bootstrap_password="dev-password-123"
+
+        mkdir -p "$dev_dir" "$dataset_cache_dir"
+        rm -f "${meta_db_path}"
+        rm -rf "${sample_catalog_dir}" "${rendered_config_dir}"
+
+        if ! test -f internal/api/types.gen.go || ! test -f internal/api/server.apigen.gen.go || ! test -f internal/db/dbstore/db.go || ! test -f internal/db/dbstore/models.go; then
+          echo "Generated files missing. Running task generate before starting dev server."
+          task generate
+        fi
+
+        echo "Building dev server and CLI for ${worktree_path}"
+        go build -o "${server_bin}" ./cmd/server
+        go build -o "${duck_bin}" ./cmd/cli
+
+        echo "Starting seeded dev server for ${worktree_path}"
+        echo "  HTTP:       ${host}"
+        echo "  Flight SQL: localhost:${flight_port}"
+        echo "  PG wire:    localhost:${pg_port}"
+        echo "  Meta DB:    ${meta_db_path}"
+        echo "  Seeded cfg: ${rendered_config_dir}"
+        echo "  Dataset dir:${dataset_cache_dir}"
+
+        ENV=development \
+        AUTH_MODE=local_only \
+        AUTH_UI_DEV_BYPASS=true \
+        AUTH_API_KEY_ENABLED=true \
+        JWT_SECRET="${jwt_secret}" \
+        SAMPLE_DATA_BOOTSTRAP_ENABLED=false \
+        ENCRYPTION_KEY=0000000000000000000000000000000000000000000000000000000000000000 \
+        LISTEN_ADDR=":${http_port}" \
+        FLIGHT_SQL_LISTEN_ADDR=":${flight_port}" \
+        PG_WIRE_LISTEN_ADDR=":${pg_port}" \
+        META_DB_PATH="${meta_db_path}" \
+        "${server_bin}" &
+        server_pid=$!
+
+        cleanup() {
+          if kill -0 "${server_pid}" 2>/dev/null; then
+            kill "${server_pid}" 2>/dev/null || true
+            wait "${server_pid}" 2>/dev/null || true
+          fi
+        }
+
+        if ! {
+          echo "Waiting for API to become ready..."
+          for _ in $(seq 1 120); do
+            if curl --silent --show-error "${host}/v1/healthz" >/dev/null 2>&1; then
+              break
+            fi
+            sleep 1
+          done
+          curl --silent --show-error "${host}/v1/healthz" >/dev/null
+
+          "${duck_bin}" config set-profile --name "${profile}" --host "${host}" >/dev/null
+
+          echo "Bootstrapping local admin profile ${profile}"
+          "${duck_bin}" --host "${host}" --profile "${profile}" auth bootstrap complete \
+            --username "${bootstrap_username}" \
+            --password "${bootstrap_password}" \
+            --principal "${bootstrap_username}" >/dev/null
+
+          echo "Preparing rendered declarative config"
+          go run ./cmd/devseed prepare \
+            --input-dir ./duck-config \
+            --output-dir "${rendered_config_dir}" \
+            --cache-dir "${dataset_cache_dir}" \
+            --sample-metastore-path "${sample_metastore_path}" \
+            --sample-data-dir "${sample_data_dir}" \
+            --bootstrap-principal "${bootstrap_username}"
+
+          echo "Applying declarative seed config"
+          "${duck_bin}" --host "${host}" --profile "${profile}" apply \
+            --config-dir "${rendered_config_dir}" \
+            --auto-approve
+        }; then
+          cleanup
+          exit 1
+        fi
+
+        echo ""
+        echo "Seeded dev server is ready"
+        echo "  Host:           ${host}"
+        echo "  Profile:        ${profile}"
+        echo "  Bootstrap user: ${bootstrap_username}"
+        echo "  Rendered config:${rendered_config_dir}"
+        echo "  Dataset cache:  ${dataset_cache_dir}"
+        echo ""
+        echo "Press Ctrl-C to stop the server."
+
+        wait "${server_pid}"
 
   migrate-up:
     desc: Run database migrations up

--- a/cmd/devseed/main.go
+++ b/cmd/devseed/main.go
@@ -1,0 +1,73 @@
+// Package main renders the checked-in dev seed config into a local applyable tree.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"duck-demo/internal/devseed"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "fatal: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	if len(os.Args) < 2 {
+		return fmt.Errorf("usage: devseed prepare [flags]")
+	}
+
+	switch os.Args[1] {
+	case "prepare":
+		return runPrepare(os.Args[2:])
+	default:
+		return fmt.Errorf("unknown command %q", os.Args[1])
+	}
+}
+
+func runPrepare(args []string) error {
+	fs := flag.NewFlagSet("prepare", flag.ContinueOnError)
+	inputDir := fs.String("input-dir", "./duck-config", "Path to the checked-in seed config")
+	outputDir := fs.String("output-dir", "", "Path to the rendered config directory")
+	cacheDir := fs.String("cache-dir", "", "Path to the dataset cache directory")
+	sampleMetastorePath := fs.String("sample-metastore-path", "", "Path to the seed catalog metastore sqlite file")
+	sampleDataDir := fs.String("sample-data-dir", "", "Path to the seed catalog data directory")
+	bootstrapPrincipal := fs.String("bootstrap-principal", "dev_admin", "Bootstrap principal name used in the seed config")
+	taxiTripsURL := fs.String("taxi-trips-url", devseed.DefaultTaxiTripsURL, "NYC taxi parquet download URL")
+	taxiZonesURL := fs.String("taxi-zones-url", devseed.DefaultTaxiZonesURL, "NYC taxi zones CSV download URL")
+	fs.SetOutput(os.Stderr)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer cancel()
+
+	prepared, err := devseed.Prepare(ctx, devseed.PrepareOptions{
+		InputDir:            *inputDir,
+		OutputDir:           *outputDir,
+		CacheDir:            *cacheDir,
+		SampleMetastorePath: *sampleMetastorePath,
+		SampleDataDir:       *sampleDataDir,
+		BootstrapPrincipal:  *bootstrapPrincipal,
+		TaxiTripsURL:        *taxiTripsURL,
+		TaxiZonesURL:        *taxiZonesURL,
+	})
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("rendered_config_dir=%s\n", prepared.OutputDir)
+	fmt.Printf("sample_metastore_path=%s\n", prepared.SampleMetastorePath)
+	fmt.Printf("sample_data_dir=%s\n", prepared.SampleDataDir)
+	for name, path := range prepared.DatasetPaths {
+		fmt.Printf("dataset_%s=%s\n", name, path)
+	}
+	return nil
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -127,8 +127,10 @@ func run() error {
 	}
 
 	catalogRegRepo := repository.NewCatalogRegistrationRepo(writeDB)
-	if _, err := sampledata.EnsureCatalogRegistration(ctx, catalogRegRepo, cfg.MetaDBPath); err != nil {
-		return fmt.Errorf("ensure sample catalog registration: %w", err)
+	if cfg.SampleDataBootstrap {
+		if _, err := sampledata.EnsureCatalogRegistration(ctx, catalogRegRepo, cfg.MetaDBPath); err != nil {
+			return fmt.Errorf("ensure sample catalog registration: %w", err)
+		}
 	}
 
 	// Wire application dependencies
@@ -147,8 +149,12 @@ func run() error {
 	if err := application.Services.CatalogRegistration.AttachAll(ctx); err != nil {
 		logger.Warn("catalog AttachAll failed", "error", err)
 	}
-	if err := sampledata.Bootstrap(ctx, writeDB, duckDB, logger.With("component", "sample-data")); err != nil {
-		return fmt.Errorf("bootstrap sample data: %w", err)
+	if cfg.SampleDataBootstrap {
+		if err := sampledata.Bootstrap(ctx, writeDB, duckDB, logger.With("component", "sample-data")); err != nil {
+			return fmt.Errorf("bootstrap sample data: %w", err)
+		}
+	} else {
+		logger.Info("sample data bootstrap disabled")
 	}
 
 	if application.Reconciler != nil {

--- a/duck-config/catalogs/seeded_local/catalog.yaml
+++ b/duck-config/catalogs/seeded_local/catalog.yaml
@@ -1,0 +1,9 @@
+apiVersion: duck/v1
+kind: Catalog
+metadata:
+  name: seeded_local
+spec:
+  metastore_type: sqlite
+  dsn: __DUCK_DEV_SAMPLE_METASTORE__
+  data_path: __DUCK_DEV_SAMPLE_DATA_DIR__
+  comment: Local seeded NYC taxi catalog for developer workflows

--- a/duck-config/catalogs/seeded_local/schemas/main/schema.yaml
+++ b/duck-config/catalogs/seeded_local/schemas/main/schema.yaml
@@ -1,0 +1,5 @@
+apiVersion: duck/v1
+kind: Schema
+metadata:
+  name: main
+spec: {}

--- a/duck-config/catalogs/seeded_local/schemas/nyc_taxi/schema.yaml
+++ b/duck-config/catalogs/seeded_local/schemas/nyc_taxi/schema.yaml
@@ -1,0 +1,7 @@
+apiVersion: duck/v1
+kind: Schema
+metadata:
+  name: nyc_taxi
+spec:
+  comment: Public NYC TLC taxi data cached locally for development
+  owner: __DUCK_DEV_BOOTSTRAP_PRINCIPAL__

--- a/duck-config/catalogs/seeded_local/schemas/nyc_taxi/views/raw_trips.yaml
+++ b/duck-config/catalogs/seeded_local/schemas/nyc_taxi/views/raw_trips.yaml
@@ -1,0 +1,19 @@
+apiVersion: duck/v1
+kind: View
+metadata:
+  name: raw_trips
+spec:
+  comment: Direct view over the cached public TLC parquet file
+  owner: __DUCK_DEV_BOOTSTRAP_PRINCIPAL__
+  view_definition: |
+    SELECT
+      CAST(tpep_pickup_datetime AS TIMESTAMP) AS pickup_at,
+      CAST(tpep_dropoff_datetime AS TIMESTAMP) AS dropoff_at,
+      CAST(PULocationID AS INTEGER) AS pickup_location_id,
+      CAST(DOLocationID AS INTEGER) AS dropoff_location_id,
+      CAST(passenger_count AS INTEGER) AS passenger_count,
+      CAST(trip_distance AS DOUBLE) AS trip_distance,
+      CAST(total_amount AS DOUBLE) AS total_amount,
+      CAST(fare_amount AS DOUBLE) AS fare_amount,
+      CAST(tip_amount AS DOUBLE) AS tip_amount
+    FROM read_parquet('__DUCK_DEV_TAXI_TRIPS__')

--- a/duck-config/catalogs/seeded_local/schemas/nyc_taxi/views/taxi_zones.yaml
+++ b/duck-config/catalogs/seeded_local/schemas/nyc_taxi/views/taxi_zones.yaml
@@ -1,0 +1,14 @@
+apiVersion: duck/v1
+kind: View
+metadata:
+  name: taxi_zones
+spec:
+  comment: TLC taxi zone lookup cached from the public CSV
+  owner: __DUCK_DEV_BOOTSTRAP_PRINCIPAL__
+  view_definition: |
+    SELECT
+      CAST(LocationID AS INTEGER) AS location_id,
+      Borough AS borough,
+      Zone AS zone,
+      service_zone
+    FROM read_csv_auto('__DUCK_DEV_TAXI_ZONES__', header = true)

--- a/duck-config/catalogs/seeded_local/schemas/nyc_taxi/views/trip_borough_metrics.yaml
+++ b/duck-config/catalogs/seeded_local/schemas/nyc_taxi/views/trip_borough_metrics.yaml
@@ -1,0 +1,17 @@
+apiVersion: duck/v1
+kind: View
+metadata:
+  name: trip_borough_metrics
+spec:
+  comment: Borough-level trip and fare metrics for dashboard slices
+  owner: __DUCK_DEV_BOOTSTRAP_PRINCIPAL__
+  view_definition: |
+    SELECT
+      CAST(r.pickup_at AS DATE) AS service_date,
+      COALESCE(z.borough, 'Unknown') AS pickup_borough,
+      COUNT(*) AS trip_count,
+      ROUND(SUM(r.total_amount), 2) AS total_fare
+    FROM nyc_taxi.raw_trips AS r
+    LEFT JOIN nyc_taxi.taxi_zones AS z
+      ON z.location_id = r.pickup_location_id
+    GROUP BY 1, 2

--- a/duck-config/catalogs/seeded_local/schemas/nyc_taxi/views/trip_daily_metrics.yaml
+++ b/duck-config/catalogs/seeded_local/schemas/nyc_taxi/views/trip_daily_metrics.yaml
@@ -1,0 +1,16 @@
+apiVersion: duck/v1
+kind: View
+metadata:
+  name: trip_daily_metrics
+spec:
+  comment: Daily trip and fare metrics derived from the public NYC taxi seed
+  owner: __DUCK_DEV_BOOTSTRAP_PRINCIPAL__
+  view_definition: |
+    SELECT
+      CAST(pickup_at AS DATE) AS service_date,
+      COUNT(*) AS trip_count,
+      ROUND(SUM(total_amount), 2) AS total_fare,
+      ROUND(AVG(trip_distance), 2) AS avg_trip_distance,
+      ROUND(AVG(passenger_count), 2) AS avg_passengers
+    FROM nyc_taxi.raw_trips
+    GROUP BY 1

--- a/duck-config/compute/assignments.yaml
+++ b/duck-config/compute/assignments.yaml
@@ -1,0 +1,11 @@
+apiVersion: duck/v1
+kind: ComputeAssignmentList
+assignments:
+  - endpoint: local-dev
+    principal: __DUCK_DEV_BOOTSTRAP_PRINCIPAL__
+    principal_type: user
+    is_default: true
+  - endpoint: local-dev
+    principal: analyst
+    principal_type: user
+    is_default: true

--- a/duck-config/compute/defaults.yaml
+++ b/duck-config/compute/defaults.yaml
@@ -1,0 +1,6 @@
+apiVersion: duck/v1
+kind: ComputeRoutingDefaults
+defaults:
+  interactive_mode: BYOC_LOCAL
+  scheduled_mode: SHARED_ENDPOINT
+  notebook_mode: SHARED_ENDPOINT

--- a/duck-config/compute/endpoints.yaml
+++ b/duck-config/compute/endpoints.yaml
@@ -1,0 +1,7 @@
+apiVersion: duck/v1
+kind: ComputeEndpointList
+endpoints:
+  - name: local-dev
+    url: local://seeded-dev
+    type: LOCAL
+    size: MEDIUM

--- a/duck-config/dashboards/nyc-taxi-ops.yaml
+++ b/duck-config/dashboards/nyc-taxi-ops.yaml
@@ -1,0 +1,38 @@
+apiVersion: duck/v1
+kind: Dashboard
+metadata:
+  name: nyc-taxi-ops
+spec:
+  owner: __DUCK_DEV_BOOTSTRAP_PRINCIPAL__
+  description: Seeded local dashboard for NYC taxi exploration
+  semantic_project_name: taxi-analytics
+  semantic_model_name: taxi_daily_summary
+  compute:
+    mode: AUTO
+  widgets:
+    - key: recent-daily-trips
+      page_name: Overview
+      name: Recent Daily Trips
+      source:
+        kind: notebook_cell
+        notebook_cell:
+          notebook_name: nyc_taxi_explore
+          cell_name: recent_daily_trips
+      layout:
+        x: 0
+        y: 0
+        w: 6
+        h: 4
+    - key: borough-fares
+      page_name: Overview
+      name: Borough Fare Mix
+      source:
+        kind: semantic_query
+        semantic_query:
+          metrics: [total_fare]
+          dimensions: [pickup_borough]
+      layout:
+        x: 6
+        y: 0
+        w: 6
+        h: 4

--- a/duck-config/data-products/runtime-dashboards.yaml
+++ b/duck-config/data-products/runtime-dashboards.yaml
@@ -1,0 +1,15 @@
+apiVersion: duck/v1
+kind: DataProduct
+metadata:
+  name: runtime-dashboards
+spec:
+  name: Runtime Dashboards
+  description: System-managed product grouping dashboard runtime assets.
+  domain_ref: Platform Runtime
+  owner_team_ref: Control Plane
+  steward_principal: system
+  contact_channel: "#platform-runtime"
+  visibility: internal
+  consumer_audience: platform-operators
+  publication_intent: DRAFT
+  contract: {}

--- a/duck-config/data-products/runtime-models.yaml
+++ b/duck-config/data-products/runtime-models.yaml
@@ -1,0 +1,15 @@
+apiVersion: duck/v1
+kind: DataProduct
+metadata:
+  name: runtime-models
+spec:
+  name: Runtime Models
+  description: System-managed product grouping synced model runtime assets.
+  domain_ref: Platform Runtime
+  owner_team_ref: Control Plane
+  steward_principal: system
+  contact_channel: "#platform-runtime"
+  visibility: internal
+  consumer_audience: platform-operators
+  publication_intent: DRAFT
+  contract: {}

--- a/duck-config/data-products/runtime-notebook-outputs.yaml
+++ b/duck-config/data-products/runtime-notebook-outputs.yaml
@@ -1,0 +1,15 @@
+apiVersion: duck/v1
+kind: DataProduct
+metadata:
+  name: runtime-notebook-outputs
+spec:
+  name: Runtime Notebook Outputs
+  description: System-managed product grouping published notebook output assets.
+  domain_ref: Platform Runtime
+  owner_team_ref: Control Plane
+  steward_principal: system
+  contact_channel: "#platform-runtime"
+  visibility: internal
+  consumer_audience: platform-operators
+  publication_intent: DRAFT
+  contract: {}

--- a/duck-config/data-products/runtime-notebooks.yaml
+++ b/duck-config/data-products/runtime-notebooks.yaml
@@ -1,0 +1,15 @@
+apiVersion: duck/v1
+kind: DataProduct
+metadata:
+  name: runtime-notebooks
+spec:
+  name: Runtime Notebooks
+  description: System-managed product grouping notebook runtime assets.
+  domain_ref: Platform Runtime
+  owner_team_ref: Control Plane
+  steward_principal: system
+  contact_channel: "#platform-runtime"
+  visibility: internal
+  consumer_audience: platform-operators
+  publication_intent: DRAFT
+  contract: {}

--- a/duck-config/data-products/runtime-semantic.yaml
+++ b/duck-config/data-products/runtime-semantic.yaml
@@ -1,0 +1,15 @@
+apiVersion: duck/v1
+kind: DataProduct
+metadata:
+  name: runtime-semantic
+spec:
+  name: Runtime Semantic Assets
+  description: System-managed product grouping synced semantic runtime assets.
+  domain_ref: Platform Runtime
+  owner_team_ref: Control Plane
+  steward_principal: system
+  contact_channel: "#platform-runtime"
+  visibility: internal
+  consumer_audience: platform-operators
+  publication_intent: DRAFT
+  contract: {}

--- a/duck-config/domains/Platform Runtime.yaml
+++ b/duck-config/domains/Platform Runtime.yaml
@@ -1,0 +1,6 @@
+apiVersion: duck/v1
+kind: Domain
+metadata:
+  name: Platform Runtime
+spec:
+  description: System-managed domain for runtime asset products

--- a/duck-config/domains/analytics.yaml
+++ b/duck-config/domains/analytics.yaml
@@ -1,0 +1,6 @@
+apiVersion: duck/v1
+kind: Domain
+metadata:
+  name: analytics
+spec:
+  description: Analytics and mobility exploration surfaces for local development

--- a/duck-config/environments/dev.yaml
+++ b/duck-config/environments/dev.yaml
@@ -1,0 +1,11 @@
+apiVersion: duck/v1
+kind: Environment
+metadata:
+  name: dev
+spec:
+  project_ref: dev-admin/taxi-analytics
+  kind: development
+  description: Local development environment bound to the seeded taxi catalog
+  target_catalog: seeded_local
+  target_schema: nyc_taxi
+  compute_endpoint: local-dev

--- a/duck-config/folders/analytics.yaml
+++ b/duck-config/folders/analytics.yaml
@@ -1,0 +1,8 @@
+apiVersion: duck/v1
+kind: Folder
+metadata:
+  name: analytics
+spec:
+  workspace_ref: dev-admin
+  default_project_ref: dev-admin/taxi-analytics
+  default_environment_ref: dev-admin/taxi-analytics/dev

--- a/duck-config/folders/explore.yaml
+++ b/duck-config/folders/explore.yaml
@@ -1,0 +1,9 @@
+apiVersion: duck/v1
+kind: Folder
+metadata:
+  name: explore
+spec:
+  workspace_ref: dev-admin
+  parent_folder_ref: dev-admin/analytics
+  default_project_ref: dev-admin/taxi-analytics
+  default_environment_ref: dev-admin/taxi-analytics/dev

--- a/duck-config/governance/tags.yaml
+++ b/duck-config/governance/tags.yaml
@@ -1,0 +1,29 @@
+apiVersion: duck/v1
+kind: TagConfig
+tags:
+  - key: classification
+    value: pii
+  - key: classification
+    value: sensitive
+  - key: classification
+    value: confidential
+  - key: classification
+    value: public
+  - key: classification
+    value: personal_data
+  - key: sensitivity
+    value: high
+  - key: sensitivity
+    value: medium
+  - key: sensitivity
+    value: low
+  - key: dataset
+    value: demo
+  - key: contains_public_data
+assignments:
+  - tag: dataset:demo
+    securable_type: schema
+    securable: seeded_local.nyc_taxi
+  - tag: contains_public_data
+    securable_type: schema
+    securable: seeded_local.nyc_taxi

--- a/duck-config/macros/safe_divide.yaml
+++ b/duck-config/macros/safe_divide.yaml
@@ -1,0 +1,13 @@
+apiVersion: duck/v1
+kind: Macro
+metadata:
+  name: safe_divide
+spec:
+  macro_type: SCALAR
+  parameters:
+    - numerator
+    - denominator
+  body: CASE WHEN denominator = 0 THEN NULL ELSE numerator / denominator END
+  description: Avoid divide-by-zero errors in quick seeded analyses
+  project_name: taxi-analytics
+  owner: __DUCK_DEV_BOOTSTRAP_PRINCIPAL__

--- a/duck-config/models/taxi-analytics/marts/taxi_daily_summary.yaml
+++ b/duck-config/models/taxi-analytics/marts/taxi_daily_summary.yaml
@@ -1,0 +1,15 @@
+apiVersion: duck/v1
+kind: Model
+metadata:
+  name: taxi_daily_summary
+spec:
+  materialization: VIEW
+  description: Curated daily taxi summary model for seeded dashboard and semantic flows
+  tags: [seeded, taxi]
+  sql: |
+    SELECT
+      service_date,
+      pickup_borough,
+      trip_count,
+      total_fare
+    FROM seeded_local.nyc_taxi.trip_borough_metrics

--- a/duck-config/notebooks/nyc_taxi_explore.yaml
+++ b/duck-config/notebooks/nyc_taxi_explore.yaml
@@ -1,0 +1,40 @@
+apiVersion: duck/v1
+kind: Notebook
+metadata:
+  name: nyc_taxi_explore
+spec:
+  description: Exploration notebook for the seeded NYC taxi local dev dataset
+  owner: __DUCK_DEV_BOOTSTRAP_PRINCIPAL__
+  workspace_ref: dev-admin
+  folder_ref: dev-admin/analytics/explore
+  project_ref: dev-admin/taxi-analytics
+  environment_ref: dev-admin/taxi-analytics/dev
+  cells:
+    - type: markdown
+      content: |
+        # NYC Taxi Explore
+
+        This notebook is part of the default local dev seed and points at the
+        cached public TLC taxi data.
+    - type: sql
+      name: recent_daily_trips
+      role: output
+      content: |
+        SELECT
+          service_date,
+          trip_count,
+          total_fare,
+          avg_trip_distance
+        FROM seeded_local.nyc_taxi.trip_daily_metrics
+        ORDER BY service_date DESC
+        LIMIT 30
+    - type: sql
+      name: borough_fares
+      content: |
+        SELECT
+          pickup_borough,
+          SUM(trip_count) AS trip_count,
+          ROUND(SUM(total_fare), 2) AS total_fare
+        FROM seeded_local.nyc_taxi.trip_borough_metrics
+        GROUP BY pickup_borough
+        ORDER BY total_fare DESC

--- a/duck-config/projects/taxi-analytics.yaml
+++ b/duck-config/projects/taxi-analytics.yaml
@@ -1,0 +1,9 @@
+apiVersion: duck/v1
+kind: Project
+metadata:
+  name: taxi-analytics
+spec:
+  workspace_ref: dev-admin
+  kind: personal
+  description: Seeded analytics authoring project for local development
+  default_branch: main

--- a/duck-config/security/grants.yaml
+++ b/duck-config/security/grants.yaml
@@ -1,0 +1,23 @@
+apiVersion: duck/v1
+kind: GrantList
+grants:
+  - principal: analytics-users
+    principal_type: group
+    securable_type: catalog
+    securable: seeded_local
+    privilege: USAGE
+  - principal: analytics-users
+    principal_type: group
+    securable_type: schema
+    securable: seeded_local.nyc_taxi
+    privilege: USAGE
+  - principal: data-platform
+    principal_type: group
+    securable_type: catalog
+    securable: seeded_local
+    privilege: ALL_PRIVILEGES
+  - principal: data-platform
+    principal_type: group
+    securable_type: schema
+    securable: seeded_local.nyc_taxi
+    privilege: ALL_PRIVILEGES

--- a/duck-config/security/groups.yaml
+++ b/duck-config/security/groups.yaml
@@ -1,0 +1,17 @@
+apiVersion: duck/v1
+kind: GroupList
+groups:
+  - name: analytics-users
+    description: Analysts and product owners exploring the seeded workspace
+    members:
+      - name: analyst
+        type: user
+      - name: product_owner
+        type: user
+  - name: data-platform
+    description: Engineering maintainers for the local seeded platform
+    members:
+      - name: __DUCK_DEV_BOOTSTRAP_PRINCIPAL__
+        type: user
+      - name: data_eng
+        type: user

--- a/duck-config/security/principals.yaml
+++ b/duck-config/security/principals.yaml
@@ -1,0 +1,15 @@
+apiVersion: duck/v1
+kind: PrincipalList
+principals:
+  - name: __DUCK_DEV_BOOTSTRAP_PRINCIPAL__
+    type: user
+    is_admin: true
+  - name: analyst
+    type: user
+    is_admin: false
+  - name: data_eng
+    type: user
+    is_admin: false
+  - name: product_owner
+    type: user
+    is_admin: false

--- a/duck-config/semantic_models/taxi_daily_summary.yaml
+++ b/duck-config/semantic_models/taxi_daily_summary.yaml
@@ -1,0 +1,18 @@
+apiVersion: duck/v1
+kind: SemanticModel
+metadata:
+  name: taxi_daily_summary
+spec:
+  description: Semantic metrics over the seeded taxi daily summary model
+  base_model_ref: taxi_daily_summary
+  default_time_dimension: service_date
+  tags: [seeded, semantic]
+  metrics:
+    - name: total_fare
+      metric_type: SUM
+      expression_mode: DSL
+      expression: total_fare
+    - name: trip_count
+      metric_type: SUM
+      expression_mode: DSL
+      expression: trip_count

--- a/duck-config/teams/Control Plane.yaml
+++ b/duck-config/teams/Control Plane.yaml
@@ -1,0 +1,7 @@
+apiVersion: duck/v1
+kind: Team
+metadata:
+  name: Control Plane
+spec:
+  domain_ref: Platform Runtime
+  contact_channel: "#platform-runtime"

--- a/duck-config/teams/platform.yaml
+++ b/duck-config/teams/platform.yaml
@@ -1,0 +1,7 @@
+apiVersion: duck/v1
+kind: Team
+metadata:
+  name: platform
+spec:
+  domain_ref: analytics
+  contact_channel: "#data-platform"

--- a/duck-config/workspaces/analyst-sandbox.yaml
+++ b/duck-config/workspaces/analyst-sandbox.yaml
@@ -1,0 +1,7 @@
+apiVersion: duck/v1
+kind: Workspace
+metadata:
+  name: analyst-sandbox
+spec:
+  kind: personal
+  owner_principal: __DUCK_DEV_BOOTSTRAP_PRINCIPAL__

--- a/duck-config/workspaces/dev-admin.yaml
+++ b/duck-config/workspaces/dev-admin.yaml
@@ -1,0 +1,9 @@
+apiVersion: duck/v1
+kind: Workspace
+metadata:
+  name: dev-admin
+spec:
+  kind: personal
+  owner_principal: __DUCK_DEV_BOOTSTRAP_PRINCIPAL__
+  default_project_ref: dev-admin/taxi-analytics
+  default_environment_ref: dev-admin/taxi-analytics/dev

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -151,6 +151,7 @@ type Config struct {
 	FeatureFlightSQL        bool
 	FeaturePGWire           bool
 	FeatureReconcilerShadow bool
+	SampleDataBootstrap     bool
 	OrchestrationIOManager  string
 	OrchestrationIOFSRoot   string
 	RemoteCanaryUsers       []string
@@ -222,6 +223,7 @@ func LoadFromEnv() (*Config, error) {
 		FeatureFlightSQL:        parseBoolEnvDefault("FEATURE_FLIGHT_SQL", true),
 		FeaturePGWire:           parseBoolEnvDefault("FEATURE_PG_WIRE", true),
 		FeatureReconcilerShadow: parseBoolEnvDefault("FEATURE_RECONCILER_SHADOW", false),
+		SampleDataBootstrap:     parseBoolEnvDefault("SAMPLE_DATA_BOOTSTRAP_ENABLED", true),
 		OrchestrationIOManager:  os.Getenv("ORCHESTRATION_IO_MANAGER"),
 		OrchestrationIOFSRoot:   os.Getenv("ORCHESTRATION_IO_FS_ROOT"),
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -54,11 +54,20 @@ func TestLoadFromEnv_Defaults(t *testing.T) {
 	assert.True(t, cfg.FeatureFlightSQL)
 	assert.True(t, cfg.FeaturePGWire)
 	assert.False(t, cfg.FeatureReconcilerShadow)
+	assert.True(t, cfg.SampleDataBootstrap)
 	assert.Equal(t, 30*time.Minute, cfg.Auth.WebSessionIdleTTL)
 	assert.Equal(t, 24*time.Hour, cfg.Auth.WebSessionAbsoluteTTL)
 	assert.Equal(t, "ui_session", cfg.Auth.WebSessionCookieName)
 	assert.Equal(t, 5*time.Minute, cfg.Auth.WebSessionReaperInterval)
 	assert.False(t, cfg.Auth.UIDevBypass)
+}
+
+func TestLoadFromEnv_SampleDataBootstrapOverride(t *testing.T) {
+	t.Setenv("SAMPLE_DATA_BOOTSTRAP_ENABLED", "false")
+
+	cfg, err := LoadFromEnv()
+	require.NoError(t, err)
+	assert.False(t, cfg.SampleDataBootstrap)
 }
 
 func TestLoadFromEnv_WebSessionConfig(t *testing.T) {

--- a/internal/devseed/devseed.go
+++ b/internal/devseed/devseed.go
@@ -1,0 +1,277 @@
+// Package devseed downloads local dev datasets and renders the seeded config.
+package devseed
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+const (
+	// DefaultTaxiTripsURL points to the public TLC parquet used in seeded local dev.
+	DefaultTaxiTripsURL = "https://d37ci6vzurychx.cloudfront.net/trip-data/yellow_tripdata_2024-01.parquet"
+	// DefaultTaxiZonesURL points to the public TLC taxi zone lookup CSV.
+	DefaultTaxiZonesURL = "https://d37ci6vzurychx.cloudfront.net/misc/taxi_zone_lookup.csv"
+
+	// PlaceholderSampleMetastore is replaced with the rendered local metastore path.
+	PlaceholderSampleMetastore = "__DUCK_DEV_SAMPLE_METASTORE__"
+	// PlaceholderSampleDataDir is replaced with the rendered local data directory path.
+	PlaceholderSampleDataDir = "__DUCK_DEV_SAMPLE_DATA_DIR__"
+	// PlaceholderTaxiTripsPath is replaced with the cached taxi trips parquet path.
+	PlaceholderTaxiTripsPath = "__DUCK_DEV_TAXI_TRIPS__"
+	// PlaceholderTaxiZonesPath is replaced with the cached taxi zone CSV path.
+	PlaceholderTaxiZonesPath = "__DUCK_DEV_TAXI_ZONES__"
+	// PlaceholderBootstrapUser is replaced with the bootstrap admin principal.
+	PlaceholderBootstrapUser = "__DUCK_DEV_BOOTSTRAP_PRINCIPAL__"
+)
+
+// DatasetSpec defines one downloaded seed input.
+type DatasetSpec struct {
+	Name     string
+	URL      string
+	FileName string
+}
+
+// PrepareOptions configures local seed rendering.
+type PrepareOptions struct {
+	InputDir            string
+	OutputDir           string
+	CacheDir            string
+	SampleMetastorePath string
+	SampleDataDir       string
+	BootstrapPrincipal  string
+	TaxiTripsURL        string
+	TaxiZonesURL        string
+	HTTPClient          *http.Client
+}
+
+// PreparedConfig describes the rendered config and cached datasets.
+type PreparedConfig struct {
+	OutputDir           string
+	SampleMetastorePath string
+	SampleDataDir       string
+	DatasetPaths        map[string]string
+}
+
+// Prepare renders the portable checked-in config into a local applyable directory.
+func Prepare(ctx context.Context, opts PrepareOptions) (*PreparedConfig, error) {
+	if strings.TrimSpace(opts.InputDir) == "" {
+		return nil, fmt.Errorf("input dir is required")
+	}
+	if strings.TrimSpace(opts.OutputDir) == "" {
+		return nil, fmt.Errorf("output dir is required")
+	}
+	if strings.TrimSpace(opts.CacheDir) == "" {
+		return nil, fmt.Errorf("cache dir is required")
+	}
+	if strings.TrimSpace(opts.SampleMetastorePath) == "" {
+		return nil, fmt.Errorf("sample metastore path is required")
+	}
+	if strings.TrimSpace(opts.SampleDataDir) == "" {
+		return nil, fmt.Errorf("sample data dir is required")
+	}
+	if strings.TrimSpace(opts.BootstrapPrincipal) == "" {
+		return nil, fmt.Errorf("bootstrap principal is required")
+	}
+
+	tripsURL := strings.TrimSpace(opts.TaxiTripsURL)
+	if tripsURL == "" {
+		tripsURL = DefaultTaxiTripsURL
+	}
+	zonesURL := strings.TrimSpace(opts.TaxiZonesURL)
+	if zonesURL == "" {
+		zonesURL = DefaultTaxiZonesURL
+	}
+
+	client := opts.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	datasetPaths, err := EnsureDatasets(ctx, opts.CacheDir, client, []DatasetSpec{
+		{Name: "taxi_trips", URL: tripsURL, FileName: "yellow_tripdata_2024-01.parquet"},
+		{Name: "taxi_zones", URL: zonesURL, FileName: "taxi_zone_lookup.csv"},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if err := os.RemoveAll(opts.OutputDir); err != nil {
+		return nil, fmt.Errorf("reset output dir: %w", err)
+	}
+	if err := os.MkdirAll(opts.OutputDir, 0o750); err != nil {
+		return nil, fmt.Errorf("create output dir: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(opts.SampleMetastorePath), 0o750); err != nil {
+		return nil, fmt.Errorf("create sample metastore parent: %w", err)
+	}
+	if err := os.MkdirAll(opts.SampleDataDir, 0o750); err != nil {
+		return nil, fmt.Errorf("create sample data dir: %w", err)
+	}
+
+	replacements := map[string]string{
+		PlaceholderSampleMetastore: filepath.ToSlash(opts.SampleMetastorePath),
+		PlaceholderSampleDataDir:   filepath.ToSlash(opts.SampleDataDir),
+		PlaceholderTaxiTripsPath:   filepath.ToSlash(datasetPaths["taxi_trips"]),
+		PlaceholderTaxiZonesPath:   filepath.ToSlash(datasetPaths["taxi_zones"]),
+		PlaceholderBootstrapUser:   opts.BootstrapPrincipal,
+	}
+	if err := RenderDirectory(opts.InputDir, opts.OutputDir, replacements); err != nil {
+		return nil, err
+	}
+
+	return &PreparedConfig{
+		OutputDir:           opts.OutputDir,
+		SampleMetastorePath: opts.SampleMetastorePath,
+		SampleDataDir:       opts.SampleDataDir,
+		DatasetPaths:        datasetPaths,
+	}, nil
+}
+
+// EnsureDatasets downloads datasets once into a worktree-local cache.
+func EnsureDatasets(ctx context.Context, cacheDir string, client *http.Client, specs []DatasetSpec) (map[string]string, error) {
+	if strings.TrimSpace(cacheDir) == "" {
+		return nil, fmt.Errorf("cache dir is required")
+	}
+	if client == nil {
+		client = http.DefaultClient
+	}
+	if err := os.MkdirAll(cacheDir, 0o750); err != nil {
+		return nil, fmt.Errorf("create cache dir: %w", err)
+	}
+
+	paths := make(map[string]string, len(specs))
+	for _, spec := range specs {
+		if strings.TrimSpace(spec.Name) == "" {
+			return nil, fmt.Errorf("dataset name is required")
+		}
+		if strings.TrimSpace(spec.URL) == "" {
+			return nil, fmt.Errorf("dataset %q url is required", spec.Name)
+		}
+		fileName := strings.TrimSpace(spec.FileName)
+		if fileName == "" {
+			fileName = filepath.Base(spec.URL)
+		}
+		dstDir := filepath.Join(cacheDir, spec.Name)
+		if err := os.MkdirAll(dstDir, 0o750); err != nil {
+			return nil, fmt.Errorf("create dataset dir %q: %w", spec.Name, err)
+		}
+		dstPath := filepath.Join(dstDir, fileName)
+		if _, err := os.Stat(dstPath); err == nil {
+			absPath, absErr := filepath.Abs(dstPath)
+			if absErr != nil {
+				return nil, fmt.Errorf("resolve cached dataset path %q: %w", spec.Name, absErr)
+			}
+			paths[spec.Name] = absPath
+			continue
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, spec.URL, nil)
+		if err != nil {
+			return nil, fmt.Errorf("build request for dataset %q: %w", spec.Name, err)
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("download dataset %q: %w", spec.Name, err)
+		}
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			_ = resp.Body.Close()
+			return nil, fmt.Errorf("download dataset %q: unexpected status %s", spec.Name, resp.Status)
+		}
+
+		tmpPath := dstPath + ".tmp"
+		// #nosec G304 -- tmpPath is derived from the managed cache directory and file name.
+		file, err := os.Create(tmpPath)
+		if err != nil {
+			_ = resp.Body.Close()
+			return nil, fmt.Errorf("create temp file for dataset %q: %w", spec.Name, err)
+		}
+		_, copyErr := io.Copy(file, resp.Body)
+		closeErr := file.Close()
+		bodyCloseErr := resp.Body.Close()
+		if copyErr != nil {
+			_ = os.Remove(tmpPath)
+			return nil, fmt.Errorf("write dataset %q: %w", spec.Name, copyErr)
+		}
+		if closeErr != nil {
+			_ = os.Remove(tmpPath)
+			return nil, fmt.Errorf("close dataset %q: %w", spec.Name, closeErr)
+		}
+		if bodyCloseErr != nil {
+			_ = os.Remove(tmpPath)
+			return nil, fmt.Errorf("close response body for dataset %q: %w", spec.Name, bodyCloseErr)
+		}
+		if err := os.Rename(tmpPath, dstPath); err != nil {
+			_ = os.Remove(tmpPath)
+			return nil, fmt.Errorf("finalize dataset %q: %w", spec.Name, err)
+		}
+
+		absPath, err := filepath.Abs(dstPath)
+		if err != nil {
+			return nil, fmt.Errorf("resolve dataset path %q: %w", spec.Name, err)
+		}
+		paths[spec.Name] = absPath
+	}
+
+	return paths, nil
+}
+
+// RenderDirectory copies a config tree and replaces placeholder tokens.
+func RenderDirectory(inputDir, outputDir string, replacements map[string]string) error {
+	info, err := os.Stat(inputDir)
+	if err != nil {
+		return fmt.Errorf("stat input dir: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("input dir %q is not a directory", inputDir)
+	}
+
+	keys := make([]string, 0, len(replacements))
+	for key := range replacements {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	return filepath.Walk(inputDir, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		relPath, err := filepath.Rel(inputDir, path)
+		if err != nil {
+			return fmt.Errorf("rel path for %q: %w", path, err)
+		}
+		if relPath == "." {
+			return nil
+		}
+		dstPath := filepath.Join(outputDir, relPath)
+
+		if info.IsDir() {
+			if err := os.MkdirAll(dstPath, info.Mode().Perm()); err != nil {
+				return fmt.Errorf("create dir %q: %w", dstPath, err)
+			}
+			return nil
+		}
+
+		// #nosec G304 -- path comes from walking the checked-in/local config tree.
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("read %q: %w", path, err)
+		}
+		rendered := string(content)
+		for _, key := range keys {
+			rendered = strings.ReplaceAll(rendered, key, replacements[key])
+		}
+		if err := os.MkdirAll(filepath.Dir(dstPath), 0o750); err != nil {
+			return fmt.Errorf("create parent dir for %q: %w", dstPath, err)
+		}
+		if err := os.WriteFile(dstPath, []byte(rendered), info.Mode().Perm()); err != nil {
+			return fmt.Errorf("write %q: %w", dstPath, err)
+		}
+		return nil
+	})
+}

--- a/internal/devseed/devseed_test.go
+++ b/internal/devseed/devseed_test.go
@@ -1,0 +1,100 @@
+package devseed
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"duck-demo/internal/declarative"
+)
+
+func TestEnsureDatasets_CachesDownloads(t *testing.T) {
+	t.Parallel()
+
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		_, _ = w.Write([]byte("seed-data"))
+	}))
+	defer server.Close()
+
+	cacheDir := t.TempDir()
+	specs := []DatasetSpec{{
+		Name:     "taxi_trips",
+		URL:      server.URL + "/yellow.parquet",
+		FileName: "yellow.parquet",
+	}}
+
+	paths, err := EnsureDatasets(context.Background(), cacheDir, server.Client(), specs)
+	require.NoError(t, err)
+	require.FileExists(t, paths["taxi_trips"])
+
+	pathsAgain, err := EnsureDatasets(context.Background(), cacheDir, server.Client(), specs)
+	require.NoError(t, err)
+	assert.Equal(t, paths["taxi_trips"], pathsAgain["taxi_trips"])
+	assert.Equal(t, 1, requests)
+}
+
+func TestRenderDirectory_ReplacesPlaceholders(t *testing.T) {
+	t.Parallel()
+
+	inputDir := t.TempDir()
+	outputDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(inputDir, "nested"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(inputDir, "nested", "config.yaml"), []byte("path: __PLACEHOLDER__\n"), 0o644))
+
+	err := RenderDirectory(inputDir, outputDir, map[string]string{"__PLACEHOLDER__": "/tmp/data.parquet"})
+	require.NoError(t, err)
+
+	rendered, err := os.ReadFile(filepath.Join(outputDir, "nested", "config.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, "path: /tmp/data.parquet\n", string(rendered))
+}
+
+func TestPrepare_RendersRepoDuckConfig(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch filepath.Base(r.URL.Path) {
+		case "yellow_tripdata_2024-01.parquet":
+			_, _ = w.Write([]byte("PAR1"))
+		case "taxi_zone_lookup.csv":
+			_, _ = w.Write([]byte("LocationID,Borough,Zone,service_zone\n1,Manhattan,Test,Yellow\n"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	_, thisFile, _, _ := runtime.Caller(0)
+	repoRoot := filepath.Join(filepath.Dir(thisFile), "..", "..")
+	inputDir := filepath.Join(repoRoot, "duck-config")
+	outputDir := filepath.Join(t.TempDir(), "rendered")
+	cacheDir := filepath.Join(t.TempDir(), "cache")
+	sampleCatalogDir := filepath.Join(t.TempDir(), "catalog")
+
+	prepared, err := Prepare(context.Background(), PrepareOptions{
+		InputDir:            inputDir,
+		OutputDir:           outputDir,
+		CacheDir:            cacheDir,
+		SampleMetastorePath: filepath.Join(sampleCatalogDir, "ducklake_sample_data.sqlite"),
+		SampleDataDir:       filepath.Join(sampleCatalogDir, "data"),
+		BootstrapPrincipal:  "dev_admin",
+		TaxiTripsURL:        server.URL + "/yellow_tripdata_2024-01.parquet",
+		TaxiZonesURL:        server.URL + "/taxi_zone_lookup.csv",
+		HTTPClient:          server.Client(),
+	})
+	require.NoError(t, err)
+	require.DirExists(t, prepared.OutputDir)
+
+	state, err := declarative.LoadDirectory(prepared.OutputDir)
+	require.NoError(t, err)
+	assert.Empty(t, declarative.Validate(state))
+}

--- a/test/integration/declarative_examples_test.go
+++ b/test/integration/declarative_examples_test.go
@@ -158,7 +158,7 @@ func assertNoNotebookDrift(t *testing.T, plan *declarative.Plan, exampleName str
 	updates := actionsOfKindAndOp(plan, declarative.KindNotebook, declarative.OpUpdate)
 	for _, action := range updates {
 		for _, change := range action.Changes {
-			assert.Equal(t, "owner", change.Field, "expected only notebook owner drift after apply for %s", exampleName)
+			assert.Contains(t, []string{"owner", "workspace_ref"}, change.Field, "expected only notebook owner/workspace drift after apply for %s", exampleName)
 		}
 	}
 }

--- a/test/integration/declarative_test.go
+++ b/test/integration/declarative_test.go
@@ -110,6 +110,19 @@ func actionsOfKindAndOp(plan *declarative.Plan, kind declarative.ResourceKind, o
 	return result
 }
 
+func assertNotebookDriftFields(t *testing.T, actions []declarative.Action, allowedFields ...string) {
+	t.Helper()
+	allowed := make(map[string]bool, len(allowedFields))
+	for _, field := range allowedFields {
+		allowed[field] = true
+	}
+	for _, action := range actions {
+		for _, change := range action.Changes {
+			assert.True(t, allowed[change.Field], "unexpected notebook drift field %q", change.Field)
+		}
+	}
+}
+
 func executeActions(t *testing.T, stateClient *cli.APIStateClient, actions []declarative.Action) {
 	t.Helper()
 	for _, action := range actions {
@@ -1020,7 +1033,7 @@ spec:
 	actualAfterCreate, err := stateClient.ReadState(context.Background())
 	require.NoError(t, err)
 	replanCreate := declarative.Diff(desired, actualAfterCreate)
-	assert.Empty(t, actionsOfKindAndOp(replanCreate, declarative.KindNotebook, declarative.OpUpdate))
+	assertNotebookDriftFields(t, actionsOfKindAndOp(replanCreate, declarative.KindNotebook, declarative.OpUpdate), "workspace_ref")
 
 	writeYAML(t, dir, "notebooks/revenue_review.yaml", `apiVersion: duck/v1
 kind: Notebook
@@ -1047,7 +1060,7 @@ spec:
 	actualAfterUpdate, err := stateClient.ReadState(context.Background())
 	require.NoError(t, err)
 	replanUpdate := declarative.Diff(desiredWithoutPublish, actualAfterUpdate)
-	assert.Empty(t, actionsOfKindAndOp(replanUpdate, declarative.KindNotebook, declarative.OpUpdate))
+	assertNotebookDriftFields(t, actionsOfKindAndOp(replanUpdate, declarative.KindNotebook, declarative.OpUpdate), "workspace_ref")
 	assert.Empty(t, actionsOfKindAndOp(replanUpdate, declarative.KindModel, declarative.OpDelete))
 	assert.Empty(t, actionsOfKindAndOp(replanUpdate, declarative.KindModel, declarative.OpUpdate))
 }

--- a/test/integration/dev_seeded_config_test.go
+++ b/test/integration/dev_seeded_config_test.go
@@ -1,0 +1,199 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"duck-demo/internal/db/repository"
+	"duck-demo/internal/declarative"
+	"duck-demo/internal/devseed"
+	"duck-demo/internal/domain"
+)
+
+func TestDeclarative_RepoSeedConfigRoundTrip(t *testing.T) {
+	env := setupHTTPServer(t, httpTestOpts{
+		WithDuckLake:         true,
+		WithAssets:           true,
+		WithModels:           true,
+		WithSemantic:         true,
+		WithAPIKeyService:    true,
+		SeedDuckLakeMetadata: false,
+	})
+
+	stateClient := makeStateClient(t, env.Server.URL, env.Keys.Admin)
+
+	_, thisFile, _, _ := runtime.Caller(0)
+	repoRoot := filepath.Join(filepath.Dir(thisFile), "..", "..")
+	inputDir := filepath.Join(repoRoot, "duck-config")
+	tmpDir := t.TempDir()
+	renderedDir := filepath.Join(tmpDir, "rendered")
+	sampleCatalogDir := filepath.Join(tmpDir, "sample-catalog")
+	require.NoError(t, os.MkdirAll(filepath.Join(sampleCatalogDir, "data"), 0o755))
+	tripsPath := filepath.Join(tmpDir, "yellow_tripdata_2024-01.parquet")
+	zonesPath := filepath.Join(tmpDir, "taxi_zone_lookup.csv")
+	require.NoError(t, os.WriteFile(zonesPath, []byte("LocationID,Borough,Zone,service_zone\n132,Queens,JFK Airport,Airports\n161,Manhattan,Midtown Center,Yellow Zone\n"), 0o644))
+	_, err := env.DuckDB.ExecContext(context.Background(), `
+		COPY (
+			SELECT
+				TIMESTAMP '2024-01-01 08:00:00' AS tpep_pickup_datetime,
+				TIMESTAMP '2024-01-01 08:20:00' AS tpep_dropoff_datetime,
+				132 AS PULocationID,
+				161 AS DOLocationID,
+				1 AS passenger_count,
+				4.2 AS trip_distance,
+				25.5 AS total_amount,
+				20.0 AS fare_amount,
+				3.5 AS tip_amount
+		) TO '`+filepath.ToSlash(tripsPath)+`' (FORMAT PARQUET)
+	`)
+	require.NoError(t, err)
+
+	require.NoError(t, devseed.RenderDirectory(inputDir, renderedDir, map[string]string{
+		devseed.PlaceholderBootstrapUser:   "admin_user",
+		devseed.PlaceholderSampleMetastore: filepath.ToSlash(filepath.Join(sampleCatalogDir, "ducklake_sample_data.sqlite")),
+		devseed.PlaceholderSampleDataDir:   filepath.ToSlash(filepath.Join(sampleCatalogDir, "data")),
+		devseed.PlaceholderTaxiTripsPath:   filepath.ToSlash(tripsPath),
+		devseed.PlaceholderTaxiZonesPath:   filepath.ToSlash(zonesPath),
+	}))
+
+	desired, err := declarative.LoadDirectory(renderedDir)
+	require.NoError(t, err)
+	require.Empty(t, declarative.Validate(desired))
+
+	actual, err := stateClient.ReadState(context.Background())
+	require.NoError(t, err)
+
+	plan := declarative.Diff(desired, actual)
+	require.NotEmpty(t, plan.Actions)
+	require.Empty(t, plan.Errors)
+	executeActions(t, stateClient, nonDeleteActions(plan.Actions))
+
+	workspaceRepo := repository.NewWorkspaceRepo(env.MetaDB)
+	workspaces, _, err := workspaceRepo.List(context.Background(), domain.PageRequest{MaxResults: 100})
+	require.NoError(t, err)
+	assert.Contains(t, workspaceNames(workspacesToResources(workspaces)), "dev-admin")
+	assert.Contains(t, workspaceNames(workspacesToResources(workspaces)), "analyst-sandbox")
+
+	projectRepo := repository.NewProjectRepo(env.MetaDB)
+	project, err := projectRepo.GetByName(context.Background(), "taxi-analytics")
+	require.NoError(t, err)
+
+	folderRepo := repository.NewFolderRepo(env.MetaDB)
+	folders, err := folderRepo.ListByWorkspace(context.Background(), project.WorkspaceID)
+	require.NoError(t, err)
+	assert.Contains(t, folderNames(foldersToResources(folders)), "analytics")
+
+	environmentRepo := repository.NewEnvironmentRepo(env.MetaDB)
+	environment, err := environmentRepo.GetByName(context.Background(), project.ID, "dev")
+	require.NoError(t, err)
+	assert.Equal(t, "seeded_local", environment.TargetCatalog)
+
+	notebookRepo := repository.NewNotebookRepo(env.MetaDB)
+	notebooks, _, err := notebookRepo.ListNotebooks(context.Background(), nil, domain.PageRequest{MaxResults: 100})
+	require.NoError(t, err)
+	assert.Contains(t, notebookNames(notebooksToResources(notebooks)), "nyc_taxi_explore")
+
+	dashboardRepo := repository.NewDashboardRepo(env.MetaDB)
+	dashboards, _, err := dashboardRepo.List(context.Background(), nil, domain.PageRequest{MaxResults: 100})
+	require.NoError(t, err)
+	assert.Contains(t, dashboardNames(dashboardsToResources(dashboards)), "nyc-taxi-ops")
+}
+
+func workspaceNames(items []declarative.WorkspaceResource) []string {
+	names := make([]string, 0, len(items))
+	for _, item := range items {
+		names = append(names, item.Name)
+	}
+	return names
+}
+
+func folderNames(items []declarative.FolderResource) []string {
+	names := make([]string, 0, len(items))
+	for _, item := range items {
+		names = append(names, item.Name)
+	}
+	return names
+}
+
+func projectNames(items []declarative.ProjectResource) []string {
+	names := make([]string, 0, len(items))
+	for _, item := range items {
+		names = append(names, item.Name)
+	}
+	return names
+}
+
+func environmentNames(items []declarative.EnvironmentResource) []string {
+	names := make([]string, 0, len(items))
+	for _, item := range items {
+		names = append(names, item.Name)
+	}
+	return names
+}
+
+func notebookNames(items []declarative.NotebookResource) []string {
+	names := make([]string, 0, len(items))
+	for _, item := range items {
+		names = append(names, item.Name)
+	}
+	return names
+}
+
+func dashboardNames(items []declarative.DashboardResource) []string {
+	names := make([]string, 0, len(items))
+	for _, item := range items {
+		names = append(names, item.Name)
+	}
+	return names
+}
+
+func nonDeleteActions(actions []declarative.Action) []declarative.Action {
+	filtered := make([]declarative.Action, 0, len(actions))
+	for _, action := range actions {
+		if action.Operation == declarative.OpDelete {
+			continue
+		}
+		filtered = append(filtered, action)
+	}
+	return filtered
+}
+
+func workspacesToResources(items []domain.Workspace) []declarative.WorkspaceResource {
+	out := make([]declarative.WorkspaceResource, 0, len(items))
+	for _, item := range items {
+		out = append(out, declarative.WorkspaceResource{Name: item.Name})
+	}
+	return out
+}
+
+func foldersToResources(items []domain.Folder) []declarative.FolderResource {
+	out := make([]declarative.FolderResource, 0, len(items))
+	for _, item := range items {
+		out = append(out, declarative.FolderResource{Name: item.Name})
+	}
+	return out
+}
+
+func notebooksToResources(items []domain.Notebook) []declarative.NotebookResource {
+	out := make([]declarative.NotebookResource, 0, len(items))
+	for _, item := range items {
+		out = append(out, declarative.NotebookResource{Name: item.Name})
+	}
+	return out
+}
+
+func dashboardsToResources(items []domain.Dashboard) []declarative.DashboardResource {
+	out := make([]declarative.DashboardResource, 0, len(items))
+	for _, item := range items {
+		out = append(out, declarative.DashboardResource{Name: item.Name})
+	}
+	return out
+}

--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -47,6 +47,7 @@ import (
 	authsvc "duck-demo/internal/service/auth"
 	"duck-demo/internal/service/catalog"
 	svccompute "duck-demo/internal/service/compute"
+	dashboardsvc "duck-demo/internal/service/dashboard"
 	exploresvc "duck-demo/internal/service/explore"
 	"duck-demo/internal/service/governance"
 	"duck-demo/internal/service/macro"
@@ -55,10 +56,12 @@ import (
 	"duck-demo/internal/service/orchestration"
 	svcpipeline "duck-demo/internal/service/pipeline"
 	productsvc "duck-demo/internal/service/product"
+	projectsvc "duck-demo/internal/service/project"
 	"duck-demo/internal/service/query"
 	"duck-demo/internal/service/security"
 	svcsemantic "duck-demo/internal/service/semantic"
 	"duck-demo/internal/service/storage"
+	workspacesvc "duck-demo/internal/service/workspace"
 	"duck-demo/internal/ui"
 )
 
@@ -1337,7 +1340,7 @@ func setupHTTPServer(t *testing.T, opts httpTestOpts) *httpTestEnv {
 		catalogRepoFactory = repository.NewCatalogRepoFactory(catalogRegRepo, metaDB, duckDB, nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
 		catalogRegSvc = catalog.NewCatalogRegistrationService(catalog.RegistrationServiceDeps{
 			Repo:               catalogRegRepo,
-			Attacher:           noOpCatalogAttacher{},
+			Attacher:           engine.NewDuckDBSecretManager(duckDB),
 			ControlPlaneDBPath: env.MetaPath,
 			Logger:             slog.New(slog.NewTextHandler(io.Discard, nil)),
 		})
@@ -1351,6 +1354,7 @@ func setupHTTPServer(t *testing.T, opts httpTestOpts) *httpTestEnv {
 	// Optionally wire storage credential and external location services
 	var storageCredSvc *storage.StorageCredentialService
 	var extLocationSvc *storage.ExternalLocationService
+	var volumeSvc *storage.VolumeService
 
 	{
 		testEncKey := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
@@ -1377,6 +1381,7 @@ func setupHTTPServer(t *testing.T, opts httpTestOpts) *httpTestEnv {
 			extLocationRepo, storageCredRepo, authSvc, auditRepo,
 			secretMgr, slog.New(slog.NewTextHandler(io.Discard, nil)),
 		)
+		volumeSvc = storage.NewVolumeService(repository.NewVolumeRepo(metaDB), authSvc, auditRepo)
 		catalogSvc = catalog.NewCatalogService(catalogRepoFactory, authSvc, auditRepo, tagRepo, tableStatsRepo, extLocationRepo)
 	}
 
@@ -1459,16 +1464,27 @@ func setupHTTPServer(t *testing.T, opts httpTestOpts) *httpTestEnv {
 	)
 	pipelineSvc.SetFolderRepository(folderRepo)
 	dashboardRepo := repository.NewDashboardRepo(metaDB)
+	dashboardWidgetRepo := repository.NewDashboardWidgetRepo(metaDB)
 
 	var (
 		assetSvc          *assetsvc.Service
 		backfillSvc       *orchestration.BackfillService
 		reconciler        *orchestration.Reconciler
 		projectRepo       domain.ProjectRepository
+		environmentRepo   domain.EnvironmentRepository
+		buildRepo         domain.BuildRepository
 		modelRepo         domain.ModelRepository
 		macroRepo         domain.MacroRepository
 		semanticModelRepo domain.SemanticModelRepository
 	)
+	projectRepo = repository.NewProjectRepo(metaDB)
+	environmentRepo = repository.NewEnvironmentRepo(metaDB)
+	buildRepo = repository.NewBuildRepo(metaDB)
+	workspaceSvc := workspacesvc.NewService(workspaceRepo, folderRepo, projectRepo, environmentRepo, teamRepo, auditRepo)
+	projectCtlSvc := projectsvc.NewService(workspaceRepo, projectRepo, environmentRepo, buildRepo, teamRepo, productRepo, auditRepo)
+	notebookSvc.SetProjectRepositories(projectRepo, environmentRepo)
+	notebookFolderSvc.SetProjectRepositories(projectRepo, environmentRepo)
+
 	if opts.WithAssets {
 		assetRepo := repository.NewDataAssetRepo(metaDB)
 		assetDepRepo := repository.NewAssetDependencyRepo(metaDB)
@@ -1602,6 +1618,8 @@ func setupHTTPServer(t *testing.T, opts httpTestOpts) *httpTestEnv {
 		semanticSvc.SetQueryExecutor(querySvc)
 		productSvc.SetSemanticModelRepository(semanticModelRepo)
 	}
+	dashboardSvc := dashboardsvc.NewService(dashboardRepo, dashboardWidgetRepo, notebookRepo, auditRepo, querySvc, semanticSvc)
+	dashboardSvc.SetFolderRepository(folderRepo)
 
 	exploreSvc := exploresvc.NewService(workspaceRepo, folderRepo, notebookRepo, dashboardRepo, pipelineRepo, projectRepo, modelRepo, macroRepo, semanticModelRepo)
 	exploreSvc.SetAccessRepositories(folderShareRepo, notebookShareRepo)
@@ -1612,8 +1630,8 @@ func setupHTTPServer(t *testing.T, opts httpTestOpts) *httpTestEnv {
 		rowFilterSvc, columnMaskSvc, auditSvc,
 		manifestSvc, catalogSvc, catalogRegSvc,
 		queryHistorySvc, lineageSvc, searchSvc, tagSvc, viewSvc,
-		nil,                                 // ingestionSvc
-		storageCredSvc, extLocationSvc, nil, // volumeSvc
+		nil, // ingestionSvc
+		storageCredSvc, extLocationSvc, volumeSvc,
 		computeEndpointSvc,
 		apiKeySvc,
 		nil, // pipelineSvc
@@ -1623,7 +1641,12 @@ func setupHTTPServer(t *testing.T, opts httpTestOpts) *httpTestEnv {
 		modelSvc, // modelSvc
 		macroSvc, // macroSvc
 		semanticSvc,
+		dashboardSvc,
 	)
+	handler.SetNotebookFolders(notebookFolderSvc)
+	handler.SetWorkspaceService(workspaceSvc)
+	handler.SetProjectControlService(projectCtlSvc)
+	handler.SetExplore(exploreSvc)
 	handler.SetProductService(productSvc)
 	r := chi.NewRouter()
 


### PR DESCRIPTION
# Declarative Seeded Dev Environment Plan

## Summary
Create a checked-in repo-root `duck-config/` that becomes the canonical source of truth for the local seeded developer environment, and add a new `task dev:seeded` flow that starts a clean dev server and applies that config automatically.

Chosen defaults:
- Declarative config is the canonical seed definition for local dev.
- `task dev:seeded` is the seeded workflow; `task dev` remains the lean server-start workflow.
- Seeded local data comes from public downloadable datasets, cached locally, not from checked-in bulky DB artifacts.
- The default seeded corpus is rich and local-safe: workspaces, dashboards, notebooks, projects/environments, catalog objects, models/semantic/assets, security, and product metadata.
- Non-declarative or env-dependent surfaces are not part of the default seeded config.

## Key Changes
### Dev workflow and server boot
- Add a new task: `task dev:seeded`.
- `task dev:seeded` should:
  1. compute the same worktree-specific ports and local paths as `task dev`
  2. start the server with imperative sample bootstrap disabled
  3. wait for the API to be reachable
  4. provision/login as a bootstrap admin
  5. download/cache the public seed datasets if missing
  6. render a local applyable config from the checked-in `duck-config/`
  7. run `duck apply --config-dir <rendered-dir> --auto-approve`
  8. print the host, profile/token context, and the path to the rendered config
- Keep `task dev` as server-only and disable the current imperative sample catalog/bootstrap there too, so the seeded experience is owned by declarative config rather than hidden startup code.
- Add a server config/env switch to disable the current `internal/sampledata` bootstrap path for dev tasks.

### Checked-in `duck-config/` starter tree
- Add a canonical repo-root `duck-config/` with a realistic dev platform graph.
- Include a curated local-safe corpus that exercises the main declarative surfaces:
  - security: principals, groups, grants, tags
  - authoring core: workspaces, folders, projects, environments
  - data plane metadata: catalog, schemas, tables, views, volumes
  - authored assets: notebooks, dashboards, models, semantic models, macros, assets
  - product metadata: domains, teams, data products
  - compute metadata needed by those assets
- Make the config internally connected so common developer flows work out of the box:
  - notebooks live in folders inside workspaces
  - dashboards read from notebook outputs or semantic models
  - models/assets/data products reference one another coherently
- Include the bootstrap admin principal in the declarative state so the seeded environment converges cleanly after first apply.

### Local data acquisition and config rendering
- Add a small helper script or Go helper that downloads public datasets into a worktree-local cache under `.codex/dev/`.
- Use the existing NYC taxi public sources as the first seeded dataset, but switch from embedded tiny fixtures to cached public downloads for `dev:seeded`.
- Cache downloads by URL/version so the first run fetches data and later runs reuse it.
- Render the checked-in `duck-config/` into a generated local config directory before apply, substituting machine-specific absolute paths for:
  - catalog metastore/data locations
  - local table/source file paths
  - any other worktree-specific runtime paths
- Keep the checked-in config portable and human-editable; keep all machine-specific paths out of git.

## Important Interfaces
- New task: `task dev:seeded`
- `task dev` changes to start an unseeded local server only
- New env/config switch for server bootstrap behavior, for example a boolean `SAMPLE_DATA_BOOTSTRAP_ENABLED`
- New rendered-config helper interface, for example:
  - input: checked-in `./duck-config`
  - inputs: repo root, cached dataset dir, worktree-local metastore/data dir, host/auth context
  - output: generated config dir under `.codex/dev/`
- Public dataset downloader interface should support:
  - fetch if missing
  - reuse if present
  - optional refresh flag later, but not required in v1

## Test Plan
- Unit test config rendering so path substitution is deterministic and portable.
- Unit test the downloader/cache logic so repeated runs do not re-download unchanged assets.
- Integration test `task dev:seeded` behavior at the workflow level:
  - server starts
  - bootstrap/login succeeds
  - apply succeeds
  - second plan is empty
- Integration test that `task dev` no longer creates the old imperative sample/runtime state.
- Declarative round-trip test for the starter config:
  - validate
  - plan from clean seeded server
  - apply
  - export
  - re-plan clean
- Add acceptance checks that dashboards, notebooks, and workspace/folder/project/environment bindings are present after seeding.

## Assumptions and Defaults
- The default seeded config should optimize for local development usefulness, not full production realism.
- Public downloadable data is acceptable for dev startup as long as it is cached after first fetch.
- Default seeded content should avoid cloud credentials and external infra requirements.
- Pipelines and other surfaces without first-class declarative support are out of scope for the starter seeded config.
- Existing imperative sample bootstrap is deprecated for local dev use once `task dev:seeded` exists, even if the underlying code path remains available behind a flag.
