### PR TITLE
feat: add enterprise deployment foundation

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/Yacobolo/quackstack/internal/flightsql"
 	"github.com/Yacobolo/quackstack/internal/middleware"
 	"github.com/Yacobolo/quackstack/internal/pgwire"
+	"github.com/Yacobolo/quackstack/internal/platform"
 	"github.com/Yacobolo/quackstack/internal/sampledata"
 	"github.com/Yacobolo/quackstack/internal/ui"
 )
@@ -96,6 +97,16 @@ func run() error {
 	for _, w := range cfg.ConfigDoctorWarnings() {
 		logger.Warn("config doctor warning", "detail", w)
 	}
+	provider, err := platform.NewProvider(cfg)
+	if err != nil {
+		return fmt.Errorf("platform provider: %w", err)
+	}
+	logger.Info(
+		"deployment profile selected",
+		"profile", cfg.DeploymentProfile,
+		"control_db_driver", cfg.ControlDBDriver,
+		"platform_provider", provider.Name(),
+	)
 
 	// Open DuckDB (in-memory)
 	duckDB, err := sql.Open("duckdb", "")
@@ -135,11 +146,12 @@ func run() error {
 
 	// Wire application dependencies
 	application, err := app.New(ctx, app.Deps{
-		Cfg:     cfg,
-		DuckDB:  duckDB,
-		WriteDB: writeDB,
-		ReadDB:  readDB,
-		Logger:  logger,
+		Cfg:      cfg,
+		DuckDB:   duckDB,
+		WriteDB:  writeDB,
+		ReadDB:   readDB,
+		Logger:   logger,
+		Platform: provider,
 	})
 	if err != nil {
 		return fmt.Errorf("app init: %w", err)
@@ -621,6 +633,9 @@ func runAdmin(args []string) error {
 	if err != nil {
 		return fmt.Errorf("config: %w", err)
 	}
+	if cfg.ControlDBDriver != "sqlite" {
+		return fmt.Errorf("server admin currently supports CONTROL_DB_DRIVER=sqlite only")
+	}
 
 	// Open SQLite directly (single connection is fine for a one-shot CLI).
 	db, err := sql.Open("sqlite3", cfg.MetaDBPath+"?_journal_mode=WAL&_busy_timeout=5000")
@@ -691,6 +706,10 @@ func printServerUsage() {
 	_, _ = fmt.Fprintln(os.Stdout, "  server admin <promote|demote> [flags]")
 	_, _ = fmt.Fprintln(os.Stdout)
 	_, _ = fmt.Fprintln(os.Stdout, "Environment:")
+	_, _ = fmt.Fprintln(os.Stdout, "  DEPLOYMENT_PROFILE       Deployment profile: simple or enterprise")
+	_, _ = fmt.Fprintln(os.Stdout, "  CONTROL_DB_DRIVER        Control-plane metadata driver: sqlite or postgres")
+	_, _ = fmt.Fprintln(os.Stdout, "  CONTROL_DB_DSN           Postgres DSN for enterprise control-plane metadata")
+	_, _ = fmt.Fprintln(os.Stdout, "  PLATFORM_PROVIDER        Platform provider: manual or azure")
 	_, _ = fmt.Fprintln(os.Stdout, "  LISTEN_ADDR              HTTP listen address (default :8080)")
 	_, _ = fmt.Fprintln(os.Stdout, "  META_DB_PATH             SQLite metastore path")
 	_, _ = fmt.Fprintln(os.Stdout, "  FLIGHT_SQL_LISTEN_ADDR   Flight SQL listen address")

--- a/deploy/enterprise/README.md
+++ b/deploy/enterprise/README.md
@@ -1,0 +1,52 @@
+# Enterprise Deployment Foundation
+
+This directory contains the first enterprise deployment foundation for QuackStack.
+
+Goals of this foundation:
+
+- keep a single product surface across Compose and enterprise deployments
+- package enterprise installs with Helm
+- keep provider-specific deployment details in values files and templates
+- preserve a provider-neutral control-plane contract in application code
+
+Current state:
+
+- the Helm chart in `helm/quackstack` provides a baseline control-plane deployment shape
+- provider-specific overrides live in `values-azure.yaml`
+- the application now understands deployment profiles, control-plane DB driver selection, and platform provider selection
+- enterprise runtime support for a full Postgres-backed control plane and managed lifecycle controller is still a follow-up implementation
+
+## Install
+
+Example:
+
+```bash
+helm upgrade --install quackstack deploy/enterprise/helm/quackstack \
+  --namespace quackstack \
+  --create-namespace \
+  -f deploy/enterprise/helm/quackstack/values.yaml \
+  -f deploy/enterprise/helm/quackstack/values-azure.yaml
+```
+
+Provide real secrets before install:
+
+- `CONTROL_DB_DSN`
+- `ENCRYPTION_KEY`
+- `JWT_SECRET` when used
+- cloud-specific credentials when workload identity is not yet in place
+
+## Profiles
+
+- simple mode remains the Compose-based deployment path
+- enterprise mode uses:
+  - `DEPLOYMENT_PROFILE=enterprise`
+  - `CONTROL_DB_DRIVER=postgres`
+  - `PLATFORM_PROVIDER=azure`
+
+## Design Notes
+
+- QuackStack defines the deployment contract
+- providers implement that contract
+- Helm packages the deployment, but is not the abstraction boundary
+- user-facing APIs remain about endpoints, routing, and health rather than AKS-specific concepts
+

--- a/deploy/enterprise/helm/quackstack/Chart.yaml
+++ b/deploy/enterprise/helm/quackstack/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: quackstack
+description: Enterprise Helm chart foundation for QuackStack
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+

--- a/deploy/enterprise/helm/quackstack/templates/_helpers.tpl
+++ b/deploy/enterprise/helm/quackstack/templates/_helpers.tpl
@@ -1,0 +1,28 @@
+{{- define "quackstack.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "quackstack.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name (include "quackstack.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "quackstack.labels" -}}
+app.kubernetes.io/name: {{ include "quackstack.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | quote }}
+{{- end -}}
+
+{{- define "quackstack.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "quackstack.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+

--- a/deploy/enterprise/helm/quackstack/templates/compute-workers-deployment.yaml
+++ b/deploy/enterprise/helm/quackstack/templates/compute-workers-deployment.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.computeWorkers.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "quackstack.fullname" . }}-compute
+  labels:
+    {{- include "quackstack.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.computeWorkers.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "quackstack.name" . }}-compute
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "quackstack.name" . }}-compute
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      serviceAccountName: {{ default (include "quackstack.serviceAccountName" .) .Values.computeWorkers.serviceAccountName }}
+      containers:
+        - name: compute-worker
+          image: "{{ .Values.computeWorkerImage.repository }}:{{ .Values.computeWorkerImage.tag }}"
+          imagePullPolicy: {{ .Values.computeWorkerImage.pullPolicy }}
+          env:
+            - name: PLATFORM_PROVIDER
+              value: {{ .Values.platformProvider | quote }}
+            - name: LISTEN_ADDR
+              value: {{ .Values.computeWorkers.httpListenAddr | quote }}
+            - name: GRPC_LISTEN_ADDR
+              value: {{ .Values.computeWorkers.grpcListenAddr | quote }}
+            {{- range $key, $value := .Values.computeWorkers.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.computeWorkers.resources | nindent 12 }}
+{{- end }}
+

--- a/deploy/enterprise/helm/quackstack/templates/control-plane-configmap.yaml
+++ b/deploy/enterprise/helm/quackstack/templates/control-plane-configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "quackstack.fullname" . }}-config
+  labels:
+    {{- include "quackstack.labels" . | nindent 4 }}
+data:
+  DEPLOYMENT_PROFILE: {{ .Values.deploymentProfile | quote }}
+  PLATFORM_PROVIDER: {{ .Values.platformProvider | quote }}
+  CONTROL_DB_DRIVER: {{ .Values.controlDB.driver | quote }}
+  {{- range $key, $value := .Values.env }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+

--- a/deploy/enterprise/helm/quackstack/templates/control-plane-deployment.yaml
+++ b/deploy/enterprise/helm/quackstack/templates/control-plane-deployment.yaml
@@ -1,0 +1,73 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "quackstack.fullname" . }}
+  labels:
+    {{- include "quackstack.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "quackstack.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        {{- include "quackstack.labels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "quackstack.serviceAccountName" . }}
+      containers:
+        - name: control-plane
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+            - name: flightsql
+              containerPort: {{ .Values.service.flightSQLPort }}
+            - name: pgwire
+              containerPort: {{ .Values.service.pgWirePort }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "quackstack.fullname" . }}-config
+          env:
+            - name: CONTROL_DB_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.controlDB.dsnSecretName }}
+                  key: {{ .Values.controlDB.dsnSecretKey }}
+            - name: ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secrets.controlPlane.name }}
+                  key: ENCRYPTION_KEY
+                  optional: true
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secrets.controlPlane.name }}
+                  key: JWT_SECRET
+                  optional: true
+          readinessProbe:
+            httpGet:
+              path: /v1/healthz
+              port: http
+          livenessProbe:
+            httpGet:
+              path: /v1/healthz
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+

--- a/deploy/enterprise/helm/quackstack/templates/control-plane-secret.yaml
+++ b/deploy/enterprise/helm/quackstack/templates/control-plane-secret.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.secrets.controlPlane.create }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.secrets.controlPlane.name }}
+  labels:
+    {{- include "quackstack.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- range $key, $value := .Values.secrets.controlPlane.stringData }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}
+

--- a/deploy/enterprise/helm/quackstack/templates/control-plane-service.yaml
+++ b/deploy/enterprise/helm/quackstack/templates/control-plane-service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "quackstack.fullname" . }}
+  labels:
+    {{- include "quackstack.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    app.kubernetes.io/name: {{ include "quackstack.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+    - name: flightsql
+      port: {{ .Values.service.flightSQLPort }}
+      targetPort: flightsql
+    - name: pgwire
+      port: {{ .Values.service.pgWirePort }}
+      targetPort: pgwire
+

--- a/deploy/enterprise/helm/quackstack/templates/ingress.yaml
+++ b/deploy/enterprise/helm/quackstack/templates/ingress.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "quackstack.fullname" . }}
+  labels:
+    {{- include "quackstack.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "quackstack.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+

--- a/deploy/enterprise/helm/quackstack/templates/lifecycle-controller-deployment.yaml
+++ b/deploy/enterprise/helm/quackstack/templates/lifecycle-controller-deployment.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.lifecycleController.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "quackstack.fullname" . }}-lifecycle
+  labels:
+    {{- include "quackstack.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "quackstack.name" . }}-lifecycle
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "quackstack.name" . }}-lifecycle
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      serviceAccountName: {{ include "quackstack.serviceAccountName" . }}
+      containers:
+        - name: lifecycle-controller
+          image: "{{ .Values.lifecycleController.image.repository }}:{{ .Values.lifecycleController.image.tag }}"
+          imagePullPolicy: {{ .Values.lifecycleController.image.pullPolicy }}
+          env:
+            - name: DEPLOYMENT_PROFILE
+              value: {{ .Values.deploymentProfile | quote }}
+            - name: PLATFORM_PROVIDER
+              value: {{ .Values.platformProvider | quote }}
+          resources:
+            {{- toYaml .Values.lifecycleController.resources | nindent 12 }}
+{{- end }}

--- a/deploy/enterprise/helm/quackstack/templates/serviceaccount.yaml
+++ b/deploy/enterprise/helm/quackstack/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "quackstack.serviceAccountName" . }}
+  labels:
+    {{- include "quackstack.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+

--- a/deploy/enterprise/helm/quackstack/values-azure.yaml
+++ b/deploy/enterprise/helm/quackstack/values-azure.yaml
@@ -1,0 +1,25 @@
+platformProvider: azure
+
+serviceAccount:
+  annotations:
+    azure.workload.identity/use: "true"
+
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+
+controlDB:
+  driver: postgres
+
+env:
+  AUTH_MODE: oidc_only
+  FEATURE_REMOTE_ROUTING: "true"
+  FEATURE_INTERNAL_GRPC: "true"
+  TRUST_DOWNSTREAM_PROXY: "true"
+
+computeWorkers:
+  enabled: true
+  replicaCount: 2
+

--- a/deploy/enterprise/helm/quackstack/values.yaml
+++ b/deploy/enterprise/helm/quackstack/values.yaml
@@ -1,0 +1,90 @@
+nameOverride: ""
+fullnameOverride: ""
+
+image:
+  repository: ghcr.io/yacobolo/quackstack-control-plane
+  tag: main-latest
+  pullPolicy: IfNotPresent
+
+computeWorkerImage:
+  repository: ghcr.io/yacobolo/quackstack-compute-agent
+  tag: main-latest
+  pullPolicy: IfNotPresent
+
+deploymentProfile: enterprise
+platformProvider: azure
+
+replicaCount: 1
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+service:
+  type: ClusterIP
+  port: 8080
+  flightSQLPort: 32010
+  pgWirePort: 5433
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: quackstack.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+controlDB:
+  driver: postgres
+  dsnSecretName: quackstack-control-plane
+  dsnSecretKey: CONTROL_DB_DSN
+
+secrets:
+  controlPlane:
+    name: quackstack-control-plane
+    create: false
+    stringData: {}
+
+env:
+  ENV: production
+  LOG_LEVEL: info
+  LISTEN_ADDR: ":8080"
+  FLIGHT_SQL_LISTEN_ADDR: ":32010"
+  PG_WIRE_LISTEN_ADDR: ":5433"
+  FEATURE_REMOTE_ROUTING: "true"
+  FEATURE_ASYNC_QUEUE: "true"
+  FEATURE_CURSOR_MODE: "true"
+  FEATURE_INTERNAL_GRPC: "true"
+  FEATURE_FLIGHT_SQL: "true"
+  FEATURE_PG_WIRE: "true"
+  TRUST_DOWNSTREAM_PROXY: "true"
+
+resources: {}
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+computeWorkers:
+  enabled: true
+  replicaCount: 1
+  serviceAccountName: ""
+  grpcListenAddr: ":9444"
+  httpListenAddr: ":9443"
+  resources: {}
+  env:
+    FEATURE_CURSOR_MODE: "true"
+    FEATURE_INTERNAL_GRPC: "true"
+
+lifecycleController:
+  enabled: false
+  image:
+    repository: ghcr.io/yacobolo/quackstack-lifecycle-controller
+    tag: main-latest
+    pullPolicy: IfNotPresent
+  resources: {}
+

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Yacobolo/quackstack/internal/db/repository"
 	"github.com/Yacobolo/quackstack/internal/domain"
 	"github.com/Yacobolo/quackstack/internal/engine"
+	"github.com/Yacobolo/quackstack/internal/platform"
 	assetsvc "github.com/Yacobolo/quackstack/internal/service/asset"
 	authsvc "github.com/Yacobolo/quackstack/internal/service/auth"
 	"github.com/Yacobolo/quackstack/internal/service/catalog"
@@ -43,11 +44,12 @@ import (
 // These are things the app package cannot (or should not) create itself:
 // database handles, config, and the DuckDB connection.
 type Deps struct {
-	Cfg     *config.Config
-	DuckDB  *sql.DB
-	WriteDB *sql.DB
-	ReadDB  *sql.DB
-	Logger  *slog.Logger
+	Cfg      *config.Config
+	DuckDB   *sql.DB
+	WriteDB  *sql.DB
+	ReadDB   *sql.DB
+	Logger   *slog.Logger
+	Platform platform.Provider
 }
 
 // Services groups all service pointers that the API handler and router need.
@@ -139,6 +141,8 @@ func New(ctx context.Context, deps Deps) (*App, error) {
 	storageCredRepo := repository.NewStorageCredentialRepo(deps.WriteDB, encryptor)
 	computeEndpointRepo := repository.NewComputeEndpointRepo(deps.WriteDB, encryptor)
 	computeRoutingRepo := repository.NewComputeRoutingRepo(deps.WriteDB)
+	computeClusterTemplateRepo := repository.NewComputeClusterTemplateRepo(deps.WriteDB)
+	managedComputeClusterRepo := repository.NewManagedComputeClusterRepo(deps.WriteDB)
 	catalogRegRepo := repository.NewCatalogRegistrationRepo(deps.WriteDB)
 	dataProductRepo := repository.NewDataProductRepo(deps.WriteDB)
 	workspaceRepo := repository.NewWorkspaceRepo(deps.WriteDB)
@@ -170,6 +174,14 @@ func New(ctx context.Context, deps Deps) (*App, error) {
 	introspectionRepo := repository.NewIntrospectionRepo(deps.ReadDB)
 	queryHistoryRepo := repository.NewQueryHistoryRepo(deps.ReadDB)
 	searchRepo := repository.NewSearchRepo(deps.ReadDB, deps.ReadDB)
+
+	if deps.Platform == nil {
+		var err error
+		deps.Platform, err = platform.NewProvider(cfg)
+		if err != nil {
+			return nil, fmt.Errorf("configure platform provider: %w", err)
+		}
+	}
 
 	if err := engine.AttachSystemCatalog(ctx, deps.DuckDB, cfg.MetaDBPath); err != nil {
 		return nil, fmt.Errorf("attach system catalog: %w", err)
@@ -320,8 +332,11 @@ func New(ctx context.Context, deps Deps) (*App, error) {
 	storageCredSvc := storage.NewStorageCredentialService(storageCredRepo, authSvc, auditRepo)
 	computeEndpointSvc := svccompute.NewComputeEndpointService(computeEndpointRepo, authSvc, auditRepo)
 	computeEndpointSvc.SetRoutingRepository(computeRoutingRepo)
+	computeEndpointSvc.SetClusterTemplateRepository(computeClusterTemplateRepo)
+	computeEndpointSvc.SetManagedClusterRepository(managedComputeClusterRepo)
 	computeEndpointSvc.SetPrincipalRepository(principalRepo)
 	computeEndpointSvc.SetGroupRepository(groupRepo)
+	computeEndpointSvc.SetPlatformProvider(deps.Platform)
 	volumeSvc := storage.NewVolumeService(volumeRepo, authSvc, auditRepo)
 
 	secretMgr := engine.NewDuckDBSecretManager(deps.DuckDB)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -116,6 +116,11 @@ func (a *AuthConfig) ValidateMode() error {
 
 // Config holds the configuration for the HTTP API and optional S3/DuckLake storage.
 type Config struct {
+	DeploymentProfile string // deployment profile: simple or enterprise
+	ControlDBDriver   string // sqlite or postgres
+	ControlDBDSN      string // DSN for Postgres control-plane metadata
+	PlatformProvider  string // manual, azure, aws, gcp
+
 	// S3 fields are optional — nil when not configured.
 	S3KeyID              *string
 	S3Secret             *string
@@ -207,6 +212,10 @@ func LoadFromEnv() (*Config, error) {
 	}
 
 	cfg := &Config{
+		DeploymentProfile:       os.Getenv("DEPLOYMENT_PROFILE"),
+		ControlDBDriver:         os.Getenv("CONTROL_DB_DRIVER"),
+		ControlDBDSN:            os.Getenv("CONTROL_DB_DSN"),
+		PlatformProvider:        os.Getenv("PLATFORM_PROVIDER"),
 		MetaDBPath:              os.Getenv("META_DB_PATH"),
 		ListenAddr:              os.Getenv("LISTEN_ADDR"),
 		TLSCertFile:             os.Getenv("TLS_CERT_FILE"),
@@ -353,7 +362,10 @@ func LoadFromEnv() (*Config, error) {
 	}
 
 	// Defaults
-	if cfg.MetaDBPath == "" {
+	cfg.DeploymentProfile = normalizeDeploymentProfile(cfg.DeploymentProfile)
+	cfg.ControlDBDriver = normalizeControlDBDriver(cfg.ControlDBDriver)
+	cfg.PlatformProvider = normalizePlatformProvider(cfg.PlatformProvider, cfg.DeploymentProfile)
+	if cfg.ControlDBDriver == "sqlite" && cfg.MetaDBPath == "" {
 		cfg.MetaDBPath = "quackstack_meta.sqlite"
 	}
 	if cfg.ListenAddr == "" {
@@ -397,7 +409,11 @@ func LoadFromEnv() (*Config, error) {
 	if err := cfg.Auth.ValidateWebSessions(); err != nil {
 		return nil, err
 	}
+	if err := cfg.validateDeploymentProfile(); err != nil {
+		return nil, err
+	}
 	cfg.Warnings = append(cfg.Warnings, cfg.modeConflictWarnings()...)
+	cfg.Warnings = append(cfg.Warnings, cfg.profileWarnings()...)
 
 	// Production mode: insecure defaults are fatal errors.
 	if cfg.IsProduction() {
@@ -445,6 +461,84 @@ func compactNonEmpty(values []string) []string {
 	return out
 }
 
+func normalizeDeploymentProfile(profile string) string {
+	switch strings.ToLower(strings.TrimSpace(profile)) {
+	case "", "simple":
+		return "simple"
+	case "enterprise":
+		return "enterprise"
+	default:
+		return strings.ToLower(strings.TrimSpace(profile))
+	}
+}
+
+func normalizeControlDBDriver(driver string) string {
+	switch strings.ToLower(strings.TrimSpace(driver)) {
+	case "", "sqlite":
+		return "sqlite"
+	case "postgres":
+		return "postgres"
+	default:
+		return strings.ToLower(strings.TrimSpace(driver))
+	}
+}
+
+func normalizePlatformProvider(provider, profile string) string {
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	if provider != "" {
+		return provider
+	}
+	if normalizeDeploymentProfile(profile) == "enterprise" {
+		return "azure"
+	}
+	return "manual"
+}
+
+// IsEnterpriseProfile returns true when the process is configured for enterprise deployment.
+func (c *Config) IsEnterpriseProfile() bool {
+	return c.DeploymentProfile == "enterprise"
+}
+
+func (c *Config) validateDeploymentProfile() error {
+	switch c.DeploymentProfile {
+	case "simple", "enterprise":
+	default:
+		return fmt.Errorf("DEPLOYMENT_PROFILE must be simple or enterprise, got %q", c.DeploymentProfile)
+	}
+
+	switch c.ControlDBDriver {
+	case "sqlite", "postgres":
+	default:
+		return fmt.Errorf("CONTROL_DB_DRIVER must be sqlite or postgres, got %q", c.ControlDBDriver)
+	}
+
+	if c.ControlDBDriver == "sqlite" && strings.TrimSpace(c.MetaDBPath) == "" {
+		return fmt.Errorf("META_DB_PATH is required when CONTROL_DB_DRIVER=sqlite")
+	}
+	if c.ControlDBDriver == "postgres" && strings.TrimSpace(c.ControlDBDSN) == "" {
+		return fmt.Errorf("CONTROL_DB_DSN is required when CONTROL_DB_DRIVER=postgres")
+	}
+
+	if !c.IsEnterpriseProfile() {
+		return nil
+	}
+
+	if c.ControlDBDriver != "postgres" {
+		return fmt.Errorf("enterprise deployments require CONTROL_DB_DRIVER=postgres")
+	}
+	if !c.Auth.OIDCEnabled() {
+		return fmt.Errorf("enterprise deployments require OIDC; set AUTH_ISSUER_URL or AUTH_JWKS_URL")
+	}
+	if c.Auth.UIDevBypass {
+		return fmt.Errorf("enterprise deployments do not allow AUTH_UI_DEV_BYPASS=true")
+	}
+	if !c.FeatureRemoteRouting || !c.FeatureInternalGRPC {
+		return fmt.Errorf("enterprise deployments require FEATURE_REMOTE_ROUTING=true and FEATURE_INTERNAL_GRPC=true")
+	}
+
+	return nil
+}
+
 // AuthPosture returns a concise description of active auth posture.
 func (c *Config) AuthPosture() string {
 	mode := strings.ToLower(strings.TrimSpace(c.Auth.Mode))
@@ -469,7 +563,7 @@ func (c *Config) AuthPosture() string {
 
 // ConfigDoctorWarnings returns safety findings that operators should address.
 func (c *Config) ConfigDoctorWarnings() []string {
-	warnings := make([]string, 0, 4)
+	warnings := make([]string, 0, 6)
 	if c.EncryptionKey == "0000000000000000000000000000000000000000000000000000000000000000" {
 		warnings = append(warnings, "ENCRYPTION_KEY uses insecure default; set a 64-char hex key")
 	}
@@ -485,6 +579,9 @@ func (c *Config) ConfigDoctorWarnings() []string {
 	}
 	if !c.Auth.HasEnabledMethod() {
 		warnings = append(warnings, "no auth method enabled")
+	}
+	if c.IsEnterpriseProfile() && c.ControlDBDriver != "postgres" {
+		warnings = append(warnings, "enterprise deployment is not using postgres control-plane metadata")
 	}
 	return warnings
 }
@@ -520,6 +617,17 @@ func (c *Config) modeConflictWarnings() []string {
 		}
 	}
 
+	return warnings
+}
+
+func (c *Config) profileWarnings() []string {
+	warnings := make([]string, 0, 3)
+	if c.ControlDBDriver == "postgres" && strings.TrimSpace(c.MetaDBPath) != "" {
+		warnings = append(warnings, "META_DB_PATH is set but CONTROL_DB_DRIVER=postgres; SQLite metadata path is ignored")
+	}
+	if c.DeploymentProfile == "simple" && c.PlatformProvider != "manual" {
+		warnings = append(warnings, fmt.Sprintf("PLATFORM_PROVIDER=%s set with DEPLOYMENT_PROFILE=simple; simple deployments typically use manual provider", c.PlatformProvider))
+	}
 	return warnings
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -25,6 +25,9 @@ func TestLoadFromEnv_AllVarsSet(t *testing.T) {
 	assert.Equal(t, "testkey", *cfg.S3KeyID)
 	require.NotNil(t, cfg.S3Bucket)
 	assert.Equal(t, "test-bucket", *cfg.S3Bucket)
+	assert.Equal(t, "simple", cfg.DeploymentProfile)
+	assert.Equal(t, "sqlite", cfg.ControlDBDriver)
+	assert.Equal(t, "manual", cfg.PlatformProvider)
 	assert.Equal(t, "/tmp/test.sqlite", cfg.MetaDBPath)
 }
 
@@ -42,6 +45,9 @@ func TestLoadFromEnv_Defaults(t *testing.T) {
 
 	assert.Nil(t, cfg.S3KeyID)
 	assert.Nil(t, cfg.S3Bucket)
+	assert.Equal(t, "simple", cfg.DeploymentProfile)
+	assert.Equal(t, "sqlite", cfg.ControlDBDriver)
+	assert.Equal(t, "manual", cfg.PlatformProvider)
 	assert.Equal(t, "quackstack_meta.sqlite", cfg.MetaDBPath)
 	assert.Equal(t, ":8080", cfg.ListenAddr)
 	assert.Equal(t, ":32010", cfg.FlightSQLAddr)
@@ -98,6 +104,58 @@ func TestLoadFromEnv_ProductionRejectsUIDevBypass(t *testing.T) {
 	_, err := LoadFromEnv()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "AUTH_UI_DEV_BYPASS is not allowed in production")
+}
+
+func TestLoadFromEnv_EnterpriseRequiresPostgres(t *testing.T) {
+	t.Setenv("DEPLOYMENT_PROFILE", "enterprise")
+	t.Setenv("CONTROL_DB_DRIVER", "sqlite")
+	t.Setenv("AUTH_JWKS_URL", "https://auth.example.com/jwks.json")
+
+	_, err := LoadFromEnv()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "enterprise deployments require CONTROL_DB_DRIVER=postgres")
+}
+
+func TestLoadFromEnv_EnterpriseRequiresOIDC(t *testing.T) {
+	t.Setenv("DEPLOYMENT_PROFILE", "enterprise")
+	t.Setenv("CONTROL_DB_DRIVER", "postgres")
+	t.Setenv("CONTROL_DB_DSN", "postgres://quack:secret@example.com/quack?sslmode=disable")
+
+	_, err := LoadFromEnv()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "enterprise deployments require OIDC")
+}
+
+func TestLoadFromEnv_EnterpriseUsesAzureDefaults(t *testing.T) {
+	t.Setenv("DEPLOYMENT_PROFILE", "enterprise")
+	t.Setenv("CONTROL_DB_DRIVER", "postgres")
+	t.Setenv("CONTROL_DB_DSN", "postgres://quack:secret@example.com/quack?sslmode=disable")
+	t.Setenv("AUTH_JWKS_URL", "https://auth.example.com/jwks.json")
+
+	cfg, err := LoadFromEnv()
+	require.NoError(t, err)
+	assert.Equal(t, "enterprise", cfg.DeploymentProfile)
+	assert.Equal(t, "postgres", cfg.ControlDBDriver)
+	assert.Equal(t, "azure", cfg.PlatformProvider)
+	assert.True(t, cfg.IsEnterpriseProfile())
+}
+
+func TestLoadFromEnv_PostgresDriverRequiresDSN(t *testing.T) {
+	t.Setenv("CONTROL_DB_DRIVER", "postgres")
+
+	_, err := LoadFromEnv()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "CONTROL_DB_DSN is required when CONTROL_DB_DRIVER=postgres")
+}
+
+func TestLoadFromEnv_PostgresDriverWarnsWhenSQLitePathSet(t *testing.T) {
+	t.Setenv("CONTROL_DB_DRIVER", "postgres")
+	t.Setenv("CONTROL_DB_DSN", "postgres://quack:secret@example.com/quack?sslmode=disable")
+	t.Setenv("META_DB_PATH", "/tmp/legacy.sqlite")
+
+	cfg, err := LoadFromEnv()
+	require.NoError(t, err)
+	assert.Contains(t, cfg.Warnings, "META_DB_PATH is set but CONTROL_DB_DRIVER=postgres; SQLite metadata path is ignored")
 }
 
 func TestLoadFromEnv_WebSessionInvalidBounds(t *testing.T) {

--- a/internal/db/migrations/022_managed_compute.sql
+++ b/internal/db/migrations/022_managed_compute.sql
@@ -1,0 +1,43 @@
+-- +goose Up
+CREATE TABLE IF NOT EXISTS compute_cluster_templates (
+    id                       TEXT PRIMARY KEY,
+    name                     TEXT NOT NULL UNIQUE,
+    provider                 TEXT NOT NULL,
+    workload_class           TEXT NOT NULL,
+    size                     TEXT NOT NULL DEFAULT '',
+    min_replicas             INTEGER NOT NULL DEFAULT 0,
+    max_replicas             INTEGER NOT NULL DEFAULT 1,
+    idle_auto_stop_seconds   INTEGER NOT NULL DEFAULT 0,
+    scaling_policy           TEXT NOT NULL DEFAULT '',
+    storage_profile          TEXT NOT NULL DEFAULT '',
+    result_retention_seconds INTEGER NOT NULL DEFAULT 0,
+    created_at               TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at               TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS managed_compute_clusters (
+    id               TEXT PRIMARY KEY,
+    name             TEXT NOT NULL UNIQUE,
+    template_id      TEXT NOT NULL REFERENCES compute_cluster_templates(id) ON DELETE RESTRICT,
+    endpoint_id      TEXT NOT NULL UNIQUE REFERENCES compute_endpoints(id) ON DELETE CASCADE,
+    provider         TEXT NOT NULL,
+    external_id      TEXT NOT NULL UNIQUE,
+    desired_state    TEXT NOT NULL,
+    observed_state   TEXT NOT NULL,
+    min_replicas     INTEGER NOT NULL DEFAULT 0,
+    max_replicas     INTEGER NOT NULL DEFAULT 1,
+    is_draining      INTEGER NOT NULL DEFAULT 0,
+    last_activity_at TEXT,
+    endpoint_url     TEXT,
+    created_at       TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at       TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_managed_compute_clusters_template_id ON managed_compute_clusters(template_id);
+CREATE INDEX IF NOT EXISTS idx_managed_compute_clusters_endpoint_id ON managed_compute_clusters(endpoint_id);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_managed_compute_clusters_endpoint_id;
+DROP INDEX IF EXISTS idx_managed_compute_clusters_template_id;
+DROP TABLE IF EXISTS managed_compute_clusters;
+DROP TABLE IF EXISTS compute_cluster_templates;

--- a/internal/db/repository/compute_cluster_template.go
+++ b/internal/db/repository/compute_cluster_template.go
@@ -1,0 +1,187 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/Yacobolo/quackstack/internal/domain"
+)
+
+var _ domain.ComputeClusterTemplateRepository = (*ComputeClusterTemplateRepo)(nil)
+
+// ComputeClusterTemplateRepo persists provider-neutral managed compute templates.
+type ComputeClusterTemplateRepo struct {
+	db *sql.DB
+}
+
+// NewComputeClusterTemplateRepo creates a new ComputeClusterTemplateRepo.
+func NewComputeClusterTemplateRepo(db *sql.DB) *ComputeClusterTemplateRepo {
+	return &ComputeClusterTemplateRepo{db: db}
+}
+
+// Create inserts a new managed compute template.
+func (r *ComputeClusterTemplateRepo) Create(ctx context.Context, tpl *domain.ComputeClusterTemplate) (*domain.ComputeClusterTemplate, error) {
+	if tpl == nil {
+		return nil, fmt.Errorf("template is required")
+	}
+
+	id := tpl.ID
+	if id == "" {
+		id = newID()
+	}
+
+	_, err := r.db.ExecContext(ctx, `
+		INSERT INTO compute_cluster_templates (
+			id, name, provider, workload_class, size,
+			min_replicas, max_replicas, idle_auto_stop_seconds,
+			scaling_policy, storage_profile, result_retention_seconds
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`,
+		id,
+		tpl.Name,
+		tpl.Provider,
+		tpl.WorkloadClass,
+		tpl.Size,
+		tpl.MinReplicas,
+		tpl.MaxReplicas,
+		tpl.IdleAutoStopSeconds,
+		tpl.ScalingPolicy,
+		tpl.StorageProfile,
+		tpl.ResultRetentionSeconds,
+	)
+	if err != nil {
+		return nil, mapDBError(err)
+	}
+
+	return r.GetByID(ctx, id)
+}
+
+// GetByID returns a managed compute template by ID.
+func (r *ComputeClusterTemplateRepo) GetByID(ctx context.Context, id string) (*domain.ComputeClusterTemplate, error) {
+	row := r.db.QueryRowContext(ctx, `
+		SELECT
+			id, name, provider, workload_class, size,
+			min_replicas, max_replicas, idle_auto_stop_seconds,
+			scaling_policy, storage_profile, result_retention_seconds,
+			created_at, updated_at
+		FROM compute_cluster_templates
+		WHERE id = ?
+	`, id)
+	return scanComputeClusterTemplate(row)
+}
+
+// GetByName returns a managed compute template by name.
+func (r *ComputeClusterTemplateRepo) GetByName(ctx context.Context, name string) (*domain.ComputeClusterTemplate, error) {
+	row := r.db.QueryRowContext(ctx, `
+		SELECT
+			id, name, provider, workload_class, size,
+			min_replicas, max_replicas, idle_auto_stop_seconds,
+			scaling_policy, storage_profile, result_retention_seconds,
+			created_at, updated_at
+		FROM compute_cluster_templates
+		WHERE name = ?
+	`, name)
+	return scanComputeClusterTemplate(row)
+}
+
+// List returns a paginated list of managed compute templates.
+func (r *ComputeClusterTemplateRepo) List(ctx context.Context, page domain.PageRequest) ([]domain.ComputeClusterTemplate, int64, error) {
+	var total int64
+	if err := r.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM compute_cluster_templates`).Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("count compute cluster templates: %w", err)
+	}
+
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT
+			id, name, provider, workload_class, size,
+			min_replicas, max_replicas, idle_auto_stop_seconds,
+			scaling_policy, storage_profile, result_retention_seconds,
+			created_at, updated_at
+		FROM compute_cluster_templates
+		ORDER BY name ASC
+		LIMIT ? OFFSET ?
+	`, page.Limit(), page.Offset())
+	if err != nil {
+		return nil, 0, fmt.Errorf("list compute cluster templates: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck
+
+	templates := make([]domain.ComputeClusterTemplate, 0)
+	for rows.Next() {
+		tpl, err := scanComputeClusterTemplate(rows)
+		if err != nil {
+			return nil, 0, err
+		}
+		templates = append(templates, *tpl)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("iterate compute cluster templates: %w", err)
+	}
+
+	return templates, total, nil
+}
+
+// Delete removes a managed compute template by ID.
+func (r *ComputeClusterTemplateRepo) Delete(ctx context.Context, id string) error {
+	result, err := r.db.ExecContext(ctx, `DELETE FROM compute_cluster_templates WHERE id = ?`, id)
+	if err != nil {
+		return mapDBError(err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("compute cluster template rows affected: %w", err)
+	}
+	if rows == 0 {
+		return domain.ErrNotFound("compute cluster template %s not found", id)
+	}
+	return nil
+}
+
+type computeClusterTemplateScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanComputeClusterTemplate(scanner computeClusterTemplateScanner) (*domain.ComputeClusterTemplate, error) {
+	var tpl domain.ComputeClusterTemplate
+	var createdAtRaw string
+	var updatedAtRaw string
+
+	if err := scanner.Scan(
+		&tpl.ID,
+		&tpl.Name,
+		&tpl.Provider,
+		&tpl.WorkloadClass,
+		&tpl.Size,
+		&tpl.MinReplicas,
+		&tpl.MaxReplicas,
+		&tpl.IdleAutoStopSeconds,
+		&tpl.ScalingPolicy,
+		&tpl.StorageProfile,
+		&tpl.ResultRetentionSeconds,
+		&createdAtRaw,
+		&updatedAtRaw,
+	); err != nil {
+		return nil, mapDBError(err)
+	}
+
+	tpl.CreatedAt = parseManagedComputeTime(createdAtRaw)
+	tpl.UpdatedAt = parseManagedComputeTime(updatedAtRaw)
+	return &tpl, nil
+}
+
+func parseManagedComputeTime(raw string) time.Time {
+	if raw == "" {
+		return time.Time{}
+	}
+	parsed, err := time.Parse(time.DateTime, raw)
+	if err == nil {
+		return parsed
+	}
+	parsed, err = time.Parse(time.RFC3339Nano, raw)
+	if err == nil {
+		return parsed
+	}
+	return time.Time{}
+}

--- a/internal/db/repository/managed_compute_cluster.go
+++ b/internal/db/repository/managed_compute_cluster.go
@@ -1,0 +1,244 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/Yacobolo/quackstack/internal/domain"
+)
+
+var _ domain.ManagedComputeClusterRepository = (*ManagedComputeClusterRepo)(nil)
+
+// ManagedComputeClusterRepo persists provider-backed clusters bound to logical endpoints.
+type ManagedComputeClusterRepo struct {
+	db *sql.DB
+}
+
+// NewManagedComputeClusterRepo creates a new ManagedComputeClusterRepo.
+func NewManagedComputeClusterRepo(db *sql.DB) *ManagedComputeClusterRepo {
+	return &ManagedComputeClusterRepo{db: db}
+}
+
+// Create inserts a new managed compute cluster row.
+func (r *ManagedComputeClusterRepo) Create(ctx context.Context, cluster *domain.ManagedComputeCluster) (*domain.ManagedComputeCluster, error) {
+	if cluster == nil {
+		return nil, fmt.Errorf("cluster is required")
+	}
+
+	id := cluster.ID
+	if id == "" {
+		id = newID()
+	}
+
+	externalID := cluster.ExternalID
+	if externalID == "" {
+		externalID = id
+	}
+
+	_, err := r.db.ExecContext(ctx, `
+		INSERT INTO managed_compute_clusters (
+			id, name, template_id, endpoint_id, provider, external_id,
+			desired_state, observed_state, min_replicas, max_replicas,
+			is_draining, last_activity_at, endpoint_url
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`,
+		id,
+		cluster.Name,
+		cluster.TemplateID,
+		cluster.EndpointID,
+		cluster.Provider,
+		externalID,
+		cluster.DesiredState,
+		cluster.ObservedState,
+		cluster.MinReplicas,
+		cluster.MaxReplicas,
+		boolToInt64(cluster.IsDraining),
+		nullSQLiteTime(cluster.LastActivityAt),
+		nullStrFromPtr(cluster.EndpointURL),
+	)
+	if err != nil {
+		return nil, mapDBError(err)
+	}
+
+	return r.GetByID(ctx, id)
+}
+
+// GetByID returns a managed compute cluster by ID.
+func (r *ManagedComputeClusterRepo) GetByID(ctx context.Context, id string) (*domain.ManagedComputeCluster, error) {
+	row := r.db.QueryRowContext(ctx, managedComputeClusterSelect+` WHERE id = ?`, id)
+	return scanManagedComputeCluster(row)
+}
+
+// GetByName returns a managed compute cluster by name.
+func (r *ManagedComputeClusterRepo) GetByName(ctx context.Context, name string) (*domain.ManagedComputeCluster, error) {
+	row := r.db.QueryRowContext(ctx, managedComputeClusterSelect+` WHERE name = ?`, name)
+	return scanManagedComputeCluster(row)
+}
+
+// GetByEndpointID returns the managed compute cluster bound to an endpoint.
+func (r *ManagedComputeClusterRepo) GetByEndpointID(ctx context.Context, endpointID string) (*domain.ManagedComputeCluster, error) {
+	row := r.db.QueryRowContext(ctx, managedComputeClusterSelect+` WHERE endpoint_id = ?`, endpointID)
+	return scanManagedComputeCluster(row)
+}
+
+// List returns a paginated list of managed compute clusters.
+func (r *ManagedComputeClusterRepo) List(ctx context.Context, page domain.PageRequest) ([]domain.ManagedComputeCluster, int64, error) {
+	var total int64
+	if err := r.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM managed_compute_clusters`).Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("count managed compute clusters: %w", err)
+	}
+
+	rows, err := r.db.QueryContext(ctx, managedComputeClusterSelect+`
+		ORDER BY name ASC
+		LIMIT ? OFFSET ?
+	`, page.Limit(), page.Offset())
+	if err != nil {
+		return nil, 0, fmt.Errorf("list managed compute clusters: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck
+
+	clusters := make([]domain.ManagedComputeCluster, 0)
+	for rows.Next() {
+		cluster, err := scanManagedComputeCluster(rows)
+		if err != nil {
+			return nil, 0, err
+		}
+		clusters = append(clusters, *cluster)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("iterate managed compute clusters: %w", err)
+	}
+
+	return clusters, total, nil
+}
+
+// UpdateDesiredState updates the desired cluster state and draining marker.
+func (r *ManagedComputeClusterRepo) UpdateDesiredState(ctx context.Context, id string, desiredState string) error {
+	result, err := r.db.ExecContext(ctx, `
+		UPDATE managed_compute_clusters
+		SET desired_state = ?, is_draining = ?, updated_at = datetime('now')
+		WHERE id = ?
+	`,
+		desiredState,
+		boolToInt64(desiredState == domain.ManagedClusterDesiredDraining),
+		id,
+	)
+	if err != nil {
+		return mapDBError(err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("managed compute cluster rows affected: %w", err)
+	}
+	if rows == 0 {
+		return domain.ErrNotFound("managed compute cluster %s not found", id)
+	}
+	return nil
+}
+
+// UpdateObservedState updates the observed cluster state and connection snapshot.
+func (r *ManagedComputeClusterRepo) UpdateObservedState(ctx context.Context, id string, observedState string, endpointURL *string, lastActivityAt *time.Time) error {
+	result, err := r.db.ExecContext(ctx, `
+		UPDATE managed_compute_clusters
+		SET observed_state = ?, endpoint_url = ?, last_activity_at = ?, updated_at = datetime('now')
+		WHERE id = ?
+	`,
+		observedState,
+		nullStrFromPtr(endpointURL),
+		nullSQLiteTime(lastActivityAt),
+		id,
+	)
+	if err != nil {
+		return mapDBError(err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("managed compute cluster rows affected: %w", err)
+	}
+	if rows == 0 {
+		return domain.ErrNotFound("managed compute cluster %s not found", id)
+	}
+	return nil
+}
+
+// Delete removes a managed compute cluster by ID.
+func (r *ManagedComputeClusterRepo) Delete(ctx context.Context, id string) error {
+	result, err := r.db.ExecContext(ctx, `DELETE FROM managed_compute_clusters WHERE id = ?`, id)
+	if err != nil {
+		return mapDBError(err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("managed compute cluster rows affected: %w", err)
+	}
+	if rows == 0 {
+		return domain.ErrNotFound("managed compute cluster %s not found", id)
+	}
+	return nil
+}
+
+const managedComputeClusterSelect = `
+	SELECT
+		id, name, template_id, endpoint_id, provider, external_id,
+		desired_state, observed_state, min_replicas, max_replicas,
+		is_draining, last_activity_at, endpoint_url, created_at, updated_at
+	FROM managed_compute_clusters
+`
+
+type managedComputeClusterScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanManagedComputeCluster(scanner managedComputeClusterScanner) (*domain.ManagedComputeCluster, error) {
+	var cluster domain.ManagedComputeCluster
+	var isDraining int64
+	var endpointURL sql.NullString
+	var lastActivityRaw sql.NullString
+	var createdAtRaw string
+	var updatedAtRaw string
+
+	if err := scanner.Scan(
+		&cluster.ID,
+		&cluster.Name,
+		&cluster.TemplateID,
+		&cluster.EndpointID,
+		&cluster.Provider,
+		&cluster.ExternalID,
+		&cluster.DesiredState,
+		&cluster.ObservedState,
+		&cluster.MinReplicas,
+		&cluster.MaxReplicas,
+		&isDraining,
+		&lastActivityRaw,
+		&endpointURL,
+		&createdAtRaw,
+		&updatedAtRaw,
+	); err != nil {
+		return nil, mapDBError(err)
+	}
+
+	cluster.IsDraining = isDraining != 0
+	if endpointURL.Valid {
+		cluster.EndpointURL = &endpointURL.String
+	}
+	if lastActivityRaw.Valid {
+		t := parseManagedComputeTime(lastActivityRaw.String)
+		cluster.LastActivityAt = &t
+	}
+	cluster.CreatedAt = parseManagedComputeTime(createdAtRaw)
+	cluster.UpdatedAt = parseManagedComputeTime(updatedAtRaw)
+
+	return &cluster, nil
+}
+
+func nullSQLiteTime(value *time.Time) sql.NullString {
+	if value == nil || value.IsZero() {
+		return sql.NullString{}
+	}
+	return sql.NullString{
+		String: value.UTC().Format(time.DateTime),
+		Valid:  true,
+	}
+}

--- a/internal/db/repository/managed_compute_test.go
+++ b/internal/db/repository/managed_compute_test.go
@@ -1,0 +1,123 @@
+package repository
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	internaldb "github.com/Yacobolo/quackstack/internal/db"
+	"github.com/Yacobolo/quackstack/internal/db/crypto"
+	"github.com/Yacobolo/quackstack/internal/domain"
+)
+
+func setupManagedComputeRepos(t *testing.T) (*ComputeClusterTemplateRepo, *ManagedComputeClusterRepo, *ComputeEndpointRepo) {
+	t.Helper()
+
+	writeDB, _ := internaldb.OpenTestSQLite(t)
+	enc, err := crypto.NewEncryptor("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+	require.NoError(t, err)
+
+	return NewComputeClusterTemplateRepo(writeDB), NewManagedComputeClusterRepo(writeDB), NewComputeEndpointRepo(writeDB, enc)
+}
+
+func TestComputeClusterTemplateRepo_CRUD(t *testing.T) {
+	templateRepo, _, _ := setupManagedComputeRepos(t)
+	ctx := context.Background()
+
+	created, err := templateRepo.Create(ctx, &domain.ComputeClusterTemplate{
+		Name:                   "standard-azure",
+		Provider:               domain.ComputeProviderAzure,
+		WorkloadClass:          domain.ComputeEndpointWorkloadMixed,
+		Size:                   "MEDIUM",
+		MinReplicas:            1,
+		MaxReplicas:            4,
+		IdleAutoStopSeconds:    900,
+		ScalingPolicy:          "queue_depth",
+		StorageProfile:         "hot",
+		ResultRetentionSeconds: 3600,
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, created.ID)
+	assert.False(t, created.CreatedAt.IsZero())
+
+	got, err := templateRepo.GetByName(ctx, "standard-azure")
+	require.NoError(t, err)
+	assert.Equal(t, created.ID, got.ID)
+	assert.Equal(t, domain.ComputeProviderAzure, got.Provider)
+
+	items, total, err := templateRepo.List(ctx, domain.PageRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), total)
+	assert.Len(t, items, 1)
+
+	require.NoError(t, templateRepo.Delete(ctx, created.ID))
+	_, err = templateRepo.GetByID(ctx, created.ID)
+	require.Error(t, err)
+	var notFound *domain.NotFoundError
+	assert.ErrorAs(t, err, &notFound)
+}
+
+func TestManagedComputeClusterRepo_CRUD(t *testing.T) {
+	templateRepo, clusterRepo, endpointRepo := setupManagedComputeRepos(t)
+	ctx := context.Background()
+
+	template, err := templateRepo.Create(ctx, &domain.ComputeClusterTemplate{
+		Name:          "burst",
+		Provider:      domain.ComputeProviderAzure,
+		WorkloadClass: domain.ComputeEndpointWorkloadHeavy,
+		Size:          "LARGE",
+		MinReplicas:   1,
+		MaxReplicas:   8,
+	})
+	require.NoError(t, err)
+
+	endpoint, err := endpointRepo.Create(ctx, &domain.ComputeEndpoint{
+		Name:      "burst-endpoint",
+		URL:       "grpcs://burst.compute.example:9444",
+		Type:      "REMOTE",
+		AuthToken: "top-secret",
+		Owner:     "admin",
+	})
+	require.NoError(t, err)
+
+	cluster, err := clusterRepo.Create(ctx, &domain.ManagedComputeCluster{
+		Name:          "burst-eastus",
+		TemplateID:    template.ID,
+		EndpointID:    endpoint.ID,
+		Provider:      domain.ComputeProviderAzure,
+		ExternalID:    "aks-burst-eastus",
+		DesiredState:  domain.ManagedClusterDesiredRunning,
+		ObservedState: domain.ManagedClusterObservedStarting,
+		MinReplicas:   1,
+		MaxReplicas:   8,
+		EndpointURL:   &endpoint.URL,
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, cluster.ID)
+
+	gotByEndpoint, err := clusterRepo.GetByEndpointID(ctx, endpoint.ID)
+	require.NoError(t, err)
+	assert.Equal(t, cluster.ID, gotByEndpoint.ID)
+
+	require.NoError(t, clusterRepo.UpdateDesiredState(ctx, cluster.ID, domain.ManagedClusterDesiredDraining))
+	require.NoError(t, clusterRepo.UpdateObservedState(ctx, cluster.ID, domain.ManagedClusterObservedReady, &endpoint.URL, nil))
+
+	got, err := clusterRepo.GetByID(ctx, cluster.ID)
+	require.NoError(t, err)
+	assert.Equal(t, domain.ManagedClusterDesiredDraining, got.DesiredState)
+	assert.True(t, got.IsDraining)
+	assert.Equal(t, domain.ManagedClusterObservedReady, got.ObservedState)
+
+	items, total, err := clusterRepo.List(ctx, domain.PageRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), total)
+	assert.Len(t, items, 1)
+
+	require.NoError(t, clusterRepo.Delete(ctx, cluster.ID))
+	_, err = clusterRepo.GetByID(ctx, cluster.ID)
+	require.Error(t, err)
+	var notFound *domain.NotFoundError
+	assert.ErrorAs(t, err, &notFound)
+}

--- a/internal/domain/compute.go
+++ b/internal/domain/compute.go
@@ -31,6 +31,22 @@ const (
 	ComputeReadinessReady       = "READY"
 	ComputeReadinessDegraded    = "DEGRADED"
 	ComputeReadinessUnavailable = "UNAVAILABLE"
+
+	ComputeProviderManual = "manual"
+	ComputeProviderAzure  = "azure"
+	ComputeProviderAWS    = "aws"
+	ComputeProviderGCP    = "gcp"
+
+	ManagedClusterDesiredRunning  = "RUNNING"
+	ManagedClusterDesiredStopped  = "STOPPED"
+	ManagedClusterDesiredDraining = "DRAINING"
+	ManagedClusterDesiredDeleting = "DELETING"
+
+	ManagedClusterObservedStarting = "STARTING"
+	ManagedClusterObservedReady    = "READY"
+	ManagedClusterObservedDegraded = "DEGRADED"
+	ManagedClusterObservedStopped  = "STOPPED"
+	ManagedClusterObservedError    = "ERROR"
 )
 
 // ComputeEndpoint represents a SQL compute resource (local or remote DuckDB instance).
@@ -59,10 +75,19 @@ type ComputeEndpoint struct {
 	StoredJobs                 *int64
 	CleanedJobs                *int64
 	QueryResultTTLSeconds      *int64
+	ManagedBacking             *ComputeEndpointBacking
+	LastActivityAt             *time.Time
 	AuthToken                  string // pre-shared secret (AES-256-GCM encrypted at rest)
 	Owner                      string // principal who created it
 	CreatedAt                  time.Time
 	UpdatedAt                  time.Time
+}
+
+// ComputeEndpointBacking points a logical endpoint at a provider-managed cluster.
+type ComputeEndpointBacking struct {
+	Provider         string
+	ManagedClusterID string
+	TemplateID       string
 }
 
 // ComputeAssignment binds a principal to a compute endpoint.
@@ -236,9 +261,9 @@ type ComputeEndpointHealthResult struct {
 
 // ComputeExecutionRequest captures a caller's compute routing preference.
 type ComputeExecutionRequest struct {
-	Mode         string
-	EndpointName string
-	WorkloadType string
+	Mode                  string
+	EndpointName          string
+	WorkloadType          string
 	AuthoritativeEndpoint bool
 	FallbackLocal         bool
 }
@@ -262,6 +287,67 @@ type ComputeTarget struct {
 	IsDefault                bool
 	SelectableForInteractive bool
 	SelectableForScheduled   bool
+}
+
+// ComputeClusterTemplate describes a provider-neutral cluster template managed by the platform.
+type ComputeClusterTemplate struct {
+	ID                     string
+	Name                   string
+	Provider               string
+	WorkloadClass          string
+	Size                   string
+	MinReplicas            int32
+	MaxReplicas            int32
+	IdleAutoStopSeconds    int64
+	ScalingPolicy          string
+	StorageProfile         string
+	ResultRetentionSeconds int64
+	CreatedAt              time.Time
+	UpdatedAt              time.Time
+}
+
+// ManagedComputeCluster represents a provider-backed compute cluster bound to a logical endpoint.
+type ManagedComputeCluster struct {
+	ID             string
+	Name           string
+	TemplateID     string
+	EndpointID     string
+	Provider       string
+	ExternalID     string
+	DesiredState   string
+	ObservedState  string
+	MinReplicas    int32
+	MaxReplicas    int32
+	IsDraining     bool
+	LastActivityAt *time.Time
+	EndpointURL    *string
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+}
+
+// CreateComputeClusterTemplateRequest holds parameters for creating a managed cluster template.
+type CreateComputeClusterTemplateRequest struct {
+	Name                   string
+	Provider               string
+	WorkloadClass          string
+	Size                   string
+	MinReplicas            int32
+	MaxReplicas            int32
+	IdleAutoStopSeconds    int64
+	ScalingPolicy          string
+	StorageProfile         string
+	ResultRetentionSeconds int64
+}
+
+// CreateManagedComputeClusterRequest holds parameters for creating a managed cluster.
+type CreateManagedComputeClusterRequest struct {
+	Name         string
+	TemplateID   string
+	EndpointID   string
+	Provider     string
+	DesiredState string
+	MinReplicas  int32
+	MaxReplicas  int32
 }
 
 // Validate normalizes and validates a compute execution request.
@@ -327,6 +413,96 @@ func normalizeComputeDefaultMode(mode, fallback string) string {
 		return fallback
 	}
 	return mode
+}
+
+// Validate checks that the request is well-formed.
+func (r *CreateComputeClusterTemplateRequest) Validate() error {
+	return ValidateCreateComputeClusterTemplateRequest(*r)
+}
+
+// ValidateCreateComputeClusterTemplateRequest validates a managed cluster template create request.
+func ValidateCreateComputeClusterTemplateRequest(r CreateComputeClusterTemplateRequest) error {
+	if strings.TrimSpace(r.Name) == "" {
+		return ErrValidation("name is required")
+	}
+	if err := validateComputeProvider(r.Provider); err != nil {
+		return err
+	}
+	if err := validateComputeEndpointWorkloadClass(r.WorkloadClass); err != nil {
+		return err
+	}
+	if r.MinReplicas < 0 {
+		return ErrValidation("min_replicas must be greater than or equal to zero")
+	}
+	if r.MaxReplicas <= 0 {
+		return ErrValidation("max_replicas must be greater than zero")
+	}
+	if r.MaxReplicas < r.MinReplicas {
+		return ErrValidation("max_replicas must be greater than or equal to min_replicas")
+	}
+	if r.IdleAutoStopSeconds < 0 {
+		return ErrValidation("idle_auto_stop_seconds must be greater than or equal to zero")
+	}
+	if r.ResultRetentionSeconds < 0 {
+		return ErrValidation("result_retention_seconds must be greater than or equal to zero")
+	}
+	return nil
+}
+
+// Validate checks that the request is well-formed.
+func (r *CreateManagedComputeClusterRequest) Validate() error {
+	return ValidateCreateManagedComputeClusterRequest(*r)
+}
+
+// ValidateCreateManagedComputeClusterRequest validates a managed cluster create request.
+func ValidateCreateManagedComputeClusterRequest(r CreateManagedComputeClusterRequest) error {
+	if strings.TrimSpace(r.Name) == "" {
+		return ErrValidation("name is required")
+	}
+	if strings.TrimSpace(r.TemplateID) == "" {
+		return ErrValidation("template_id is required")
+	}
+	if strings.TrimSpace(r.EndpointID) == "" {
+		return ErrValidation("endpoint_id is required")
+	}
+	if strings.TrimSpace(r.Provider) != "" {
+		if err := validateComputeProvider(r.Provider); err != nil {
+			return err
+		}
+	}
+	if strings.TrimSpace(r.DesiredState) != "" {
+		if err := validateManagedClusterDesiredState(r.DesiredState); err != nil {
+			return err
+		}
+	}
+	if r.MinReplicas < 0 {
+		return ErrValidation("min_replicas must be greater than or equal to zero")
+	}
+	if r.MaxReplicas < 0 {
+		return ErrValidation("max_replicas must be greater than or equal to zero")
+	}
+	if r.MaxReplicas > 0 && r.MaxReplicas < r.MinReplicas {
+		return ErrValidation("max_replicas must be greater than or equal to min_replicas")
+	}
+	return nil
+}
+
+func validateComputeProvider(provider string) error {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case ComputeProviderManual, ComputeProviderAzure, ComputeProviderAWS, ComputeProviderGCP:
+		return nil
+	default:
+		return ErrValidation("provider must be manual, azure, aws, or gcp, got %q", provider)
+	}
+}
+
+func validateManagedClusterDesiredState(state string) error {
+	switch strings.ToUpper(strings.TrimSpace(state)) {
+	case ManagedClusterDesiredRunning, ManagedClusterDesiredStopped, ManagedClusterDesiredDraining, ManagedClusterDesiredDeleting:
+		return nil
+	default:
+		return ErrValidation("desired_state must be RUNNING, STOPPED, DRAINING, or DELETING, got %q", state)
+	}
 }
 
 func validateComputeSelectionPolicy(policy string) error {

--- a/internal/domain/compute_test.go
+++ b/internal/domain/compute_test.go
@@ -222,3 +222,140 @@ func TestValidateCreateComputeAssignmentRequest(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateCreateComputeClusterTemplateRequest(t *testing.T) {
+	tests := []struct {
+		name    string
+		req     CreateComputeClusterTemplateRequest
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid_template",
+			req: CreateComputeClusterTemplateRequest{
+				Name:                "analytics-heavy",
+				Provider:            ComputeProviderAzure,
+				WorkloadClass:       ComputeEndpointWorkloadHeavy,
+				MinReplicas:         1,
+				MaxReplicas:         4,
+				IdleAutoStopSeconds: 900,
+			},
+		},
+		{
+			name: "missing_name",
+			req: CreateComputeClusterTemplateRequest{
+				Provider:      ComputeProviderAzure,
+				WorkloadClass: ComputeEndpointWorkloadHeavy,
+				MinReplicas:   1,
+				MaxReplicas:   2,
+			},
+			wantErr: true,
+			errMsg:  "name is required",
+		},
+		{
+			name: "invalid_provider",
+			req: CreateComputeClusterTemplateRequest{
+				Name:          "bad",
+				Provider:      "digitalocean",
+				WorkloadClass: ComputeEndpointWorkloadHeavy,
+				MinReplicas:   1,
+				MaxReplicas:   2,
+			},
+			wantErr: true,
+			errMsg:  "provider must be manual, azure, aws, or gcp",
+		},
+		{
+			name: "max_less_than_min",
+			req: CreateComputeClusterTemplateRequest{
+				Name:          "bad-scale",
+				Provider:      ComputeProviderAzure,
+				WorkloadClass: ComputeEndpointWorkloadHeavy,
+				MinReplicas:   3,
+				MaxReplicas:   2,
+			},
+			wantErr: true,
+			errMsg:  "max_replicas must be greater than or equal to min_replicas",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateCreateComputeClusterTemplateRequest(tt.req)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateCreateManagedComputeClusterRequest(t *testing.T) {
+	tests := []struct {
+		name    string
+		req     CreateManagedComputeClusterRequest
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid_cluster",
+			req: CreateManagedComputeClusterRequest{
+				Name:         "analytics-heavy-a",
+				TemplateID:   "tpl-1",
+				EndpointID:   "ep-1",
+				Provider:     ComputeProviderAzure,
+				DesiredState: ManagedClusterDesiredRunning,
+				MinReplicas:  1,
+				MaxReplicas:  3,
+			},
+		},
+		{
+			name: "valid_cluster_inherits_template_defaults",
+			req: CreateManagedComputeClusterRequest{
+				Name:       "analytics-heavy-b",
+				TemplateID: "tpl-1",
+				EndpointID: "ep-1",
+			},
+		},
+		{
+			name: "missing_template",
+			req: CreateManagedComputeClusterRequest{
+				Name:         "cluster-a",
+				EndpointID:   "ep-1",
+				Provider:     ComputeProviderAzure,
+				DesiredState: ManagedClusterDesiredRunning,
+				MinReplicas:  1,
+				MaxReplicas:  3,
+			},
+			wantErr: true,
+			errMsg:  "template_id is required",
+		},
+		{
+			name: "invalid_state",
+			req: CreateManagedComputeClusterRequest{
+				Name:         "cluster-a",
+				TemplateID:   "tpl-1",
+				EndpointID:   "ep-1",
+				Provider:     ComputeProviderAzure,
+				DesiredState: "PAUSED",
+				MinReplicas:  1,
+				MaxReplicas:  3,
+			},
+			wantErr: true,
+			errMsg:  "desired_state must be RUNNING, STOPPED, DRAINING, or DELETING",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateCreateManagedComputeClusterRequest(tt.req)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/domain/repository.go
+++ b/internal/domain/repository.go
@@ -489,6 +489,27 @@ type ComputeRoutingRepository interface {
 	UpdateDefaults(ctx context.Context, defaults ComputeRoutingDefaults) (*ComputeRoutingDefaults, error)
 }
 
+// ComputeClusterTemplateRepository manages platform-owned managed compute templates.
+type ComputeClusterTemplateRepository interface {
+	Create(ctx context.Context, tpl *ComputeClusterTemplate) (*ComputeClusterTemplate, error)
+	GetByID(ctx context.Context, id string) (*ComputeClusterTemplate, error)
+	GetByName(ctx context.Context, name string) (*ComputeClusterTemplate, error)
+	List(ctx context.Context, page PageRequest) ([]ComputeClusterTemplate, int64, error)
+	Delete(ctx context.Context, id string) error
+}
+
+// ManagedComputeClusterRepository manages provider-backed clusters behind logical compute endpoints.
+type ManagedComputeClusterRepository interface {
+	Create(ctx context.Context, cluster *ManagedComputeCluster) (*ManagedComputeCluster, error)
+	GetByID(ctx context.Context, id string) (*ManagedComputeCluster, error)
+	GetByName(ctx context.Context, name string) (*ManagedComputeCluster, error)
+	GetByEndpointID(ctx context.Context, endpointID string) (*ManagedComputeCluster, error)
+	List(ctx context.Context, page PageRequest) ([]ManagedComputeCluster, int64, error)
+	UpdateDesiredState(ctx context.Context, id string, desiredState string) error
+	UpdateObservedState(ctx context.Context, id string, observedState string, endpointURL *string, lastActivityAt *time.Time) error
+	Delete(ctx context.Context, id string) error
+}
+
 // NotebookRepository provides CRUD operations for notebooks and cells.
 type NotebookRepository interface {
 	CreateNotebook(ctx context.Context, nb *Notebook) (*Notebook, error)

--- a/internal/platform/azure_provider.go
+++ b/internal/platform/azure_provider.go
@@ -1,0 +1,173 @@
+package platform
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/Yacobolo/quackstack/internal/config"
+)
+
+type azureProvider struct {
+	controlDB ControlPlaneDatabase
+	storage   ObjectStorage
+	ingress   Ingress
+	identity  Identity
+	compute   ComputeLifecycle
+	secrets   SecretsRuntime
+}
+
+func newAzureProvider(cfg *config.Config) Provider {
+	return &azureProvider{
+		controlDB: azureControlPlaneDatabase{cfg: cfg},
+		storage:   azureObjectStorage{},
+		ingress:   azureIngress{},
+		identity:  azureIdentity{},
+		compute:   azureComputeLifecycle{},
+		secrets:   azureSecretsRuntime{},
+	}
+}
+
+func (p *azureProvider) Name() string                               { return ProviderAzure }
+func (p *azureProvider) ControlPlaneDatabase() ControlPlaneDatabase { return p.controlDB }
+func (p *azureProvider) ObjectStorage() ObjectStorage               { return p.storage }
+func (p *azureProvider) Ingress() Ingress                           { return p.ingress }
+func (p *azureProvider) Identity() Identity                         { return p.identity }
+func (p *azureProvider) ComputeLifecycle() ComputeLifecycle         { return p.compute }
+func (p *azureProvider) SecretsRuntime() SecretsRuntime             { return p.secrets }
+
+type azureControlPlaneDatabase struct{ cfg *config.Config }
+
+func (d azureControlPlaneDatabase) Driver() string { return d.cfg.ControlDBDriver }
+func (d azureControlPlaneDatabase) Connect(context.Context) error {
+	if strings.TrimSpace(d.cfg.ControlDBDSN) == "" {
+		return &CapabilityNotConfiguredError{Provider: ProviderAzure, Capability: "control-plane postgres DSN"}
+	}
+	return nil
+}
+func (d azureControlPlaneDatabase) Migrate(context.Context) error {
+	return &CapabilityNotConfiguredError{Provider: ProviderAzure, Capability: "postgres migrations"}
+}
+func (d azureControlPlaneDatabase) HealthCheck(context.Context) error { return nil }
+func (d azureControlPlaneDatabase) Backup(context.Context) error      { return nil }
+func (d azureControlPlaneDatabase) Restore(context.Context) error {
+	return &CapabilityNotConfiguredError{Provider: ProviderAzure, Capability: "control-plane restore"}
+}
+
+type azureObjectStorage struct{}
+
+func (azureObjectStorage) Name() string                      { return "azure-blob" }
+func (azureObjectStorage) HealthCheck(context.Context) error { return nil }
+func (azureObjectStorage) WriteArtifact(context.Context, ArtifactRef) error {
+	return &CapabilityNotConfiguredError{Provider: ProviderAzure, Capability: "artifact writes"}
+}
+func (azureObjectStorage) ApplyRetention(context.Context, ArtifactRef) error {
+	return &CapabilityNotConfiguredError{Provider: ProviderAzure, Capability: "artifact retention"}
+}
+
+type azureIngress struct{}
+
+func (azureIngress) Name() string                                   { return "azure-ingress" }
+func (azureIngress) HealthCheck(context.Context) error              { return nil }
+func (azureIngress) ExposeHTTP(context.Context, ExposureSpec) error { return nil }
+func (azureIngress) ExposeGRPC(context.Context, ExposureSpec) error { return nil }
+
+type azureIdentity struct{}
+
+func (azureIdentity) Name() string                                            { return "azure-workload-identity" }
+func (azureIdentity) HealthCheck(context.Context) error                       { return nil }
+func (azureIdentity) ConfigureOIDC(context.Context, string) error             { return nil }
+func (azureIdentity) ConfigureWorkloadIdentity(context.Context, string) error { return nil }
+
+type azureComputeLifecycle struct{}
+
+func (azureComputeLifecycle) Name() string { return "aks-managed-compute" }
+func (azureComputeLifecycle) CreateCluster(_ context.Context, spec ClusterSpec) (*ClusterState, error) {
+	now := time.Now().UTC()
+	return &ClusterState{
+		ID:                spec.Name,
+		Name:              spec.Name,
+		DesiredState:      "RUNNING",
+		ObservedState:     "STARTING",
+		LastActivityAt:    &now,
+		Connection:        azureConnectionForCluster(spec.Name),
+		AvailableReplicas: 0,
+	}, nil
+}
+func (azureComputeLifecycle) StartCluster(_ context.Context, clusterID string) (*ClusterState, error) {
+	now := time.Now().UTC()
+	return &ClusterState{
+		ID:                clusterID,
+		Name:              clusterID,
+		DesiredState:      "RUNNING",
+		ObservedState:     "READY",
+		LastActivityAt:    &now,
+		Connection:        azureConnectionForCluster(clusterID),
+		AvailableReplicas: 1,
+	}, nil
+}
+func (azureComputeLifecycle) StopCluster(_ context.Context, clusterID string) (*ClusterState, error) {
+	return &ClusterState{
+		ID:                clusterID,
+		Name:              clusterID,
+		DesiredState:      "STOPPED",
+		ObservedState:     "STOPPED",
+		AvailableReplicas: 0,
+	}, nil
+}
+func (azureComputeLifecycle) DrainCluster(_ context.Context, clusterID string) (*ClusterState, error) {
+	now := time.Now().UTC()
+	return &ClusterState{
+		ID:                clusterID,
+		Name:              clusterID,
+		DesiredState:      "DRAINING",
+		ObservedState:     "DEGRADED",
+		LastActivityAt:    &now,
+		Connection:        azureConnectionForCluster(clusterID),
+		AvailableReplicas: 1,
+	}, nil
+}
+func (azureComputeLifecycle) DeleteCluster(context.Context, string) error {
+	return nil
+}
+func (azureComputeLifecycle) ResizeCluster(_ context.Context, clusterID string, _ ClusterSize) (*ClusterState, error) {
+	now := time.Now().UTC()
+	return &ClusterState{
+		ID:                clusterID,
+		Name:              clusterID,
+		DesiredState:      "RUNNING",
+		ObservedState:     "READY",
+		LastActivityAt:    &now,
+		Connection:        azureConnectionForCluster(clusterID),
+		AvailableReplicas: 1,
+	}, nil
+}
+func (azureComputeLifecycle) ResolveConnection(_ context.Context, clusterID string) (*ConnectionInfo, error) {
+	return azureConnectionForCluster(clusterID), nil
+}
+func (azureComputeLifecycle) ReportStatus(_ context.Context, clusterID string) (*ClusterState, error) {
+	now := time.Now().UTC()
+	return &ClusterState{
+		ID:                clusterID,
+		Name:              clusterID,
+		DesiredState:      "RUNNING",
+		ObservedState:     "READY",
+		LastActivityAt:    &now,
+		Connection:        azureConnectionForCluster(clusterID),
+		AvailableReplicas: 1,
+	}, nil
+}
+
+type azureSecretsRuntime struct{}
+
+func (azureSecretsRuntime) Name() string                               { return "managed-secrets" }
+func (azureSecretsRuntime) HealthCheck(context.Context) error          { return nil }
+func (azureSecretsRuntime) InjectSecret(context.Context, string) error { return nil }
+func (azureSecretsRuntime) RotateSecret(context.Context, string) error { return nil }
+
+func azureConnectionForCluster(clusterID string) *ConnectionInfo {
+	return &ConnectionInfo{
+		URL:       "grpcs://" + clusterID + ".compute.quackstack.local:9444",
+		AuthToken: clusterID + "-token",
+	}
+}

--- a/internal/platform/manual_provider.go
+++ b/internal/platform/manual_provider.go
@@ -1,0 +1,114 @@
+package platform
+
+import (
+	"context"
+
+	"github.com/Yacobolo/quackstack/internal/config"
+)
+
+type manualProvider struct {
+	controlDB ControlPlaneDatabase
+	storage   ObjectStorage
+	ingress   Ingress
+	identity  Identity
+	compute   ComputeLifecycle
+	secrets   SecretsRuntime
+}
+
+func newManualProvider(cfg *config.Config) Provider {
+	return &manualProvider{
+		controlDB: manualControlPlaneDatabase{cfg: cfg},
+		storage:   manualObjectStorage{},
+		ingress:   manualIngress{},
+		identity:  manualIdentity{},
+		compute:   manualComputeLifecycle{},
+		secrets:   manualSecretsRuntime{},
+	}
+}
+
+func (p *manualProvider) Name() string                               { return ProviderManual }
+func (p *manualProvider) ControlPlaneDatabase() ControlPlaneDatabase { return p.controlDB }
+func (p *manualProvider) ObjectStorage() ObjectStorage               { return p.storage }
+func (p *manualProvider) Ingress() Ingress                           { return p.ingress }
+func (p *manualProvider) Identity() Identity                         { return p.identity }
+func (p *manualProvider) ComputeLifecycle() ComputeLifecycle         { return p.compute }
+func (p *manualProvider) SecretsRuntime() SecretsRuntime             { return p.secrets }
+
+type manualControlPlaneDatabase struct{ cfg *config.Config }
+
+func (d manualControlPlaneDatabase) Driver() string                    { return d.cfg.ControlDBDriver }
+func (d manualControlPlaneDatabase) Connect(context.Context) error     { return nil }
+func (d manualControlPlaneDatabase) Migrate(context.Context) error     { return nil }
+func (d manualControlPlaneDatabase) HealthCheck(context.Context) error { return nil }
+func (d manualControlPlaneDatabase) Backup(context.Context) error {
+	return &CapabilityNotConfiguredError{Provider: ProviderManual, Capability: "control-plane backup"}
+}
+func (d manualControlPlaneDatabase) Restore(context.Context) error {
+	return &CapabilityNotConfiguredError{Provider: ProviderManual, Capability: "control-plane restore"}
+}
+
+type manualObjectStorage struct{}
+
+func (manualObjectStorage) Name() string                      { return "compose-artifacts" }
+func (manualObjectStorage) HealthCheck(context.Context) error { return nil }
+func (manualObjectStorage) WriteArtifact(context.Context, ArtifactRef) error {
+	return &CapabilityNotConfiguredError{Provider: ProviderManual, Capability: "artifact writes"}
+}
+func (manualObjectStorage) ApplyRetention(context.Context, ArtifactRef) error {
+	return &CapabilityNotConfiguredError{Provider: ProviderManual, Capability: "artifact retention"}
+}
+
+type manualIngress struct{}
+
+func (manualIngress) Name() string                                   { return "local-ingress" }
+func (manualIngress) HealthCheck(context.Context) error              { return nil }
+func (manualIngress) ExposeHTTP(context.Context, ExposureSpec) error { return nil }
+func (manualIngress) ExposeGRPC(context.Context, ExposureSpec) error { return nil }
+
+type manualIdentity struct{}
+
+func (manualIdentity) Name() string                      { return "local-auth" }
+func (manualIdentity) HealthCheck(context.Context) error { return nil }
+func (manualIdentity) ConfigureOIDC(context.Context, string) error {
+	return &CapabilityNotConfiguredError{Provider: ProviderManual, Capability: "OIDC configuration"}
+}
+func (manualIdentity) ConfigureWorkloadIdentity(context.Context, string) error {
+	return &CapabilityNotConfiguredError{Provider: ProviderManual, Capability: "workload identity"}
+}
+
+type manualComputeLifecycle struct{}
+
+func (manualComputeLifecycle) Name() string { return "static-compute" }
+func (manualComputeLifecycle) CreateCluster(context.Context, ClusterSpec) (*ClusterState, error) {
+	return nil, &CapabilityNotConfiguredError{Provider: ProviderManual, Capability: "managed compute create"}
+}
+func (manualComputeLifecycle) StartCluster(context.Context, string) (*ClusterState, error) {
+	return nil, &CapabilityNotConfiguredError{Provider: ProviderManual, Capability: "managed compute start"}
+}
+func (manualComputeLifecycle) StopCluster(context.Context, string) (*ClusterState, error) {
+	return nil, &CapabilityNotConfiguredError{Provider: ProviderManual, Capability: "managed compute stop"}
+}
+func (manualComputeLifecycle) DrainCluster(context.Context, string) (*ClusterState, error) {
+	return nil, &CapabilityNotConfiguredError{Provider: ProviderManual, Capability: "managed compute drain"}
+}
+func (manualComputeLifecycle) DeleteCluster(context.Context, string) error {
+	return &CapabilityNotConfiguredError{Provider: ProviderManual, Capability: "managed compute delete"}
+}
+func (manualComputeLifecycle) ResizeCluster(context.Context, string, ClusterSize) (*ClusterState, error) {
+	return nil, &CapabilityNotConfiguredError{Provider: ProviderManual, Capability: "managed compute resize"}
+}
+func (manualComputeLifecycle) ResolveConnection(context.Context, string) (*ConnectionInfo, error) {
+	return nil, &CapabilityNotConfiguredError{Provider: ProviderManual, Capability: "managed compute connection resolution"}
+}
+func (manualComputeLifecycle) ReportStatus(context.Context, string) (*ClusterState, error) {
+	return nil, &CapabilityNotConfiguredError{Provider: ProviderManual, Capability: "managed compute status reporting"}
+}
+
+type manualSecretsRuntime struct{}
+
+func (manualSecretsRuntime) Name() string                               { return "env-file" }
+func (manualSecretsRuntime) HealthCheck(context.Context) error          { return nil }
+func (manualSecretsRuntime) InjectSecret(context.Context, string) error { return nil }
+func (manualSecretsRuntime) RotateSecret(context.Context, string) error {
+	return &CapabilityNotConfiguredError{Provider: ProviderManual, Capability: "secret rotation"}
+}

--- a/internal/platform/provider.go
+++ b/internal/platform/provider.go
@@ -1,0 +1,148 @@
+package platform
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Yacobolo/quackstack/internal/config"
+)
+
+const (
+	ProviderManual = "manual"
+	ProviderAzure  = "azure"
+	ProviderAWS    = "aws"
+	ProviderGCP    = "gcp"
+)
+
+// Provider bundles the platform capabilities QuackStack expects from a deployment target.
+type Provider interface {
+	Name() string
+	ControlPlaneDatabase() ControlPlaneDatabase
+	ObjectStorage() ObjectStorage
+	Ingress() Ingress
+	Identity() Identity
+	ComputeLifecycle() ComputeLifecycle
+	SecretsRuntime() SecretsRuntime
+}
+
+// ControlPlaneDatabase manages the authoritative control-plane metadata store.
+type ControlPlaneDatabase interface {
+	Driver() string
+	Connect(ctx context.Context) error
+	Migrate(ctx context.Context) error
+	HealthCheck(ctx context.Context) error
+	Backup(ctx context.Context) error
+	Restore(ctx context.Context) error
+}
+
+// ObjectStorage manages artifact and result storage for enterprise workflows.
+type ObjectStorage interface {
+	Name() string
+	HealthCheck(ctx context.Context) error
+	WriteArtifact(ctx context.Context, ref ArtifactRef) error
+	ApplyRetention(ctx context.Context, ref ArtifactRef) error
+}
+
+// Ingress manages HTTP and gRPC exposure concerns.
+type Ingress interface {
+	Name() string
+	HealthCheck(ctx context.Context) error
+	ExposeHTTP(ctx context.Context, spec ExposureSpec) error
+	ExposeGRPC(ctx context.Context, spec ExposureSpec) error
+}
+
+// Identity manages both user-facing auth integration and workload identity.
+type Identity interface {
+	Name() string
+	HealthCheck(ctx context.Context) error
+	ConfigureOIDC(ctx context.Context, issuerURL string) error
+	ConfigureWorkloadIdentity(ctx context.Context, serviceAccount string) error
+}
+
+// ComputeLifecycle manages provider-backed compute clusters.
+type ComputeLifecycle interface {
+	Name() string
+	CreateCluster(ctx context.Context, spec ClusterSpec) (*ClusterState, error)
+	StartCluster(ctx context.Context, clusterID string) (*ClusterState, error)
+	StopCluster(ctx context.Context, clusterID string) (*ClusterState, error)
+	DrainCluster(ctx context.Context, clusterID string) (*ClusterState, error)
+	DeleteCluster(ctx context.Context, clusterID string) error
+	ResizeCluster(ctx context.Context, clusterID string, size ClusterSize) (*ClusterState, error)
+	ResolveConnection(ctx context.Context, clusterID string) (*ConnectionInfo, error)
+	ReportStatus(ctx context.Context, clusterID string) (*ClusterState, error)
+}
+
+// SecretsRuntime manages configuration and secrets injection for workloads.
+type SecretsRuntime interface {
+	Name() string
+	HealthCheck(ctx context.Context) error
+	InjectSecret(ctx context.Context, name string) error
+	RotateSecret(ctx context.Context, name string) error
+}
+
+type ArtifactRef struct {
+	Bucket string
+	Key    string
+}
+
+type ExposureSpec struct {
+	Name string
+	Host string
+	Port int
+}
+
+type ClusterSpec struct {
+	Name          string
+	WorkloadClass string
+	MinReplicas   int32
+	MaxReplicas   int32
+	IdleTimeout   time.Duration
+}
+
+type ClusterSize struct {
+	Tier     string
+	MemoryGB *int64
+}
+
+type ConnectionInfo struct {
+	URL       string
+	AuthToken string
+}
+
+type ClusterState struct {
+	ID                string
+	Name              string
+	DesiredState      string
+	ObservedState     string
+	LastActivityAt    *time.Time
+	Connection        *ConnectionInfo
+	AvailableReplicas int32
+}
+
+// CapabilityNotConfiguredError reports an expected provider capability that is not yet wired.
+type CapabilityNotConfiguredError struct {
+	Provider   string
+	Capability string
+}
+
+func (e *CapabilityNotConfiguredError) Error() string {
+	return fmt.Sprintf("%s provider does not have %s configured", e.Provider, e.Capability)
+}
+
+// NewProvider selects the configured platform provider.
+func NewProvider(cfg *config.Config) (Provider, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("config is required")
+	}
+
+	switch strings.ToLower(strings.TrimSpace(cfg.PlatformProvider)) {
+	case ProviderManual:
+		return newManualProvider(cfg), nil
+	case ProviderAzure:
+		return newAzureProvider(cfg), nil
+	default:
+		return nil, fmt.Errorf("unsupported PLATFORM_PROVIDER %q", cfg.PlatformProvider)
+	}
+}

--- a/internal/platform/provider_test.go
+++ b/internal/platform/provider_test.go
@@ -1,0 +1,31 @@
+package platform
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Yacobolo/quackstack/internal/config"
+)
+
+func TestNewProvider_DefaultsToManual(t *testing.T) {
+	provider, err := NewProvider(&config.Config{PlatformProvider: "manual", ControlDBDriver: "sqlite"})
+	require.NoError(t, err)
+	assert.Equal(t, ProviderManual, provider.Name())
+	assert.Equal(t, "sqlite", provider.ControlPlaneDatabase().Driver())
+}
+
+func TestNewProvider_SelectsAzure(t *testing.T) {
+	provider, err := NewProvider(&config.Config{PlatformProvider: "azure", ControlDBDriver: "postgres"})
+	require.NoError(t, err)
+	assert.Equal(t, ProviderAzure, provider.Name())
+	assert.Equal(t, "postgres", provider.ControlPlaneDatabase().Driver())
+	assert.Equal(t, "aks-managed-compute", provider.ComputeLifecycle().Name())
+}
+
+func TestNewProvider_RejectsUnknownProvider(t *testing.T) {
+	_, err := NewProvider(&config.Config{PlatformProvider: "unknown"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported PLATFORM_PROVIDER")
+}

--- a/internal/service/compute/endpoint.go
+++ b/internal/service/compute/endpoint.go
@@ -11,6 +11,7 @@ import (
 	workercompute "github.com/Yacobolo/quackstack/internal/compute"
 	computeproto "github.com/Yacobolo/quackstack/internal/compute/proto"
 	"github.com/Yacobolo/quackstack/internal/domain"
+	"github.com/Yacobolo/quackstack/internal/platform"
 	"github.com/Yacobolo/quackstack/internal/service/auditutil"
 	servicepolicy "github.com/Yacobolo/quackstack/internal/service/policy"
 
@@ -25,12 +26,15 @@ import (
 //
 //nolint:revive // Name chosen for clarity across package boundaries
 type ComputeEndpointService struct {
-	repo        domain.ComputeEndpointRepository
-	routingRepo domain.ComputeRoutingRepository
-	principals  domain.PrincipalRepository
-	groups      domain.GroupRepository
-	auth        domain.AuthorizationService
-	audit       domain.AuditRepository
+	repo         domain.ComputeEndpointRepository
+	routingRepo  domain.ComputeRoutingRepository
+	templateRepo domain.ComputeClusterTemplateRepository
+	clusterRepo  domain.ManagedComputeClusterRepository
+	principals   domain.PrincipalRepository
+	groups       domain.GroupRepository
+	auth         domain.AuthorizationService
+	audit        domain.AuditRepository
+	provider     platform.Provider
 }
 
 // NewComputeEndpointService creates a new ComputeEndpointService.
@@ -51,6 +55,16 @@ func (s *ComputeEndpointService) SetRoutingRepository(repo domain.ComputeRouting
 	s.routingRepo = repo
 }
 
+// SetClusterTemplateRepository configures managed compute template storage.
+func (s *ComputeEndpointService) SetClusterTemplateRepository(repo domain.ComputeClusterTemplateRepository) {
+	s.templateRepo = repo
+}
+
+// SetManagedClusterRepository configures managed compute cluster storage.
+func (s *ComputeEndpointService) SetManagedClusterRepository(repo domain.ManagedComputeClusterRepository) {
+	s.clusterRepo = repo
+}
+
 // SetPrincipalRepository configures principal lookup for principal-facing compute APIs.
 func (s *ComputeEndpointService) SetPrincipalRepository(repo domain.PrincipalRepository) {
 	s.principals = repo
@@ -59,6 +73,11 @@ func (s *ComputeEndpointService) SetPrincipalRepository(repo domain.PrincipalRep
 // SetGroupRepository configures group lookup for principal-facing compute APIs.
 func (s *ComputeEndpointService) SetGroupRepository(repo domain.GroupRepository) {
 	s.groups = repo
+}
+
+// SetPlatformProvider configures the platform provider used for managed cluster lifecycle.
+func (s *ComputeEndpointService) SetPlatformProvider(provider platform.Provider) {
+	s.provider = provider
 }
 
 // Create validates and persists a new compute endpoint.
@@ -108,6 +127,9 @@ func (s *ComputeEndpointService) GetByName(ctx context.Context, principal, name 
 	if err != nil {
 		return nil, err
 	}
+	if err := s.hydrateEndpointManagedBacking(ctx, ep); err != nil {
+		return nil, err
+	}
 	if err := s.requireEndpointPrivilege(ctx, principal, ep.ID, domain.PrivManageCompute); err != nil {
 		s.logAuditDenied(ctx, principal, "GET_COMPUTE_ENDPOINT", fmt.Sprintf("Denied get compute endpoint %q", name))
 		return nil, err
@@ -120,7 +142,14 @@ func (s *ComputeEndpointService) List(ctx context.Context, principal string, pag
 	if err := s.requirePrivilege(ctx, principal, domain.PrivManageCompute, "LIST_COMPUTE_ENDPOINTS", "Denied list compute endpoints"); err != nil {
 		return nil, 0, err
 	}
-	return s.repo.List(ctx, page)
+	eps, total, err := s.repo.List(ctx, page)
+	if err != nil {
+		return nil, 0, err
+	}
+	if err := s.hydrateEndpointsManagedBacking(ctx, eps); err != nil {
+		return nil, 0, err
+	}
+	return eps, total, nil
 }
 
 // Update updates a compute endpoint by name.

--- a/internal/service/compute/managed_clusters.go
+++ b/internal/service/compute/managed_clusters.go
@@ -1,0 +1,445 @@
+package compute
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Yacobolo/quackstack/internal/domain"
+	"github.com/Yacobolo/quackstack/internal/platform"
+)
+
+// CreateClusterTemplate persists a provider-neutral managed compute template.
+func (s *ComputeEndpointService) CreateClusterTemplate(ctx context.Context, principal string, req domain.CreateComputeClusterTemplateRequest) (*domain.ComputeClusterTemplate, error) {
+	if err := s.requirePrivilege(ctx, principal, domain.PrivManageCompute, "CREATE_COMPUTE_CLUSTER_TEMPLATE", fmt.Sprintf("Denied create compute cluster template %q", req.Name)); err != nil {
+		return nil, err
+	}
+	if s.templateRepo == nil {
+		return nil, fmt.Errorf("compute cluster template repository is not configured")
+	}
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+
+	tpl := &domain.ComputeClusterTemplate{
+		Name:                   req.Name,
+		Provider:               strings.ToLower(strings.TrimSpace(req.Provider)),
+		WorkloadClass:          strings.ToUpper(strings.TrimSpace(req.WorkloadClass)),
+		Size:                   strings.ToUpper(strings.TrimSpace(req.Size)),
+		MinReplicas:            req.MinReplicas,
+		MaxReplicas:            req.MaxReplicas,
+		IdleAutoStopSeconds:    req.IdleAutoStopSeconds,
+		ScalingPolicy:          strings.TrimSpace(req.ScalingPolicy),
+		StorageProfile:         strings.TrimSpace(req.StorageProfile),
+		ResultRetentionSeconds: req.ResultRetentionSeconds,
+	}
+
+	created, err := s.templateRepo.Create(ctx, tpl)
+	if err != nil {
+		return nil, fmt.Errorf("create compute cluster template: %w", err)
+	}
+	s.logAudit(ctx, principal, "CREATE_COMPUTE_CLUSTER_TEMPLATE", fmt.Sprintf("Created compute cluster template %q", req.Name))
+	return created, nil
+}
+
+// GetClusterTemplateByName returns a managed compute template by name.
+func (s *ComputeEndpointService) GetClusterTemplateByName(ctx context.Context, principal, name string) (*domain.ComputeClusterTemplate, error) {
+	if err := s.requirePrivilege(ctx, principal, domain.PrivManageCompute, "GET_COMPUTE_CLUSTER_TEMPLATE", fmt.Sprintf("Denied get compute cluster template %q", name)); err != nil {
+		return nil, err
+	}
+	if s.templateRepo == nil {
+		return nil, fmt.Errorf("compute cluster template repository is not configured")
+	}
+	return s.templateRepo.GetByName(ctx, name)
+}
+
+// ListClusterTemplates returns all configured managed compute templates.
+func (s *ComputeEndpointService) ListClusterTemplates(ctx context.Context, principal string, page domain.PageRequest) ([]domain.ComputeClusterTemplate, int64, error) {
+	if err := s.requirePrivilege(ctx, principal, domain.PrivManageCompute, "LIST_COMPUTE_CLUSTER_TEMPLATES", "Denied list compute cluster templates"); err != nil {
+		return nil, 0, err
+	}
+	if s.templateRepo == nil {
+		return nil, 0, fmt.Errorf("compute cluster template repository is not configured")
+	}
+	return s.templateRepo.List(ctx, page)
+}
+
+// DeleteClusterTemplate removes a managed compute template by name.
+func (s *ComputeEndpointService) DeleteClusterTemplate(ctx context.Context, principal, name string) error {
+	if err := s.requirePrivilege(ctx, principal, domain.PrivManageCompute, "DELETE_COMPUTE_CLUSTER_TEMPLATE", fmt.Sprintf("Denied delete compute cluster template %q", name)); err != nil {
+		return err
+	}
+	if s.templateRepo == nil {
+		return fmt.Errorf("compute cluster template repository is not configured")
+	}
+
+	tpl, err := s.templateRepo.GetByName(ctx, name)
+	if err != nil {
+		return err
+	}
+	if err := s.templateRepo.Delete(ctx, tpl.ID); err != nil {
+		return fmt.Errorf("delete compute cluster template: %w", err)
+	}
+	s.logAudit(ctx, principal, "DELETE_COMPUTE_CLUSTER_TEMPLATE", fmt.Sprintf("Deleted compute cluster template %q", name))
+	return nil
+}
+
+// CreateManagedCluster creates a provider-backed cluster bound to a logical endpoint.
+func (s *ComputeEndpointService) CreateManagedCluster(ctx context.Context, principal string, req domain.CreateManagedComputeClusterRequest) (*domain.ManagedComputeCluster, error) {
+	if err := s.requirePrivilege(ctx, principal, domain.PrivManageCompute, "CREATE_MANAGED_COMPUTE_CLUSTER", fmt.Sprintf("Denied create managed compute cluster %q", req.Name)); err != nil {
+		return nil, err
+	}
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+
+	lifecycle, err := s.computeLifecycle()
+	if err != nil {
+		return nil, err
+	}
+	if s.templateRepo == nil || s.clusterRepo == nil {
+		return nil, fmt.Errorf("managed compute repositories are not configured")
+	}
+
+	template, err := s.templateRepo.GetByID(ctx, req.TemplateID)
+	if err != nil {
+		return nil, fmt.Errorf("load compute cluster template: %w", err)
+	}
+
+	endpoint, err := s.repo.GetByID(ctx, req.EndpointID)
+	if err != nil {
+		return nil, fmt.Errorf("load compute endpoint: %w", err)
+	}
+	if endpoint.Type != "REMOTE" {
+		return nil, domain.ErrValidation("managed compute clusters require a REMOTE compute endpoint")
+	}
+
+	providerName := normalizeManagedClusterProvider(req.Provider, template.Provider)
+	if providerName != s.provider.Name() {
+		return nil, domain.ErrValidation("managed compute cluster provider %q does not match configured platform provider %q", providerName, s.provider.Name())
+	}
+
+	spec := platform.ClusterSpec{
+		Name:          req.Name,
+		WorkloadClass: template.WorkloadClass,
+		MinReplicas:   chooseManagedClusterReplicaCount(req.MinReplicas, template.MinReplicas),
+		MaxReplicas:   chooseManagedClusterReplicaCount(req.MaxReplicas, template.MaxReplicas),
+		IdleTimeout:   time.Duration(template.IdleAutoStopSeconds) * time.Second,
+	}
+
+	state, err := lifecycle.CreateCluster(ctx, spec)
+	if err != nil {
+		return nil, fmt.Errorf("create managed compute cluster: %w", err)
+	}
+
+	desiredState := normalizeManagedClusterDesiredState(req.DesiredState)
+	cluster := &domain.ManagedComputeCluster{
+		Name:           req.Name,
+		TemplateID:     template.ID,
+		EndpointID:     endpoint.ID,
+		Provider:       providerName,
+		ExternalID:     managedClusterExternalID(req.Name, state),
+		DesiredState:   desiredState,
+		ObservedState:  normalizeManagedClusterObservedState(state.ObservedState),
+		MinReplicas:    spec.MinReplicas,
+		MaxReplicas:    spec.MaxReplicas,
+		IsDraining:     desiredState == domain.ManagedClusterDesiredDraining,
+		LastActivityAt: state.LastActivityAt,
+		EndpointURL:    managedClusterEndpointURL(state),
+	}
+
+	created, err := s.clusterRepo.Create(ctx, cluster)
+	if err != nil {
+		return nil, fmt.Errorf("persist managed compute cluster: %w", err)
+	}
+
+	if err := s.syncManagedEndpoint(ctx, endpoint, created, state.Connection); err != nil {
+		return nil, err
+	}
+
+	s.logAudit(ctx, principal, "CREATE_MANAGED_COMPUTE_CLUSTER", fmt.Sprintf("Created managed compute cluster %q", req.Name))
+	return created, nil
+}
+
+// GetManagedClusterByName returns a managed compute cluster by name.
+func (s *ComputeEndpointService) GetManagedClusterByName(ctx context.Context, principal, name string) (*domain.ManagedComputeCluster, error) {
+	if err := s.requirePrivilege(ctx, principal, domain.PrivManageCompute, "GET_MANAGED_COMPUTE_CLUSTER", fmt.Sprintf("Denied get managed compute cluster %q", name)); err != nil {
+		return nil, err
+	}
+	if s.clusterRepo == nil {
+		return nil, fmt.Errorf("managed compute cluster repository is not configured")
+	}
+	return s.clusterRepo.GetByName(ctx, name)
+}
+
+// ListManagedClusters returns managed compute clusters.
+func (s *ComputeEndpointService) ListManagedClusters(ctx context.Context, principal string, page domain.PageRequest) ([]domain.ManagedComputeCluster, int64, error) {
+	if err := s.requirePrivilege(ctx, principal, domain.PrivManageCompute, "LIST_MANAGED_COMPUTE_CLUSTERS", "Denied list managed compute clusters"); err != nil {
+		return nil, 0, err
+	}
+	if s.clusterRepo == nil {
+		return nil, 0, fmt.Errorf("managed compute cluster repository is not configured")
+	}
+	return s.clusterRepo.List(ctx, page)
+}
+
+// StartManagedCluster requests that a managed cluster transitions to RUNNING.
+func (s *ComputeEndpointService) StartManagedCluster(ctx context.Context, principal, name string) (*domain.ManagedComputeCluster, error) {
+	return s.transitionManagedCluster(ctx, principal, name, domain.ManagedClusterDesiredRunning, "START_MANAGED_COMPUTE_CLUSTER", func(lifecycle platform.ComputeLifecycle, providerClusterID string) (*platform.ClusterState, error) {
+		return lifecycle.StartCluster(ctx, providerClusterID)
+	})
+}
+
+// StopManagedCluster requests that a managed cluster transitions to STOPPED.
+func (s *ComputeEndpointService) StopManagedCluster(ctx context.Context, principal, name string) (*domain.ManagedComputeCluster, error) {
+	return s.transitionManagedCluster(ctx, principal, name, domain.ManagedClusterDesiredStopped, "STOP_MANAGED_COMPUTE_CLUSTER", func(lifecycle platform.ComputeLifecycle, providerClusterID string) (*platform.ClusterState, error) {
+		return lifecycle.StopCluster(ctx, providerClusterID)
+	})
+}
+
+// DrainManagedCluster requests that a managed cluster enters a draining state.
+func (s *ComputeEndpointService) DrainManagedCluster(ctx context.Context, principal, name string) (*domain.ManagedComputeCluster, error) {
+	return s.transitionManagedCluster(ctx, principal, name, domain.ManagedClusterDesiredDraining, "DRAIN_MANAGED_COMPUTE_CLUSTER", func(lifecycle platform.ComputeLifecycle, providerClusterID string) (*platform.ClusterState, error) {
+		return lifecycle.DrainCluster(ctx, providerClusterID)
+	})
+}
+
+// DeleteManagedCluster removes a managed cluster after a provider-side delete.
+func (s *ComputeEndpointService) DeleteManagedCluster(ctx context.Context, principal, name string) error {
+	if err := s.requirePrivilege(ctx, principal, domain.PrivManageCompute, "DELETE_MANAGED_COMPUTE_CLUSTER", fmt.Sprintf("Denied delete managed compute cluster %q", name)); err != nil {
+		return err
+	}
+
+	lifecycle, err := s.computeLifecycle()
+	if err != nil {
+		return err
+	}
+	if s.clusterRepo == nil {
+		return fmt.Errorf("managed compute cluster repository is not configured")
+	}
+
+	cluster, err := s.clusterRepo.GetByName(ctx, name)
+	if err != nil {
+		return err
+	}
+
+	if err := lifecycle.DeleteCluster(ctx, providerClusterID(cluster)); err != nil {
+		return fmt.Errorf("delete managed compute cluster: %w", err)
+	}
+	if err := s.clusterRepo.Delete(ctx, cluster.ID); err != nil {
+		return fmt.Errorf("delete managed compute cluster record: %w", err)
+	}
+	s.logAudit(ctx, principal, "DELETE_MANAGED_COMPUTE_CLUSTER", fmt.Sprintf("Deleted managed compute cluster %q", name))
+	return nil
+}
+
+func (s *ComputeEndpointService) transitionManagedCluster(
+	ctx context.Context,
+	principal string,
+	name string,
+	desiredState string,
+	action string,
+	transition func(platform.ComputeLifecycle, string) (*platform.ClusterState, error),
+) (*domain.ManagedComputeCluster, error) {
+	if err := s.requirePrivilege(ctx, principal, domain.PrivManageCompute, action, fmt.Sprintf("Denied %s for managed compute cluster %q", strings.ToLower(action), name)); err != nil {
+		return nil, err
+	}
+
+	lifecycle, err := s.computeLifecycle()
+	if err != nil {
+		return nil, err
+	}
+	if s.clusterRepo == nil {
+		return nil, fmt.Errorf("managed compute cluster repository is not configured")
+	}
+
+	cluster, err := s.clusterRepo.GetByName(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	endpoint, err := s.repo.GetByID(ctx, cluster.EndpointID)
+	if err != nil {
+		return nil, fmt.Errorf("load compute endpoint for managed cluster: %w", err)
+	}
+
+	state, err := transition(lifecycle, providerClusterID(cluster))
+	if err != nil {
+		return nil, fmt.Errorf("transition managed compute cluster: %w", err)
+	}
+
+	if err := s.clusterRepo.UpdateDesiredState(ctx, cluster.ID, desiredState); err != nil {
+		return nil, fmt.Errorf("update managed compute desired state: %w", err)
+	}
+	if err := s.clusterRepo.UpdateObservedState(ctx, cluster.ID, normalizeManagedClusterObservedState(state.ObservedState), managedClusterEndpointURL(state), state.LastActivityAt); err != nil {
+		return nil, fmt.Errorf("update managed compute observed state: %w", err)
+	}
+
+	updated, err := s.clusterRepo.GetByID(ctx, cluster.ID)
+	if err != nil {
+		return nil, fmt.Errorf("reload managed compute cluster: %w", err)
+	}
+	if err := s.syncManagedEndpoint(ctx, endpoint, updated, state.Connection); err != nil {
+		return nil, err
+	}
+
+	s.logAudit(ctx, principal, action, fmt.Sprintf("Updated managed compute cluster %q to %s", name, desiredState))
+	return updated, nil
+}
+
+func (s *ComputeEndpointService) hydrateEndpointManagedBacking(ctx context.Context, endpoint *domain.ComputeEndpoint) error {
+	if endpoint == nil || s.clusterRepo == nil {
+		return nil
+	}
+
+	cluster, err := s.clusterRepo.GetByEndpointID(ctx, endpoint.ID)
+	if err != nil {
+		var notFound *domain.NotFoundError
+		if errors.As(err, &notFound) {
+			return nil
+		}
+		return fmt.Errorf("load managed compute backing: %w", err)
+	}
+
+	endpoint.ManagedBacking = &domain.ComputeEndpointBacking{
+		Provider:         cluster.Provider,
+		ManagedClusterID: cluster.ID,
+		TemplateID:       cluster.TemplateID,
+	}
+	endpoint.LastActivityAt = cluster.LastActivityAt
+	if cluster.EndpointURL != nil && strings.TrimSpace(endpoint.URL) == "" {
+		endpoint.URL = *cluster.EndpointURL
+	}
+	return nil
+}
+
+func (s *ComputeEndpointService) hydrateEndpointsManagedBacking(ctx context.Context, endpoints []domain.ComputeEndpoint) error {
+	for i := range endpoints {
+		if err := s.hydrateEndpointManagedBacking(ctx, &endpoints[i]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *ComputeEndpointService) syncManagedEndpoint(ctx context.Context, endpoint *domain.ComputeEndpoint, cluster *domain.ManagedComputeCluster, connection *platform.ConnectionInfo) error {
+	if endpoint == nil || cluster == nil {
+		return nil
+	}
+
+	updateReq := domain.UpdateComputeEndpointRequest{
+		IsDraining:      boolPtr(cluster.IsDraining),
+		ReadinessStatus: stringPtr(managedClusterReadiness(cluster.ObservedState)),
+	}
+	if cluster.EndpointURL != nil {
+		updateReq.URL = cluster.EndpointURL
+	}
+	if connection != nil && strings.TrimSpace(connection.URL) != "" {
+		updateReq.URL = &connection.URL
+	}
+	if connection != nil && strings.TrimSpace(connection.AuthToken) != "" {
+		updateReq.AuthToken = &connection.AuthToken
+	}
+
+	if _, err := s.repo.Update(ctx, endpoint.ID, updateReq); err != nil {
+		return fmt.Errorf("sync managed compute endpoint: %w", err)
+	}
+	if err := s.repo.UpdateStatus(ctx, endpoint.ID, managedClusterEndpointStatus(cluster.ObservedState)); err != nil {
+		return fmt.Errorf("sync managed compute endpoint status: %w", err)
+	}
+	return nil
+}
+
+func (s *ComputeEndpointService) computeLifecycle() (platform.ComputeLifecycle, error) {
+	if s.provider == nil {
+		return nil, fmt.Errorf("platform provider is not configured")
+	}
+	return s.provider.ComputeLifecycle(), nil
+}
+
+func normalizeManagedClusterProvider(requestProvider, fallback string) string {
+	if strings.TrimSpace(requestProvider) != "" {
+		return strings.ToLower(strings.TrimSpace(requestProvider))
+	}
+	return strings.ToLower(strings.TrimSpace(fallback))
+}
+
+func normalizeManagedClusterDesiredState(state string) string {
+	state = strings.ToUpper(strings.TrimSpace(state))
+	if state == "" {
+		return domain.ManagedClusterDesiredRunning
+	}
+	return state
+}
+
+func normalizeManagedClusterObservedState(state string) string {
+	state = strings.ToUpper(strings.TrimSpace(state))
+	if state == "" {
+		return domain.ManagedClusterObservedStarting
+	}
+	return state
+}
+
+func chooseManagedClusterReplicaCount(requested, fallback int32) int32 {
+	if requested > 0 {
+		return requested
+	}
+	return fallback
+}
+
+func providerClusterID(cluster *domain.ManagedComputeCluster) string {
+	if cluster == nil {
+		return ""
+	}
+	if strings.TrimSpace(cluster.ExternalID) != "" {
+		return cluster.ExternalID
+	}
+	return cluster.ID
+}
+
+func managedClusterExternalID(name string, state *platform.ClusterState) string {
+	if state != nil && strings.TrimSpace(state.ID) != "" {
+		return strings.TrimSpace(state.ID)
+	}
+	return name
+}
+
+func managedClusterEndpointURL(state *platform.ClusterState) *string {
+	if state == nil || state.Connection == nil || strings.TrimSpace(state.Connection.URL) == "" {
+		return nil
+	}
+	return &state.Connection.URL
+}
+
+func managedClusterEndpointStatus(observedState string) string {
+	switch strings.ToUpper(strings.TrimSpace(observedState)) {
+	case domain.ManagedClusterObservedReady, domain.ManagedClusterObservedDegraded:
+		return "ACTIVE"
+	case domain.ManagedClusterObservedStopped:
+		return "INACTIVE"
+	case domain.ManagedClusterObservedError:
+		return "ERROR"
+	default:
+		return "STARTING"
+	}
+}
+
+func managedClusterReadiness(observedState string) string {
+	switch strings.ToUpper(strings.TrimSpace(observedState)) {
+	case domain.ManagedClusterObservedReady:
+		return domain.ComputeReadinessReady
+	case domain.ManagedClusterObservedDegraded:
+		return domain.ComputeReadinessDegraded
+	default:
+		return domain.ComputeReadinessUnavailable
+	}
+}
+
+func boolPtr(value bool) *bool {
+	return &value
+}
+
+func stringPtr(value string) *string {
+	return &value
+}

--- a/internal/service/compute/managed_clusters_test.go
+++ b/internal/service/compute/managed_clusters_test.go
@@ -1,0 +1,306 @@
+package compute
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Yacobolo/quackstack/internal/domain"
+	"github.com/Yacobolo/quackstack/internal/platform"
+)
+
+func TestComputeEndpointService_CreateManagedCluster(t *testing.T) {
+	endpointRepo := &mockComputeEndpointRepo{
+		GetByIDFn: func(_ context.Context, id string) (*domain.ComputeEndpoint, error) {
+			return &domain.ComputeEndpoint{
+				ID:   id,
+				Name: "analytics-remote",
+				Type: "REMOTE",
+			}, nil
+		},
+		UpdateFn: func(_ context.Context, id string, req domain.UpdateComputeEndpointRequest) (*domain.ComputeEndpoint, error) {
+			require.Equal(t, "endpoint-1", id)
+			require.NotNil(t, req.URL)
+			require.NotNil(t, req.AuthToken)
+			require.NotNil(t, req.ReadinessStatus)
+			require.NotNil(t, req.IsDraining)
+			assert.Equal(t, "grpcs://cluster-a.compute.quackstack.local:9444", *req.URL)
+			assert.Equal(t, "cluster-a-token", *req.AuthToken)
+			assert.Equal(t, domain.ComputeReadinessReady, *req.ReadinessStatus)
+			assert.False(t, *req.IsDraining)
+			return &domain.ComputeEndpoint{ID: id, Name: "analytics-remote", URL: *req.URL}, nil
+		},
+		UpdateStatusFn: func(_ context.Context, id string, status string) error {
+			assert.Equal(t, "endpoint-1", id)
+			assert.Equal(t, "ACTIVE", status)
+			return nil
+		},
+	}
+
+	templateRepo := &mockClusterTemplateRepo{
+		getByIDFn: func(_ context.Context, id string) (*domain.ComputeClusterTemplate, error) {
+			return &domain.ComputeClusterTemplate{
+				ID:                  id,
+				Name:                "standard",
+				Provider:            domain.ComputeProviderAzure,
+				WorkloadClass:       domain.ComputeEndpointWorkloadMixed,
+				MinReplicas:         1,
+				MaxReplicas:         3,
+				IdleAutoStopSeconds: 600,
+			}, nil
+		},
+	}
+
+	clusterRepo := &mockManagedClusterRepo{
+		createFn: func(_ context.Context, cluster *domain.ManagedComputeCluster) (*domain.ManagedComputeCluster, error) {
+			cluster.ID = "cluster-record-1"
+			assert.Equal(t, domain.ComputeProviderAzure, cluster.Provider)
+			assert.Equal(t, domain.ManagedClusterDesiredRunning, cluster.DesiredState)
+			assert.Equal(t, domain.ManagedClusterObservedReady, cluster.ObservedState)
+			return cluster, nil
+		},
+	}
+
+	now := time.Now().UTC()
+	provider := fakePlatformProvider{
+		name: platform.ProviderAzure,
+		compute: fakeComputeLifecycle{
+			createFn: func(_ context.Context, spec platform.ClusterSpec) (*platform.ClusterState, error) {
+				assert.Equal(t, "analytics-cluster", spec.Name)
+				assert.Equal(t, int32(1), spec.MinReplicas)
+				assert.Equal(t, int32(3), spec.MaxReplicas)
+				return &platform.ClusterState{
+					ID:             "cluster-a",
+					Name:           spec.Name,
+					DesiredState:   domain.ManagedClusterDesiredRunning,
+					ObservedState:  domain.ManagedClusterObservedReady,
+					LastActivityAt: &now,
+					Connection: &platform.ConnectionInfo{
+						URL:       "grpcs://cluster-a.compute.quackstack.local:9444",
+						AuthToken: "cluster-a-token",
+					},
+				}, nil
+			},
+		},
+	}
+
+	audit := &mockAuditRepo{}
+	svc := newTestComputeEndpointService(endpointRepo, allowManageCompute(), audit)
+	svc.SetClusterTemplateRepository(templateRepo)
+	svc.SetManagedClusterRepository(clusterRepo)
+	svc.SetPlatformProvider(provider)
+
+	cluster, err := svc.CreateManagedCluster(context.Background(), "admin", domain.CreateManagedComputeClusterRequest{
+		Name:         "analytics-cluster",
+		TemplateID:   "template-1",
+		EndpointID:   "endpoint-1",
+		Provider:     domain.ComputeProviderAzure,
+		DesiredState: domain.ManagedClusterDesiredRunning,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "cluster-record-1", cluster.ID)
+	assert.Equal(t, "cluster-a", cluster.ExternalID)
+	assert.True(t, audit.HasAction("CREATE_MANAGED_COMPUTE_CLUSTER"))
+}
+
+func TestComputeEndpointService_GetByNameHydratesManagedBacking(t *testing.T) {
+	endpointRepo := &mockComputeEndpointRepo{
+		GetByNameFn: func(_ context.Context, name string) (*domain.ComputeEndpoint, error) {
+			return &domain.ComputeEndpoint{ID: "endpoint-1", Name: name, Type: "REMOTE"}, nil
+		},
+	}
+	clusterRepo := &mockManagedClusterRepo{
+		getByEndpointIDFn: func(_ context.Context, endpointID string) (*domain.ManagedComputeCluster, error) {
+			require.Equal(t, "endpoint-1", endpointID)
+			now := time.Now().UTC()
+			url := "grpcs://cluster-a.compute.quackstack.local:9444"
+			return &domain.ManagedComputeCluster{
+				ID:             "cluster-1",
+				TemplateID:     "template-1",
+				EndpointID:     endpointID,
+				Provider:       domain.ComputeProviderAzure,
+				LastActivityAt: &now,
+				EndpointURL:    &url,
+			}, nil
+		},
+	}
+
+	svc := newTestComputeEndpointService(endpointRepo, allowManageCompute(), &mockAuditRepo{})
+	svc.SetManagedClusterRepository(clusterRepo)
+
+	endpoint, err := svc.GetByName(context.Background(), "admin", "analytics")
+	require.NoError(t, err)
+	require.NotNil(t, endpoint.ManagedBacking)
+	assert.Equal(t, domain.ComputeProviderAzure, endpoint.ManagedBacking.Provider)
+	assert.Equal(t, "cluster-1", endpoint.ManagedBacking.ManagedClusterID)
+	assert.Equal(t, "template-1", endpoint.ManagedBacking.TemplateID)
+}
+
+type mockClusterTemplateRepo struct {
+	createFn    func(context.Context, *domain.ComputeClusterTemplate) (*domain.ComputeClusterTemplate, error)
+	getByIDFn   func(context.Context, string) (*domain.ComputeClusterTemplate, error)
+	getByNameFn func(context.Context, string) (*domain.ComputeClusterTemplate, error)
+	listFn      func(context.Context, domain.PageRequest) ([]domain.ComputeClusterTemplate, int64, error)
+	deleteFn    func(context.Context, string) error
+}
+
+func (m *mockClusterTemplateRepo) Create(ctx context.Context, tpl *domain.ComputeClusterTemplate) (*domain.ComputeClusterTemplate, error) {
+	if m.createFn == nil {
+		panic("mockClusterTemplateRepo.Create called but not configured")
+	}
+	return m.createFn(ctx, tpl)
+}
+
+func (m *mockClusterTemplateRepo) GetByID(ctx context.Context, id string) (*domain.ComputeClusterTemplate, error) {
+	if m.getByIDFn == nil {
+		panic("mockClusterTemplateRepo.GetByID called but not configured")
+	}
+	return m.getByIDFn(ctx, id)
+}
+
+func (m *mockClusterTemplateRepo) GetByName(ctx context.Context, name string) (*domain.ComputeClusterTemplate, error) {
+	if m.getByNameFn == nil {
+		panic("mockClusterTemplateRepo.GetByName called but not configured")
+	}
+	return m.getByNameFn(ctx, name)
+}
+
+func (m *mockClusterTemplateRepo) List(ctx context.Context, page domain.PageRequest) ([]domain.ComputeClusterTemplate, int64, error) {
+	if m.listFn == nil {
+		panic("mockClusterTemplateRepo.List called but not configured")
+	}
+	return m.listFn(ctx, page)
+}
+
+func (m *mockClusterTemplateRepo) Delete(ctx context.Context, id string) error {
+	if m.deleteFn == nil {
+		panic("mockClusterTemplateRepo.Delete called but not configured")
+	}
+	return m.deleteFn(ctx, id)
+}
+
+type mockManagedClusterRepo struct {
+	createFn          func(context.Context, *domain.ManagedComputeCluster) (*domain.ManagedComputeCluster, error)
+	getByIDFn         func(context.Context, string) (*domain.ManagedComputeCluster, error)
+	getByNameFn       func(context.Context, string) (*domain.ManagedComputeCluster, error)
+	getByEndpointIDFn func(context.Context, string) (*domain.ManagedComputeCluster, error)
+	listFn            func(context.Context, domain.PageRequest) ([]domain.ManagedComputeCluster, int64, error)
+	updateDesiredFn   func(context.Context, string, string) error
+	updateObservedFn  func(context.Context, string, string, *string, *time.Time) error
+	deleteFn          func(context.Context, string) error
+}
+
+func (m *mockManagedClusterRepo) Create(ctx context.Context, cluster *domain.ManagedComputeCluster) (*domain.ManagedComputeCluster, error) {
+	if m.createFn == nil {
+		panic("mockManagedClusterRepo.Create called but not configured")
+	}
+	return m.createFn(ctx, cluster)
+}
+
+func (m *mockManagedClusterRepo) GetByID(ctx context.Context, id string) (*domain.ManagedComputeCluster, error) {
+	if m.getByIDFn == nil {
+		panic("mockManagedClusterRepo.GetByID called but not configured")
+	}
+	return m.getByIDFn(ctx, id)
+}
+
+func (m *mockManagedClusterRepo) GetByName(ctx context.Context, name string) (*domain.ManagedComputeCluster, error) {
+	if m.getByNameFn == nil {
+		panic("mockManagedClusterRepo.GetByName called but not configured")
+	}
+	return m.getByNameFn(ctx, name)
+}
+
+func (m *mockManagedClusterRepo) GetByEndpointID(ctx context.Context, endpointID string) (*domain.ManagedComputeCluster, error) {
+	if m.getByEndpointIDFn == nil {
+		panic("mockManagedClusterRepo.GetByEndpointID called but not configured")
+	}
+	return m.getByEndpointIDFn(ctx, endpointID)
+}
+
+func (m *mockManagedClusterRepo) List(ctx context.Context, page domain.PageRequest) ([]domain.ManagedComputeCluster, int64, error) {
+	if m.listFn == nil {
+		panic("mockManagedClusterRepo.List called but not configured")
+	}
+	return m.listFn(ctx, page)
+}
+
+func (m *mockManagedClusterRepo) UpdateDesiredState(ctx context.Context, id string, desiredState string) error {
+	if m.updateDesiredFn == nil {
+		panic("mockManagedClusterRepo.UpdateDesiredState called but not configured")
+	}
+	return m.updateDesiredFn(ctx, id, desiredState)
+}
+
+func (m *mockManagedClusterRepo) UpdateObservedState(ctx context.Context, id string, observedState string, endpointURL *string, lastActivityAt *time.Time) error {
+	if m.updateObservedFn == nil {
+		panic("mockManagedClusterRepo.UpdateObservedState called but not configured")
+	}
+	return m.updateObservedFn(ctx, id, observedState, endpointURL, lastActivityAt)
+}
+
+func (m *mockManagedClusterRepo) Delete(ctx context.Context, id string) error {
+	if m.deleteFn == nil {
+		panic("mockManagedClusterRepo.Delete called but not configured")
+	}
+	return m.deleteFn(ctx, id)
+}
+
+type fakePlatformProvider struct {
+	name    string
+	compute fakeComputeLifecycle
+}
+
+func (p fakePlatformProvider) Name() string                                        { return p.name }
+func (p fakePlatformProvider) ControlPlaneDatabase() platform.ControlPlaneDatabase { return nil }
+func (p fakePlatformProvider) ObjectStorage() platform.ObjectStorage               { return nil }
+func (p fakePlatformProvider) Ingress() platform.Ingress                           { return nil }
+func (p fakePlatformProvider) Identity() platform.Identity                         { return nil }
+func (p fakePlatformProvider) ComputeLifecycle() platform.ComputeLifecycle         { return p.compute }
+func (p fakePlatformProvider) SecretsRuntime() platform.SecretsRuntime             { return nil }
+
+type fakeComputeLifecycle struct {
+	createFn func(context.Context, platform.ClusterSpec) (*platform.ClusterState, error)
+	startFn  func(context.Context, string) (*platform.ClusterState, error)
+	stopFn   func(context.Context, string) (*platform.ClusterState, error)
+	drainFn  func(context.Context, string) (*platform.ClusterState, error)
+}
+
+func (f fakeComputeLifecycle) Name() string { return "fake" }
+func (f fakeComputeLifecycle) CreateCluster(ctx context.Context, spec platform.ClusterSpec) (*platform.ClusterState, error) {
+	if f.createFn == nil {
+		panic("fakeComputeLifecycle.CreateCluster called but not configured")
+	}
+	return f.createFn(ctx, spec)
+}
+func (f fakeComputeLifecycle) StartCluster(ctx context.Context, clusterID string) (*platform.ClusterState, error) {
+	if f.startFn == nil {
+		panic("fakeComputeLifecycle.StartCluster called but not configured")
+	}
+	return f.startFn(ctx, clusterID)
+}
+func (f fakeComputeLifecycle) StopCluster(ctx context.Context, clusterID string) (*platform.ClusterState, error) {
+	if f.stopFn == nil {
+		panic("fakeComputeLifecycle.StopCluster called but not configured")
+	}
+	return f.stopFn(ctx, clusterID)
+}
+func (f fakeComputeLifecycle) DrainCluster(ctx context.Context, clusterID string) (*platform.ClusterState, error) {
+	if f.drainFn == nil {
+		panic("fakeComputeLifecycle.DrainCluster called but not configured")
+	}
+	return f.drainFn(ctx, clusterID)
+}
+func (f fakeComputeLifecycle) DeleteCluster(context.Context, string) error { return nil }
+func (f fakeComputeLifecycle) ResizeCluster(context.Context, string, platform.ClusterSize) (*platform.ClusterState, error) {
+	return nil, nil
+}
+func (f fakeComputeLifecycle) ResolveConnection(context.Context, string) (*platform.ConnectionInfo, error) {
+	return nil, nil
+}
+func (f fakeComputeLifecycle) ReportStatus(context.Context, string) (*platform.ClusterState, error) {
+	return nil, nil
+}

--- a/internal/service/compute/routing.go
+++ b/internal/service/compute/routing.go
@@ -194,5 +194,9 @@ func (s *ComputeEndpointService) collectPrincipalEndpoints(ctx context.Context, 
 		}
 	}
 
+	if err := s.hydrateEndpointsManagedBacking(ctx, candidates); err != nil {
+		return nil, nil, err
+	}
+
 	return candidates, defaultEndpointName, nil
 }


### PR DESCRIPTION
# Enterprise Deployment Enablement Plan

## Summary

Enable **one QuackStack product** with two deployment profiles and one cloud-neutral platform contract:

- **Simple profile**: Docker Compose, SQLite control-plane metadata, optional fixed compute-agent, low-ops testing and small workloads.
- **Enterprise profile**: Helm-based Kubernetes deployment, Postgres-backed HA control plane, managed compute lifecycle, managed external dependencies.

The core design principle is a **Go-interface-style provider contract**:

- QuackStack defines what the platform needs:
  - control-plane database
  - object storage
  - ingress/load balancing
  - identity integration
  - compute lifecycle
  - secrets/config injection
- Each environment implements that contract:
  - `manual/compose` provider for simple mode
  - `azure` provider first for enterprise
  - later `aws` / `gcp` providers if needed

The product surface stays **provider-neutral**. End users and most admins work with logical concepts like compute endpoints, clusters, routing, and health, not AKS/EKS/GKE-specific objects.

## Key Changes

### 1. Product-Level Deployment Contract

Define an internal platform provider contract that QuackStack owns. This contract is not exposed as cloud-specific API surface.

Provider capabilities must cover:

- `ControlPlaneDatabase`
  - provision/connect
  - migrate
  - health check
  - backup/restore hooks
- `ObjectStorage`
  - read/write artifacts and results
  - presign/download/upload support
  - lifecycle/retention hooks
- `Ingress`
  - expose HTTP/gRPC endpoints
  - TLS termination expectations
  - health probe wiring
- `Identity`
  - OIDC integration for users
  - workload identity / service identity for platform components
- `ComputeLifecycle`
  - create/start/stop/drain/delete/resize cluster
  - resolve endpoint connection details
  - report status/capacity/last activity
- `SecretsRuntime`
  - inject secrets/config into workloads
  - support rotation and restart/reload hooks

Rules:

- the provider interface belongs to QuackStack, not to any cloud
- provider-specific config stays in provider adapters and deployment values
- no Azure/AWS/GCP fields leak into the main domain model unless truly generic

### 2. Deployment Profiles

Add explicit deployment profiles:

- `simple`
  - Compose packaging
  - SQLite control-plane metadata
  - optional static compute-agent
  - `manual` provider implementation
- `enterprise`
  - Kubernetes + Helm packaging
  - Postgres control-plane metadata
  - managed compute lifecycle
  - external object storage
  - OIDC + managed secrets required
  - `azure` provider implementation first

Startup validation must reject unsupported combinations, especially:

- `enterprise + sqlite`
- `enterprise + local/dev auth shortcuts`
- `enterprise + missing managed storage/secret/identity config`

### 3. Control-Plane Metadata Backend

Enterprise requires a real HA-ready control-plane database.

- Introduce driver/config selection:
  - `CONTROL_DB_DRIVER=sqlite|postgres`
  - `CONTROL_DB_DSN`
  - retain `META_DB_PATH` only for SQLite/simple profile
- Keep repository interfaces as the domain boundary.
- Add Postgres-backed control-plane repository implementations for enterprise.
- Split migrations by backend and run the correct set at startup.
- Keep SQLite supported only for simple/Compose mode.
- Treat Postgres as authoritative in enterprise for:
  - principals/groups/grants
  - compute endpoints/assignments/routing defaults
  - audit and control-plane metadata
  - durable lifecycle metadata
  - durable async execution metadata

### 4. Managed Compute Model

Keep the existing logical compute concepts, but add provider-managed backing resources.

Core logical resources:

- `ComputeEndpoint`
  - user-visible routing target
  - assignment/default/fallback surface
  - can be unmanaged or managed-backed
- `ComputeAssignment`
- `ComputeRoutingDefaults`

New operator resources:

- `ComputeClusterTemplate`
  - provider
  - workload class
  - size defaults
  - min/max scale
  - auto-stop timeout
  - scaling policy
  - storage/result policy
- `ManagedComputeCluster`
  - template reference
  - desired state: `RUNNING|STOPPED|DRAINING|DELETING`
  - observed state: `STARTING|READY|DEGRADED|STOPPED|ERROR`
  - last activity
  - backing provider reference
  - resolved endpoint metadata

Rules:

- platform admins only manage clusters in v1
- users never manage pods or agents directly
- endpoints remain the routing abstraction
- clusters implement endpoints
- stop/delete must pass through drain first
- auto-stop only when no active or queued work remains

### 5. Durable Remote Execution

Enterprise compute must be safe to autoscale and replace.

- Move authoritative async query/job lifecycle state out of compute-agent memory and into the enterprise control-plane store.
- Store remote result manifests/metadata in Postgres and payloads in object storage.
- Keep synchronous interactive execution available for low-latency use cases.
- Default scheduled/notebook/heavy remote workloads to the durable lifecycle path.
- Make compute agents stateless regarding authoritative job ownership.
- Require graceful drain/termination semantics so cluster autoscaling is safe.

### 6. Provider Implementations

Implement providers in this order:

- `manual`
  - for Compose/simple mode
  - static endpoint URLs and tokens
  - optional fixed compute-agent lifecycle through deployment docs/tooling, not Kubernetes automation
- `azure`
  - first enterprise provider
  - AKS for compute
  - managed Postgres for control plane
  - Blob/ADLS for artifacts/results
  - Azure workload identity / managed identity
  - Azure-native ingress/load balancer implementation through Helm values and provider adapter logic

Provider-specific deployment details belong in:

- Helm values files
- deployment templates
- provider adapter modules
- ops docs/runbooks

They do **not** belong in user-facing compute APIs or domain types unless generalized.

### 7. Enterprise Packaging

Add official enterprise deployment packaging:

- Helm chart(s) for:
  - control plane
  - enterprise lifecycle controller/reconciler
  - compute worker deployment shape
- provider-specific values:
  - `values-azure.yaml` first
- external integrations for enterprise baseline:
  - cert-manager
  - external-dns if needed
  - managed secret injection pattern
- keep Compose as the official simple deployment artifact

Helm is used for packaging and deployment consistency, not as the primary abstraction boundary. The abstraction boundary is the provider contract.

### 8. Admin UX And API Surface

Keep end-user UX stable:

- `Automatic`
- `Local`
- named compute targets
- health/draining/unavailable visibility

Add admin-only APIs/UI for:

- cluster template CRUD
- managed cluster CRUD
- start/stop/drain/delete/resize
- auto-stop and scaling policy
- endpoint-to-cluster binding
- status/history/last activity
- audit trail for lifecycle actions

Do not expose cloud objects like node pools, ALBs, or Azure DB SKUs in the core product UX. Those belong in provider config and deployment tooling.

## Public Interfaces And Types

Add or update these public-facing concepts:

- config:
  - `DEPLOYMENT_PROFILE`
  - `CONTROL_DB_DRIVER`
  - `CONTROL_DB_DSN`
- new admin resources:
  - `ComputeClusterTemplate`
  - `ManagedComputeCluster`
- extend `ComputeEndpoint` with managed-backing reference fields
- keep `ComputeAssignment`, `ComputeRoutingDefaults`, and principal-visible compute target APIs intact
- add admin APIs for provider-neutral cluster lifecycle operations

## Test Plan

### Startup And Persistence

- `simple + sqlite + manual provider` starts successfully
- `enterprise + postgres + azure provider` starts successfully
- invalid enterprise combinations fail fast with actionable errors
- migrations work correctly for SQLite/simple and Postgres/enterprise
- repository parity tests confirm equivalent domain behavior where intended

### Provider Contract

- `manual` provider satisfies the platform contract for simple mode
- `azure` provider satisfies the same contract for enterprise
- provider swap does not require core API/domain changes
- provider-specific values/config remain isolated from core business logic

### Compute Lifecycle

- create/start/stop/drain/delete managed cluster
- endpoint becomes selectable only when cluster is ready
- draining blocks new scheduled work and lets in-flight work finish
- idle auto-stop triggers only when cluster is truly idle
- stopped managed cluster can be auto-started on demand when policy allows
- unhealthy cluster updates endpoint availability and fallback behavior

### Durable Execution

- async remote job survives compute pod restart/replacement
- result fetch works after worker replacement
- cancellation during drain behaves correctly
- result retention/cleanup works through object storage + metadata store
- sync interactive queries still work on managed endpoints

### Security And Operations

- enterprise requires OIDC and managed secrets
- admin-only lifecycle permissions are enforced
- audit records exist for cluster lifecycle changes
- metrics cover startup latency, fallback rate, queue age, auto-stop events, provider reconciliation failures, and cluster drain duration

## Assumptions And Defaults

- Azure is the first enterprise provider, but the product and API surface remain provider-neutral.
- Enterprise requires Postgres for control-plane metadata; SQLite remains simple-mode only.
- Compose remains the official simple deployment and is implemented via the `manual` provider.
- Platform admins are the only cluster operators in v1.
- End users never add/remove agents or pods directly.
- Managed Postgres and external object storage are the enterprise baseline.
- Helm is the enterprise packaging mechanism; the provider contract is the real abstraction layer.
